### PR TITLE
Add cascade deletion test for User model

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -62,4 +62,21 @@ class UserTest < ActiveSupport::TestCase
   test "JWT revocation strategy included" do
     assert_includes User.included_modules, Devise::JWT::RevocationStrategies::JTIMatcher
   end
+
+  test "deleting user cascades to delete user_lessons and user_levels" do
+    user = create(:user)
+    level = create(:level)
+    lesson = create(:lesson)
+
+    user_level = create(:user_level, user:, level:)
+    user_lesson = create(:user_lesson, user:, lesson:)
+
+    user_level_id = user_level.id
+    user_lesson_id = user_lesson.id
+
+    user.destroy!
+
+    refute UserLevel.exists?(user_level_id)
+    refute UserLesson.exists?(user_lesson_id)
+  end
 end


### PR DESCRIPTION
## Summary
- ✅ Added test for cascade deletion when user is deleted
- ✅ Verifies `dependent: :destroy` works for user_lessons and user_levels
- ✅ Ensures data integrity and no orphaned records

## Test Added

### Purpose
Verifies that deleting a user properly cascades to delete all associated:
- `UserLesson` records
- `UserLevel` records

### Implementation
```ruby
test "deleting user cascades to delete user_lessons and user_levels" do
  user = create(:user)
  level = create(:level)
  lesson = create(:lesson)

  user_level = create(:user_level, user:, level:)
  user_lesson = create(:user_lesson, user:, lesson:)

  user_level_id = user_level.id
  user_lesson_id = user_lesson.id

  user.destroy!

  refute UserLevel.exists?(user_level_id)
  refute UserLesson.exists?(user_lesson_id)
end
```

## Why This Matters

### Data Integrity
- Prevents orphaned records in the database
- Ensures user deletion is clean and complete
- Confirms the `dependent: :destroy` configuration works

### User Privacy
- When a user account is deleted, all their progress data should be removed
- No lingering progression records should exist

### Database Health
- Prevents accumulation of orphaned join table records
- Maintains referential integrity

## Testing
- ✅ All tests pass (47 tests, 137 assertions)
- ✅ Test creates relationships and verifies deletion
- ✅ Uses IDs to confirm records truly don't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)