### PR TITLE
Improve serializer test readability by extracting expected values

### DIFF
--- a/.context/testing.md
+++ b/.context/testing.md
@@ -416,6 +416,59 @@ end
 - **Maintainability**: Changes to auth logic only require updating the macro once
 - **Coverage**: Automatically tests both invalid token and missing token scenarios
 
+### Serializer Testing Patterns
+
+**IMPORTANT**: When testing serializers, extract expected values into separate variables for improved readability and maintainability.
+
+```ruby
+# CORRECT: Extract expected hash into a variable
+test "serializes multiple levels with lessons" do
+  level1 = create(:level, slug: "level-1")
+  level2 = create(:level, slug: "level-2")
+  create(:lesson, level: level1, slug: "l1", type: "exercise", data: { slug: "ex1" })
+  create(:lesson, level: level2, slug: "l2", type: "tutorial", data: { slug: "ex2" })
+
+  expected = [
+    {
+      slug: "level-1",
+      lessons: [
+        { slug: "l1", type: "exercise", data: { slug: "ex1" } }
+      ]
+    },
+    {
+      slug: "level-2",
+      lessons: [
+        { slug: "l2", type: "tutorial", data: { slug: "ex2" } }
+      ]
+    }
+  ]
+
+  assert_equal(expected, SerializeLevels.([level1, level2]))
+end
+
+# INCORRECT: Inline hash makes tests harder to read
+test "serializes multiple levels with lessons" do
+  level1 = create(:level, slug: "level-1")
+  level2 = create(:level, slug: "level-2")
+  create(:lesson, level: level1, slug: "l1", type: "exercise", data: { slug: "ex1" })
+
+  assert_equal([
+                 {
+                   slug: "level-1",
+                   lessons: [
+                     { slug: "l1", type: "exercise", data: { slug: "ex1" } }
+                   ]
+                 }
+               ], SerializeLevels.([level1]))
+end
+```
+
+**Benefits:**
+- Easier to read and understand expected output
+- Simpler to modify expected values when requirements change
+- Better diffs when tests fail
+- Consistent formatting across test files
+
 ### Performance Considerations
 - **Minimize database calls** in factory definitions
 - **Use traits wisely** to avoid complex factory hierarchies

--- a/test/serializers/serialize_lesson_test.rb
+++ b/test/serializers/serialize_lesson_test.rb
@@ -4,20 +4,24 @@ class SerializeLessonTest < ActiveSupport::TestCase
   test "serializes lesson with all fields" do
     lesson = create(:lesson, slug: "hello-world", type: "exercise", data: { slug: "basic-movement" })
 
-    assert_equal({
+    expected = {
       slug: "hello-world",
       type: "exercise",
       data: { slug: "basic-movement" }
-    }, SerializeLesson.(lesson))
+    }
+
+    assert_equal(expected, SerializeLesson.(lesson))
   end
 
   test "serializes complex data hash" do
     lesson = create(:lesson, slug: "test", type: "tutorial", data: { slug: "test-exercise", difficulty: "easy", points: 10 })
 
-    assert_equal({
+    expected = {
       slug: "test",
       type: "tutorial",
       data: { slug: "test-exercise", difficulty: "easy", points: 10 }
-    }, SerializeLesson.(lesson))
+    }
+
+    assert_equal(expected, SerializeLesson.(lesson))
   end
 end

--- a/test/serializers/serialize_lessons_test.rb
+++ b/test/serializers/serialize_lessons_test.rb
@@ -6,10 +6,12 @@ class SerializeLessonsTest < ActiveSupport::TestCase
     lesson1 = create(:lesson, level: level, slug: "lesson-1", type: "exercise", data: { slug: "ex-1" })
     lesson2 = create(:lesson, level: level, slug: "lesson-2", type: "tutorial", data: { slug: "ex-2" })
 
-    assert_equal([
-                   { slug: "lesson-1", type: "exercise", data: { slug: "ex-1" } },
-                   { slug: "lesson-2", type: "tutorial", data: { slug: "ex-2" } }
-                 ], SerializeLessons.([lesson1, lesson2]))
+    expected = [
+      { slug: "lesson-1", type: "exercise", data: { slug: "ex-1" } },
+      { slug: "lesson-2", type: "tutorial", data: { slug: "ex-2" } }
+    ]
+
+    assert_equal(expected, SerializeLessons.([lesson1, lesson2]))
   end
 
   test "returns empty array for no lessons" do
@@ -19,8 +21,10 @@ class SerializeLessonsTest < ActiveSupport::TestCase
   test "serializes single lesson" do
     lesson = create(:lesson, slug: "solo", type: "exercise", data: { slug: "test" })
 
-    assert_equal([
-                   { slug: "solo", type: "exercise", data: { slug: "test" } }
-                 ], SerializeLessons.([lesson]))
+    expected = [
+      { slug: "solo", type: "exercise", data: { slug: "test" } }
+    ]
+
+    assert_equal(expected, SerializeLessons.([lesson]))
   end
 end

--- a/test/serializers/serialize_level_test.rb
+++ b/test/serializers/serialize_level_test.rb
@@ -6,21 +6,25 @@ class SerializeLevelTest < ActiveSupport::TestCase
     create(:lesson, level: level, slug: "lesson-1", type: "exercise", data: { slug: "ex-1" })
     create(:lesson, level: level, slug: "lesson-2", type: "tutorial", data: { slug: "ex-2" })
 
-    assert_equal({
+    expected = {
       slug: "level-1",
       lessons: [
         { slug: "lesson-1", type: "exercise", data: { slug: "ex-1" } },
         { slug: "lesson-2", type: "tutorial", data: { slug: "ex-2" } }
       ]
-    }, SerializeLevel.(level))
+    }
+
+    assert_equal(expected, SerializeLevel.(level))
   end
 
   test "serializes level with no lessons" do
     level = create(:level, slug: "empty-level")
 
-    assert_equal({
+    expected = {
       slug: "empty-level",
       lessons: []
-    }, SerializeLevel.(level))
+    }
+
+    assert_equal(expected, SerializeLevel.(level))
   end
 end

--- a/test/serializers/serialize_levels_test.rb
+++ b/test/serializers/serialize_levels_test.rb
@@ -7,20 +7,22 @@ class SerializeLevelsTest < ActiveSupport::TestCase
     create(:lesson, level: level1, slug: "l1", type: "exercise", data: { slug: "ex1" })
     create(:lesson, level: level2, slug: "l2", type: "tutorial", data: { slug: "ex2" })
 
-    assert_equal([
-                   {
-                     slug: "level-1",
-                     lessons: [
-                       { slug: "l1", type: "exercise", data: { slug: "ex1" } }
-                     ]
-                   },
-                   {
-                     slug: "level-2",
-                     lessons: [
-                       { slug: "l2", type: "tutorial", data: { slug: "ex2" } }
-                     ]
-                   }
-                 ], SerializeLevels.([level1, level2]))
+    expected = [
+      {
+        slug: "level-1",
+        lessons: [
+          { slug: "l1", type: "exercise", data: { slug: "ex1" } }
+        ]
+      },
+      {
+        slug: "level-2",
+        lessons: [
+          { slug: "l2", type: "tutorial", data: { slug: "ex2" } }
+        ]
+      }
+    ]
+
+    assert_equal(expected, SerializeLevels.([level1, level2]))
   end
 
   test "returns empty array for no levels" do
@@ -31,13 +33,14 @@ class SerializeLevelsTest < ActiveSupport::TestCase
     level = create(:level, slug: "solo")
     create(:lesson, level: level, slug: "lesson-solo", type: "exercise", data: { slug: "test" })
 
-    assert_equal([
-                   {
-                     slug: "solo",
-                     lessons: [
-                       { slug: "lesson-solo", type: "exercise", data: { slug: "test" } }
-                     ]
-                   }
-                 ], SerializeLevels.([level]))
+    expected = [
+      {
+        slug: "solo",
+        lessons: [
+          { slug: "lesson-solo", type: "exercise", data: { slug: "test" } }
+        ]
+      }
+    ]
+    assert_equal(expected, SerializeLevels.([level]))
   end
 end

--- a/test/serializers/serialize_user_lesson_test.rb
+++ b/test/serializers/serialize_user_lesson_test.rb
@@ -13,33 +13,41 @@ class SerializeUserLessonTest < ActiveSupport::TestCase
     lesson = create(:lesson, slug: "hello-world")
     user_lesson = create(:user_lesson, lesson: lesson, completed_at: Time.current)
 
-    assert_equal({
+    expected = {
       lesson_slug: "hello-world",
       status: "completed"
-    }, SerializeUserLesson.(user_lesson: user_lesson))
+    }
+
+    assert_equal(expected, SerializeUserLesson.(user_lesson: user_lesson))
   end
 
   test "serializes user_lesson model with started status" do
     lesson = create(:lesson, slug: "hello-world")
     user_lesson = create(:user_lesson, lesson: lesson, completed_at: nil)
 
-    assert_equal({
+    expected = {
       lesson_slug: "hello-world",
       status: "started"
-    }, SerializeUserLesson.(user_lesson: user_lesson))
+    }
+
+    assert_equal(expected, SerializeUserLesson.(user_lesson: user_lesson))
   end
 
   test "serializes user_lesson_data hash with completed status" do
-    assert_equal({
+    expected = {
       lesson_slug: "hello-world",
       status: "completed"
-    }, SerializeUserLesson.(user_lesson_data: { lesson_slug: "hello-world", completed_at: Time.current }))
+    }
+
+    assert_equal(expected, SerializeUserLesson.(user_lesson_data: { lesson_slug: "hello-world", completed_at: Time.current }))
   end
 
   test "serializes user_lesson_data hash with started status" do
-    assert_equal({
+    expected = {
       lesson_slug: "hello-world",
       status: "started"
-    }, SerializeUserLesson.(user_lesson_data: { lesson_slug: "hello-world", completed_at: nil }))
+    }
+
+    assert_equal(expected, SerializeUserLesson.(user_lesson_data: { lesson_slug: "hello-world", completed_at: nil }))
   end
 end

--- a/test/serializers/serialize_user_levels_test.rb
+++ b/test/serializers/serialize_user_levels_test.rb
@@ -17,21 +17,23 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
     create(:user_lesson, user: user, lesson: lesson2, completed_at: nil)
     create(:user_lesson, user: user, lesson: lesson3, completed_at: Time.current)
 
-    assert_equal([
-                   {
-                     level_slug: "basics",
-                     user_lessons: [
-                       { lesson_slug: "lesson-1", status: "completed" },
-                       { lesson_slug: "lesson-2", status: "started" }
-                     ]
-                   },
-                   {
-                     level_slug: "advanced",
-                     user_lessons: [
-                       { lesson_slug: "lesson-3", status: "completed" }
-                     ]
-                   }
-                 ], SerializeUserLevels.(user.user_levels))
+    expected = [
+      {
+        level_slug: "basics",
+        user_lessons: [
+          { lesson_slug: "lesson-1", status: "completed" },
+          { lesson_slug: "lesson-2", status: "started" }
+        ]
+      },
+      {
+        level_slug: "advanced",
+        user_lessons: [
+          { lesson_slug: "lesson-3", status: "completed" }
+        ]
+      }
+    ]
+
+    assert_equal(expected, SerializeUserLevels.(user.user_levels))
   end
 
   test "returns empty array when no user_levels" do
@@ -67,11 +69,13 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
     create(:user_lesson, user: user, lesson: lesson2)
     create(:user_lesson, user: user, lesson: lesson3)
 
-    assert_equal([
-                   { level_slug: "level-a", user_lessons: [{ lesson_slug: "lesson-a", status: "started" }] },
-                   { level_slug: "level-b", user_lessons: [{ lesson_slug: "lesson-b", status: "started" }] },
-                   { level_slug: "level-c", user_lessons: [{ lesson_slug: "lesson-c", status: "started" }] }
-                 ], SerializeUserLevels.(user.user_levels))
+    expected = [
+      { level_slug: "level-a", user_lessons: [{ lesson_slug: "lesson-a", status: "started" }] },
+      { level_slug: "level-b", user_lessons: [{ lesson_slug: "lesson-b", status: "started" }] },
+      { level_slug: "level-c", user_lessons: [{ lesson_slug: "lesson-c", status: "started" }] }
+    ]
+
+    assert_equal(expected, SerializeUserLevels.(user.user_levels))
   end
 
   test "maintains lesson position order within levels" do
@@ -87,15 +91,17 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
     create(:user_lesson, user: user, lesson: lesson2)
     create(:user_lesson, user: user, lesson: lesson3)
 
-    assert_equal([
-                   {
-                     level_slug: "basics",
-                     user_lessons: [
-                       { lesson_slug: "lesson-a", status: "started" },
-                       { lesson_slug: "lesson-b", status: "started" },
-                       { lesson_slug: "lesson-c", status: "started" }
-                     ]
-                   }
-                 ], SerializeUserLevels.(user.user_levels))
+    expected = [
+      {
+        level_slug: "basics",
+        user_lessons: [
+          { lesson_slug: "lesson-a", status: "started" },
+          { lesson_slug: "lesson-b", status: "started" },
+          { lesson_slug: "lesson-c", status: "started" }
+        ]
+      }
+    ]
+
+    assert_equal(expected, SerializeUserLevels.(user.user_levels))
   end
 end


### PR DESCRIPTION
## Summary

Refactors all serializer tests to extract expected hash/array values into separate variables before assertions. This improves test readability, maintainability, and debugging experience.

### Key Changes
- **Documentation**: Added new section in `.context/testing.md` documenting the serializer testing pattern with examples
- **Test Refactoring**: Updated all 6 serializer test files to follow the extracted variable pattern
  - `serialize_lesson_test.rb` - 2 tests updated
  - `serialize_lessons_test.rb` - 2 tests updated  
  - `serialize_level_test.rb` - 2 tests updated
  - `serialize_levels_test.rb` - 2 tests updated
  - `serialize_user_lesson_test.rb` - 4 tests updated
  - `serialize_user_levels_test.rb` - 3 tests updated

### Benefits
✅ **Readability**: Expected output is clearly visible and separated from assertion logic  
✅ **Maintainability**: Simpler to modify expected values when requirements change  
✅ **Debugging**: Better diffs when tests fail - exact mismatches are immediately visible  
✅ **Consistency**: All serializer tests now follow the same pattern across the codebase

### Test Results
- ✅ All 156 tests pass
- ✅ Rubocop clean (no offenses)
- ✅ Brakeman security scan clean

## Pattern Example

**Before:**
```ruby
assert_equal([
  { slug: "level-1", lessons: [...] },
  { slug: "level-2", lessons: [...] }
], SerializeLevels.([level1, level2]))
```

**After:**
```ruby
expected = [
  { slug: "level-1", lessons: [...] },
  { slug: "level-2", lessons: [...] }
]

assert_equal(expected, SerializeLevels.([level1, level2]))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)