### PR TITLE
Add Procfile.dev with Hivemind for unified process management

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3061
+sidekiq: bundle exec sidekiq

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Ruby 3.4.4
 - Ruby 3.4.4 (see `.ruby-version`)
 - PostgreSQL
 - Bundler
+- Redis (for Sidekiq background jobs)
+- Hivemind (for running multiple processes: `brew install hivemind`)
 
 ### Installation
 
@@ -249,7 +251,9 @@ Ruby 3.4.4
 bin/dev
 ```
 
-The server runs on port 3061 by default.
+This starts both the Rails server (port 3061) and Sidekiq worker using Hivemind.
+
+**Note:** Redis must be running for Sidekiq. Start Redis with `brew services start redis` if needed.
 
 ## Tests
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,3 @@
-#!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+#!/usr/bin/env bash
+
+hivemind Procfile.dev


### PR DESCRIPTION
## Summary

- Created `Procfile.dev` defining `web` (Rails server on port 3061) and `sidekiq` (background jobs) processes
- Updated `bin/dev` to use Hivemind for running all processes together
- Updated `README.md` with Hivemind and Redis prerequisites and usage notes

## Why

This change improves the development experience by:
- Running Rails server and Sidekiq worker with a single command (`bin/dev`)
- Providing unified, color-coded output for all processes in one terminal
- Matching the proven pattern from Exercism website
- Ensuring production parity (web and workers run separately in production)

## Test Plan

- [x] All existing tests pass (256 runs, 0 failures)
- [x] Rubocop linting passes with no offenses
- [x] Brakeman security scan passes with no warnings
- [ ] Verify `bin/dev` starts both Rails and Sidekiq successfully
- [ ] Verify Sidekiq processes background jobs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)