### PR TITLE
Add development-only URL-based authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,21 @@ class ApplicationController < ActionController::API
   before_action :authenticate_user!
 
   private
+  def authenticate_user!
+    # Don't interfere with Devise's own controllers
+    return super if devise_controller?
+    # Only allow URL-based authentication in development
+    return super unless Rails.env.development?
+    return super unless params[:user_id].present?
+
+    # Development-only: Allow authentication via user_id query parameter
+    user = User.find_by(id: params[:user_id])
+    return super unless user
+
+    sign_in(user, store: false)
+    Rails.logger.warn "[DEV AUTH] Authenticated as user #{user.id} via URL parameter"
+  end
+
   def use_lesson!
     @lesson = Lesson.find_by!(slug: params[:slug])
   rescue ActiveRecord::RecordNotFound

--- a/test/controllers/dev_authentication_test.rb
+++ b/test/controllers/dev_authentication_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class DevAuthenticationTest < ActionDispatch::IntegrationTest
+  include AuthenticationHelper
+
+  setup do
+    @user = create(:user)
+  end
+
+  test "URL-based authentication works in development environment" do
+    Rails.env.stubs(:development?).returns(true)
+
+    get "#{v1_levels_path}?user_id=#{@user.id}", as: :json
+
+    assert_response :success
+  end
+
+  test "URL-based authentication is blocked in production environment" do
+    Rails.env.stubs(:development?).returns(false)
+
+    get "#{v1_levels_path}?user_id=#{@user.id}", as: :json
+
+    assert_response :unauthorized
+    assert_equal "unauthorized", response.parsed_body["error"]["type"]
+  end
+
+  test "URL-based authentication is blocked in test environment" do
+    # Test environment is the default (development? returns false)
+    get "#{v1_levels_path}?user_id=#{@user.id}", as: :json
+
+    assert_response :unauthorized
+    assert_equal "unauthorized", response.parsed_body["error"]["type"]
+  end
+
+  test "falls back to JWT authentication when no user_id param in development" do
+    Rails.env.stubs(:development?).returns(true)
+
+    headers = auth_headers_for(@user)
+    get v1_levels_path, headers: headers, as: :json
+
+    assert_response :success
+  end
+
+  test "JWT authentication still works in development without user_id" do
+    Rails.env.stubs(:development?).returns(true)
+
+    headers = auth_headers_for(@user)
+    get v1_levels_path, headers: headers, as: :json
+
+    assert_response :success
+  end
+
+  test "returns 401 when user_id is invalid in development" do
+    Rails.env.stubs(:development?).returns(true)
+
+    get "#{v1_levels_path}?user_id=99999", as: :json
+
+    assert_response :unauthorized
+    assert_equal "unauthorized", response.parsed_body["error"]["type"]
+  end
+
+  test "returns 401 in development when no authentication provided" do
+    Rails.env.stubs(:development?).returns(true)
+
+    get v1_levels_path, as: :json
+
+    assert_response :unauthorized
+    assert_equal "unauthorized", response.parsed_body["error"]["type"]
+  end
+end


### PR DESCRIPTION
## Summary

Adds a convenient development-only authentication mechanism that allows authenticating as any user by passing `?user_id=X` in the URL. This eliminates the need to manage JWT tokens during local development.

## Changes

- Override `authenticate_user!` in `ApplicationController` to check for `user_id` query param in development
- Comprehensive test coverage with 7 tests ensuring feature only works in development
- Security checks to prevent usage in production or test environments

## Usage

In development, you can now authenticate by adding a query parameter:

```
GET http://localhost:3000/v1/levels?user_id=1
```

This will authenticate the request as User #1.

## Security

- ✅ Only enabled when `Rails.env.development?` is true
- ✅ Explicitly blocked in production and test environments (tested)
- ✅ Does not interfere with Devise's authentication controllers
- ✅ Falls back to standard JWT authentication when no `user_id` present
- ✅ Logs warning when URL-based auth is used

## Test plan

- [x] All existing tests pass (144 runs, 0 failures)
- [x] 7 new tests added covering:
  - URL-based auth works in development ✓
  - URL-based auth blocked in production ✓
  - URL-based auth blocked in test ✓
  - JWT auth still works alongside URL-based auth ✓
  - Invalid user_id returns 401 ✓
  - No authentication returns 401 ✓
- [x] Rubocop passes
- [x] Brakeman security scan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)