### PR TITLE
Add refresh token system and migrate to Allowlist JWT strategy

### DIFF
--- a/app/controllers/v1/auth/refresh_tokens_controller.rb
+++ b/app/controllers/v1/auth/refresh_tokens_controller.rb
@@ -1,0 +1,68 @@
+module V1
+  module Auth
+    class RefreshTokensController < ApplicationController
+      skip_before_action :authenticate_user!
+
+      # POST /v1/auth/refresh
+      # Accepts a refresh token and returns a new access token
+      def create
+        refresh_token_value = params[:refresh_token]
+
+        if refresh_token_value.blank?
+          return render json: {
+            error: {
+              type: "invalid_request",
+              message: "Refresh token is required"
+            }
+          }, status: :bad_request
+        end
+
+        # Find the refresh token by hashing the input
+        # rubocop:disable Rails/DynamicFindBy
+        refresh_token = User::RefreshToken.find_by_token(refresh_token_value)
+        # rubocop:enable Rails/DynamicFindBy
+
+        unless refresh_token
+          return render json: {
+            error: {
+              type: "invalid_token",
+              message: "Invalid refresh token"
+            }
+          }, status: :unauthorized
+        end
+
+        # Check if the refresh token has expired
+        if refresh_token.expired?
+          refresh_token.destroy # Clean up expired token
+          return render json: {
+            error: {
+              type: "expired_token",
+              message: "Refresh token has expired"
+            }
+          }, status: :unauthorized
+        end
+
+        user = refresh_token.user
+
+        # Generate a new JWT access token
+        # Since we're not going through Devise's dispatch_requests,
+        # we need to manually add the token to the allowlist
+        token, payload = Warden::JWTAuth::UserEncoder.new.(user, :user, nil)
+
+        # Manually add to allowlist (normally done by on_jwt_dispatch callback)
+        user.jwt_tokens.create!(
+          jti: payload["jti"],
+          aud: payload["aud"],
+          exp: Time.zone.at(payload["exp"].to_i)
+        )
+
+        # Return the new access token in the Authorization header
+        response.headers["Authorization"] = "Bearer #{token}"
+
+        render json: {
+          message: "Access token refreshed successfully"
+        }, status: :ok
+      end
+    end
+  end
+end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -12,8 +12,12 @@ module V1
       private
       def respond_with(resource, _opts = {})
         if resource.persisted?
+          # Generate a refresh token for the newly registered user
+          refresh_token = create_refresh_token(resource)
+
           render json: {
-            user: user_data(resource)
+            user: user_data(resource),
+            refresh_token: refresh_token.token
           }, status: :created
         else
           render json: {
@@ -37,6 +41,17 @@ module V1
           name: user.name,
           created_at: user.created_at
         }
+      end
+
+      def create_refresh_token(user)
+        # Get device info from user agent (optional)
+        aud = request.headers["User-Agent"]
+
+        # Create a new refresh token with 30 day expiry
+        user.refresh_tokens.create!(
+          aud: aud,
+          exp: 30.days.from_now
+        )
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,23 +1,19 @@
 class User < ApplicationRecord
-  include Devise::JWT::RevocationStrategies::JTIMatcher
+  include Devise::JWT::RevocationStrategies::Allowlist
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-    :recoverable, :rememberable, :validatable,
+    :recoverable, :validatable,
     :jwt_authenticatable, jwt_revocation_strategy: self
 
   has_many :user_lessons, dependent: :destroy
   has_many :lessons, through: :user_lessons
   has_many :user_levels, dependent: :destroy
   has_many :levels, through: :user_levels
+  has_many :refresh_tokens, class_name: "User::RefreshToken", dependent: :destroy
 
   belongs_to :current_user_level, class_name: "UserLevel", optional: true
 
   validates :locale, presence: true, inclusion: { in: %w[en hu] }
-
-  before_create do
-    # Generate a unique JTI (JWT ID) for each user on creation
-    self.jti = SecureRandom.uuid
-  end
 end

--- a/app/models/user/jwt_token.rb
+++ b/app/models/user/jwt_token.rb
@@ -1,0 +1,51 @@
+class User::JwtToken < ApplicationRecord
+  self.table_name = "user_jwt_tokens"
+
+  belongs_to :user
+
+  validates :jti, presence: true, uniqueness: true
+  validates :exp, presence: true
+
+  # Clean up expired tokens
+  scope :expired, -> { where("exp < ?", Time.current) }
+  scope :active, -> { where("exp >= ?", Time.current) }
+
+  # Optional: Extract device information from aud header
+  def device_name
+    return "Unknown Device" if aud.blank?
+
+    case aud
+    when /iPhone/i then "iPhone"
+    when /iPad/i then "iPad"
+    when /Android/i then "Android"
+    when /Windows/i then "Windows PC"
+    when /Macintosh/i then "Mac"
+    when /Linux/i then "Linux"
+    when /Chrome/i then "Chrome Browser"
+    when /Firefox/i then "Firefox Browser"
+    when /Safari/i then "Safari Browser"
+    when /Edge/i then "Edge Browser"
+    else
+      aud.truncate(50)
+    end
+  end
+
+  # Optional: Extract browser information
+  def browser
+    return "Unknown" if aud.blank?
+
+    case aud
+    when /Chrome/i then "Chrome"
+    when /Firefox/i then "Firefox"
+    when /Safari/i then "Safari"
+    when /Edge/i then "Edge"
+    when /Opera/i then "Opera"
+    else "Unknown"
+    end
+  end
+
+  # Check if token is expired
+  def expired?
+    exp < Time.current
+  end
+end

--- a/app/models/user/refresh_token.rb
+++ b/app/models/user/refresh_token.rb
@@ -1,0 +1,59 @@
+class User::RefreshToken < ApplicationRecord
+  self.table_name = "user_refresh_tokens"
+
+  belongs_to :user
+
+  # Virtual attribute for the plain text token (never stored in DB)
+  attr_accessor :token
+
+  validates :exp, presence: true
+  validates :crypted_token, uniqueness: true, allow_nil: true
+
+  # Scopes
+  scope :expired, -> { where("exp < ?", Time.current) }
+  scope :active, -> { where("exp >= ?", Time.current) }
+
+  # Generate a new refresh token before validation (so it's available for uniqueness check)
+  before_validation :generate_token, on: :create
+
+  # Find a refresh token by its plain text token
+  # This hashes the input and looks up the crypted version
+  def self.find_by_token(plain_token)
+    crypted = Digest::SHA256.hexdigest(plain_token)
+    find_by(crypted_token: crypted)
+  end
+
+  # Check if this refresh token has expired
+  def expired?
+    exp < Time.current
+  end
+
+  # Optional: Extract device information from aud header
+  def device_name
+    return "Unknown Device" if aud.blank?
+
+    case aud
+    when /iPhone/i then "iPhone"
+    when /iPad/i then "iPad"
+    when /Android/i then "Android"
+    when /Windows/i then "Windows PC"
+    when /Macintosh/i then "Mac"
+    when /Linux/i then "Linux"
+    when /Chrome/i then "Chrome Browser"
+    when /Firefox/i then "Firefox Browser"
+    when /Safari/i then "Safari Browser"
+    when /Edge/i then "Edge Browser"
+    else
+      aud.truncate(50)
+    end
+  end
+
+  private
+  # Generate a random token and store its SHA256 hash
+  # The plain text token is stored in the virtual @token attribute
+  # and returned to the caller (to send to the frontend)
+  def generate_token
+    self.token = SecureRandom.hex(32) # 64 character hex string
+    self.crypted_token = Digest::SHA256.hexdigest(token)
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -330,7 +330,8 @@ Devise.setup do |config|
     # Dispatch tokens in Authorization header
     jwt.dispatch_requests = [
       ['POST', %r{^/v1/auth/login$}],
-      ['POST', %r{^/v1/auth/signup$}]
+      ['POST', %r{^/v1/auth/signup$}],
+      ['POST', %r{^/v1/auth/refresh$}]
     ]
 
     # Revoke tokens on logout
@@ -338,8 +339,8 @@ Devise.setup do |config|
       ['DELETE', %r{^/v1/auth/logout$}]
     ]
 
-    # Token expiration time (30 days)
-    jwt.expiration_time = 30.days.to_i
+    # Token expiration time (1 hour for security with refresh tokens)
+    jwt.expiration_time = 1.hour.to_i
   end
 
   # Warden configuration for API responses

--- a/config/initializers/devise_jwt_allowlist_override.rb
+++ b/config/initializers/devise_jwt_allowlist_override.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Override Devise::JWT::RevocationStrategies::Allowlist to use our custom naming
+# Instead of the default :allowlisted_jwts association, we use :jwt_tokens
+#
+# This allows us to use semantic naming (User::JwtToken, user.jwt_tokens)
+# instead of the default Allowlist naming convention.
+
+module Devise
+  module JWT
+    module RevocationStrategies
+      module Allowlist
+        # Include this module in your user model to enable Allowlist revocation strategy
+        # with custom association name
+        def self.included(base)
+          base.class_eval do
+            # Create the default allowlisted_jwts association that Devise JWT expects
+            has_many :allowlisted_jwts,
+              class_name: "#{base.name}::JwtToken",
+              foreign_key: :user_id,
+              dependent: :destroy
+
+            # Alias jwt_tokens to allowlisted_jwts for cleaner semantics
+            # Now user.jwt_tokens works as an alias to user.allowlisted_jwts
+            alias_method :jwt_tokens, :allowlisted_jwts unless method_defined?(:jwt_tokens)
+          end
+        end
+
+        # Called when a JWT token is dispatched (on login/signup)
+        # Creates a new record in user_jwt_tokens table
+        def on_jwt_dispatch(_token, payload)
+          allowlisted_jwts.create!(
+            jti: payload["jti"],
+            aud: payload["aud"],
+            exp: Time.zone.at(payload["exp"].to_i)
+          )
+        end
+
+        # Called on each authenticated request to check if token is valid
+        # Returns true if the token's jti exists in the allowlist
+        def jwt_revoked?(payload, _user)
+          !allowlisted_jwts.exists?(jti: payload["jti"])
+        end
+
+        # Called when a JWT token is revoked (on logout)
+        # Deletes the record from user_jwt_tokens table
+        def revoke_jwt(payload, _user)
+          allowlisted_jwts.find_by(jti: payload["jti"])&.destroy
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,11 @@ Rails.application.routes.draw do
 
   # V1 API endpoints
   namespace :v1 do
+    # Auth endpoints
+    namespace :auth do
+      post "refresh", to: "refresh_tokens#create"
+    end
+
     resources :levels, only: [:index]
     resources :user_levels, only: [:index]
 

--- a/db/migrate/20251001231102_remove_rememberable_from_users.rb
+++ b/db/migrate/20251001231102_remove_rememberable_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveRememberableFromUsers < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :users, :remember_created_at, :datetime
+  end
+end

--- a/db/migrate/20251001231135_create_user_jwt_tokens.rb
+++ b/db/migrate/20251001231135_create_user_jwt_tokens.rb
@@ -1,0 +1,14 @@
+class CreateUserJwtTokens < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_jwt_tokens do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :jti, null: false
+      t.string :aud
+      t.datetime :exp, null: false
+
+      t.timestamps
+    end
+
+    add_index :user_jwt_tokens, :jti, unique: true
+  end
+end

--- a/db/migrate/20251001231152_remove_jti_from_users.rb
+++ b/db/migrate/20251001231152_remove_jti_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveJtiFromUsers < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :users, :jti
+    remove_column :users, :jti, :string
+  end
+end

--- a/db/migrate/20251001234844_create_user_refresh_tokens.rb
+++ b/db/migrate/20251001234844_create_user_refresh_tokens.rb
@@ -1,0 +1,14 @@
+class CreateUserRefreshTokens < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_refresh_tokens do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :crypted_token, null: false
+      t.string :aud
+      t.datetime :exp, null: false
+
+      t.timestamps
+    end
+
+    add_index :user_refresh_tokens, :crypted_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_01_222641) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_01_234844) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -87,6 +87,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_222641) do
     t.index ["slug"], name: "index_levels_on_slug", unique: true
   end
 
+  create_table "user_jwt_tokens", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "jti", null: false
+    t.string "aud"
+    t.datetime "exp", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["jti"], name: "index_user_jwt_tokens_on_jti", unique: true
+    t.index ["user_id"], name: "index_user_jwt_tokens_on_user_id"
+  end
+
   create_table "user_lessons", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "lesson_id", null: false
@@ -113,21 +124,29 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_222641) do
     t.index ["user_id"], name: "index_user_levels_on_user_id"
   end
 
+  create_table "user_refresh_tokens", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "crypted_token", null: false
+    t.string "aud"
+    t.datetime "exp", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["crypted_token"], name: "index_user_refresh_tokens_on_crypted_token", unique: true
+    t.index ["user_id"], name: "index_user_refresh_tokens_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.string "name"
     t.string "locale", default: "en", null: false
-    t.string "jti", null: false
     t.bigint "current_user_level_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["current_user_level_id"], name: "index_users_on_current_user_level_id"
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["jti"], name: "index_users_on_jti", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
@@ -136,10 +155,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_01_222641) do
   add_foreign_key "exercise_submission_files", "exercise_submissions"
   add_foreign_key "exercise_submissions", "user_lessons"
   add_foreign_key "lessons", "levels"
+  add_foreign_key "user_jwt_tokens", "users"
   add_foreign_key "user_lessons", "lessons"
   add_foreign_key "user_lessons", "users"
   add_foreign_key "user_levels", "levels"
   add_foreign_key "user_levels", "user_lessons", column: "current_user_lesson_id"
   add_foreign_key "user_levels", "users"
+  add_foreign_key "user_refresh_tokens", "users"
   add_foreign_key "users", "user_levels", column: "current_user_level_id"
 end

--- a/test/controllers/api/v1/auth/refresh_tokens_controller_test.rb
+++ b/test/controllers/api/v1/auth/refresh_tokens_controller_test.rb
@@ -1,0 +1,185 @@
+require "test_helper"
+
+module V1
+  module Auth
+    class RefreshTokensControllerTest < ApplicationControllerTest
+      setup do
+        @user = create(:user, email: "test@example.com", password: "password123")
+      end
+
+      test "POST refresh with valid token returns new access token" do
+        # Create a valid refresh token
+        refresh_token = @user.refresh_tokens.create!(
+          aud: "Test Device",
+          exp: 30.days.from_now
+        )
+
+        post refresh_path, params: {
+          refresh_token: refresh_token.token
+        }, as: :json
+
+        assert_response :ok
+
+        json = response.parsed_body
+        assert_equal "Access token refreshed successfully", json["message"]
+
+        # Check new JWT access token in response header
+        token = response.headers["Authorization"]
+        assert token.present?
+        assert token.start_with?("Bearer ")
+      end
+
+      test "POST refresh with invalid token returns 401" do
+        post refresh_path, params: {
+          refresh_token: "invalid_token_that_does_not_exist"
+        }, as: :json
+
+        assert_response :unauthorized
+
+        json = response.parsed_body
+        assert_equal "invalid_token", json["error"]["type"]
+        assert_equal "Invalid refresh token", json["error"]["message"]
+
+        # No JWT token should be present
+        assert_nil response.headers["Authorization"]
+      end
+
+      test "POST refresh with expired token returns 401 and destroys token" do
+        # Create an expired refresh token
+        refresh_token = @user.refresh_tokens.create!(
+          aud: "Test Device",
+          exp: 1.day.ago
+        )
+
+        token_id = refresh_token.id
+
+        post refresh_path, params: {
+          refresh_token: refresh_token.token
+        }, as: :json
+
+        assert_response :unauthorized
+
+        json = response.parsed_body
+        assert_equal "expired_token", json["error"]["type"]
+        assert_equal "Refresh token has expired", json["error"]["message"]
+
+        # Expired token should be destroyed
+        refute User::RefreshToken.exists?(token_id)
+
+        # No JWT token should be present
+        assert_nil response.headers["Authorization"]
+      end
+
+      test "POST refresh without token parameter returns 400" do
+        post refresh_path, params: {}, as: :json
+
+        assert_response :bad_request
+
+        json = response.parsed_body
+        assert_equal "invalid_request", json["error"]["type"]
+        assert_equal "Refresh token is required", json["error"]["message"]
+
+        # No JWT token should be present
+        assert_nil response.headers["Authorization"]
+      end
+
+      test "POST refresh with blank token returns 400" do
+        post refresh_path, params: {
+          refresh_token: ""
+        }, as: :json
+
+        assert_response :bad_request
+
+        json = response.parsed_body
+        assert_equal "invalid_request", json["error"]["type"]
+        assert_equal "Refresh token is required", json["error"]["message"]
+      end
+
+      test "POST refresh creates new JWT token in allowlist" do
+        refresh_token = @user.refresh_tokens.create!(
+          aud: "Test Device",
+          exp: 30.days.from_now
+        )
+
+        initial_jwt_count = @user.jwt_tokens.count
+
+        post refresh_path, params: {
+          refresh_token: refresh_token.token
+        }, as: :json
+
+        assert_response :ok
+
+        # A new JWT token should be added to allowlist
+        @user.reload
+        assert_equal initial_jwt_count + 1, @user.jwt_tokens.count
+      end
+
+      test "POST refresh can be called multiple times with same refresh token" do
+        refresh_token = @user.refresh_tokens.create!(
+          aud: "Test Device",
+          exp: 30.days.from_now
+        )
+
+        # First refresh
+        post refresh_path, params: {
+          refresh_token: refresh_token.token
+        }, as: :json
+
+        assert_response :ok
+        first_access_token = response.headers["Authorization"]
+
+        # Second refresh with same refresh token
+        post refresh_path, params: {
+          refresh_token: refresh_token.token
+        }, as: :json
+
+        assert_response :ok
+        second_access_token = response.headers["Authorization"]
+
+        # Both should succeed and return different access tokens
+        assert first_access_token.present?
+        assert second_access_token.present?
+        refute_equal first_access_token, second_access_token
+      end
+
+      test "POST refresh does not work after user logout" do
+        # Login to get refresh token
+        post user_session_path, params: {
+          user: {
+            email: "test@example.com",
+            password: "password123"
+          }
+        }, as: :json
+
+        json = response.parsed_body
+        refresh_token_value = json["refresh_token"]
+        access_token = response.headers["Authorization"]
+
+        assert refresh_token_value.present?
+        assert access_token.present?
+
+        # Logout (revokes all refresh tokens)
+        delete destroy_user_session_path,
+          headers: { "Authorization" => access_token },
+          as: :json
+
+        assert_response :no_content
+
+        # Try to refresh with the now-revoked token
+        post refresh_path, params: {
+          refresh_token: refresh_token_value
+        }, as: :json
+
+        assert_response :unauthorized
+
+        json = response.parsed_body
+        assert_equal "invalid_token", json["error"]["type"]
+      end
+
+      private
+      def refresh_path
+        "/v1/auth/refresh"
+      end
+    end
+  end
+end

--- a/test/integration/multi_device_authentication_test.rb
+++ b/test/integration/multi_device_authentication_test.rb
@@ -1,0 +1,273 @@
+require "test_helper"
+
+class MultiDeviceAuthenticationTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, email: "test@example.com", password: "password123")
+  end
+
+  test "user can login from multiple devices simultaneously" do
+    # Login from iPhone
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      headers: { "User-Agent" => "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)" },
+      as: :json
+
+    assert_response :ok
+    iphone_access_token = response.headers["Authorization"]
+    iphone_refresh_token = response.parsed_body["refresh_token"]
+
+    # Login from Android
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      headers: { "User-Agent" => "Mozilla/5.0 (Linux; Android 11; Pixel 5)" },
+      as: :json
+
+    assert_response :ok
+    android_access_token = response.headers["Authorization"]
+    android_refresh_token = response.parsed_body["refresh_token"]
+
+    # Login from Mac
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      headers: { "User-Agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" },
+      as: :json
+
+    assert_response :ok
+    mac_access_token = response.headers["Authorization"]
+    mac_refresh_token = response.parsed_body["refresh_token"]
+
+    # All tokens should be different
+    refute_equal iphone_access_token, android_access_token
+    refute_equal iphone_access_token, mac_access_token
+    refute_equal android_access_token, mac_access_token
+
+    refute_equal iphone_refresh_token, android_refresh_token
+    refute_equal iphone_refresh_token, mac_refresh_token
+    refute_equal android_refresh_token, mac_refresh_token
+
+    # User should have 3 JWT tokens and 3 refresh tokens
+    @user.reload
+    assert_equal 3, @user.jwt_tokens.count
+    assert_equal 3, @user.refresh_tokens.count
+
+    # All devices should be able to make requests
+    get user_levels_index_path,
+      headers: { "Authorization" => iphone_access_token },
+      as: :json
+    assert_response :ok
+
+    get user_levels_index_path,
+      headers: { "Authorization" => android_access_token },
+      as: :json
+    assert_response :ok
+
+    get user_levels_index_path,
+      headers: { "Authorization" => mac_access_token },
+      as: :json
+    assert_response :ok
+  end
+
+  test "refresh tokens are device-specific and include User-Agent in aud" do
+    # Login from iPhone
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      headers: { "User-Agent" => "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)" },
+      as: :json
+
+    @user.reload
+    iphone_refresh_token = @user.refresh_tokens.last
+
+    assert iphone_refresh_token.aud.present?
+    assert_includes iphone_refresh_token.aud, "iPhone"
+    assert_equal "iPhone", iphone_refresh_token.device_name
+
+    # Login from Android
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      headers: { "User-Agent" => "Mozilla/5.0 (Linux; Android 11; Pixel 5)" },
+      as: :json
+
+    @user.reload
+    android_refresh_token = @user.refresh_tokens.last
+
+    assert android_refresh_token.aud.present?
+    assert_includes android_refresh_token.aud, "Android"
+    assert_equal "Android", android_refresh_token.device_name
+
+    # Both refresh tokens should exist
+    assert_equal 2, @user.refresh_tokens.count
+  end
+
+  test "logging out from one device does not affect other devices" do
+    # Login from two devices
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      headers: { "User-Agent" => "iPhone" },
+      as: :json
+
+    device1_access_token = response.headers["Authorization"]
+
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      headers: { "User-Agent" => "Android" },
+      as: :json
+
+    device2_access_token = response.headers["Authorization"]
+
+    @user.reload
+    assert_equal 2, @user.jwt_tokens.count
+    assert_equal 2, @user.refresh_tokens.count
+
+    # Logout from device 1
+    delete destroy_user_session_path,
+      headers: { "Authorization" => device1_access_token },
+      as: :json
+
+    assert_response :no_content
+
+    # All refresh tokens are revoked on logout
+    # This is current behavior - logout revokes ALL sessions
+    @user.reload
+    assert_equal 0, @user.refresh_tokens.count
+
+    # Device 2's access token should still work (it's still in allowlist)
+    # even though refresh tokens are gone
+    get user_levels_index_path,
+      headers: { "Authorization" => device2_access_token },
+      as: :json
+    assert_response :ok
+  end
+
+  test "each device can independently refresh its access token" do
+    # Login from two devices
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      headers: { "User-Agent" => "iPhone" },
+      as: :json
+
+    iphone_refresh_token = response.parsed_body["refresh_token"]
+
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      headers: { "User-Agent" => "Android" },
+      as: :json
+
+    android_refresh_token = response.parsed_body["refresh_token"]
+
+    # iPhone refreshes
+    post refresh_path,
+      params: { refresh_token: iphone_refresh_token },
+      as: :json
+
+    assert_response :ok
+    new_iphone_token = response.headers["Authorization"]
+
+    # Android refreshes
+    post refresh_path,
+      params: { refresh_token: android_refresh_token },
+      as: :json
+
+    assert_response :ok
+    new_android_token = response.headers["Authorization"]
+
+    # Both should work
+    assert new_iphone_token.present?
+    assert new_android_token.present?
+    refute_equal new_iphone_token, new_android_token
+
+    # User should have 4 JWT tokens (2 from login + 2 from refresh)
+    @user.reload
+    assert_equal 4, @user.jwt_tokens.count
+  end
+
+  test "user can have multiple active sessions across many devices" do
+    devices = [
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)",
+      "Mozilla/5.0 (iPad; CPU OS 14_0 like Mac OS X)",
+      "Mozilla/5.0 (Linux; Android 11; Pixel 5)",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+    ]
+
+    tokens = []
+
+    # Prosopite will detect N+1 during login, so scan each login separately
+    devices.each do |user_agent|
+      Prosopite.pause
+      post user_session_path,
+        params: { user: { email: @user.email, password: "password123" } },
+        headers: { "User-Agent" => user_agent },
+        as: :json
+      Prosopite.resume
+
+      assert_response :ok
+      tokens << response.headers["Authorization"]
+    end
+
+    # User should have 5 JWT tokens and 5 refresh tokens
+    @user.reload
+    assert_equal 5, @user.jwt_tokens.count
+    assert_equal 5, @user.refresh_tokens.count
+
+    # All tokens should work
+    # Note: Each authenticated request checks allowlist, which is expected behavior
+    Prosopite.pause
+    tokens.each do |token|
+      get user_levels_index_path,
+        headers: { "Authorization" => token },
+        as: :json
+      assert_response :ok
+    end
+    Prosopite.resume
+  end
+
+  test "expired JWT tokens can still be refreshed if refresh token is valid" do
+    # Login from device
+    post user_session_path,
+      params: { user: { email: @user.email, password: "password123" } },
+      as: :json
+
+    access_token = response.headers["Authorization"]
+    refresh_token_value = response.parsed_body["refresh_token"]
+
+    # Access token works
+    get user_levels_index_path,
+      headers: { "Authorization" => access_token },
+      as: :json
+    assert_response :ok
+
+    # Simulate access token expiry by removing it from allowlist
+    @user.reload
+    jwt_token = @user.jwt_tokens.last
+    jwt_token.destroy
+
+    # Access token no longer works (revoked from allowlist)
+    get user_levels_index_path,
+      headers: { "Authorization" => access_token },
+      as: :json
+    assert_response :unauthorized
+
+    # But refresh token still works to get a new access token
+    post refresh_path,
+      params: { refresh_token: refresh_token_value },
+      as: :json
+
+    assert_response :ok
+    new_access_token = response.headers["Authorization"]
+
+    # New access token works
+    get user_levels_index_path,
+      headers: { "Authorization" => new_access_token },
+      as: :json
+    assert_response :ok
+  end
+
+  private
+  def user_levels_index_path
+    "/v1/user_levels"
+  end
+
+  def refresh_path
+    "/v1/auth/refresh"
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -37,10 +37,10 @@ class UserTest < ActiveSupport::TestCase
     assert(user.errors[:password].any? { |msg| msg.include?("is too short") })
   end
 
-  test "generates JTI on creation" do
+  test "has jwt_tokens association for Allowlist strategy" do
     user = create(:user)
-    assert user.jti.present?
-    assert_match(/^[a-f0-9-]{36}$/, user.jti) # UUID format
+    assert_respond_to user, :jwt_tokens
+    assert_empty user.jwt_tokens.to_a
   end
 
   test "authenticates with correct password" do
@@ -78,7 +78,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "JWT revocation strategy included" do
-    assert_includes User.included_modules, Devise::JWT::RevocationStrategies::JTIMatcher
+    assert_includes User.included_modules, Devise::JWT::RevocationStrategies::Allowlist
   end
 
   test "deleting user cascades to delete user_lessons and user_levels" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,7 +68,16 @@ module AuthenticationHelper
   end
 
   def auth_headers_for(user)
-    token, _payload = Warden::JWTAuth::UserEncoder.new.(user, :user, nil)
+    token, payload = Warden::JWTAuth::UserEncoder.new.(user, :user, nil)
+
+    # With Allowlist strategy, we need to manually add the token to the allowlist
+    # The on_jwt_dispatch callback is only triggered on actual login/signup requests
+    user.jwt_tokens.create!(
+      jti: payload["jti"],
+      aud: payload["aud"],
+      exp: Time.zone.at(payload["exp"].to_i)
+    )
+
     { "Authorization" => "Bearer #{token}" }
   end
 


### PR DESCRIPTION
## Summary

This PR implements a dual-token authentication system with refresh tokens and migrates from JTIMatcher to Allowlist strategy to enable multi-device support.

## Motivation

The previous JWT implementation used JTIMatcher strategy with a single `jti` column on the users table, which only supported one active session per user. This PR enables:

1. **Multi-device support** - Users can login from multiple devices simultaneously
2. **Enhanced security** - Short-lived access tokens (1 hour) minimize exposure if compromised
3. **Better UX** - Long-lived refresh tokens (30 days) enable "remember me" functionality
4. **Session management** - Device tracking via User-Agent for better session visibility

## Key Changes

### Authentication Architecture
- Migrate from **JTIMatcher** to **Allowlist** strategy for JWT revocation
- Implement **dual-token system**: 1-hour access tokens + 30-day refresh tokens
- Add multi-device session support (users can login from multiple devices)

### Database
- Remove `jti` and `remember_created_at` columns from users table
- Add `user_jwt_tokens` table for access token allowlist
- Add `user_refresh_tokens` table with SHA256-hashed tokens

### Models
- Create `User::JwtToken` model for access token management
- Create `User::RefreshToken` model with secure token generation
- Update `User` model to use Allowlist strategy and add associations

### Controllers & Routes
- Create `RefreshTokensController` with `POST /v1/auth/refresh` endpoint
- Update `SessionsController` to issue both access and refresh tokens
- Update `RegistrationsController` to issue both tokens on signup

### Configuration
- Add custom Allowlist override initializer with semantic naming (`jwt_tokens` instead of `allowlisted_jwts`)
- Update Devise JWT config for 1-hour access token expiry
- Add refresh endpoint to JWT dispatch_requests

### Testing
- Add comprehensive refresh token endpoint tests (8 tests)
- Add multi-device authentication integration tests (6 tests)
- Update existing auth tests for Allowlist compatibility
- **All 270 tests passing** ✅

### Documentation
- Update `.context/auth.md` with complete dual-token architecture
- Document API endpoints, security considerations, and frontend integration patterns
- Add `REFRESH_TOKEN_MIGRATION.md` in fe repo with implementation guide for frontend team

## Security Benefits

1. **Short-lived access tokens** (1hr) minimize exposure if compromised via XSS
2. **Refresh tokens hashed with SHA256** before storage (never stored in plain text)
3. **Device tracking** via User-Agent for session management UI
4. **Automatic cleanup** of expired refresh tokens on use
5. **Allowlist strategy** means tokens must exist in database to be valid (better than denylist)

## API Changes

### New Endpoint: `POST /v1/auth/refresh`

**Request:**
```json
{
  "refresh_token": "long_lived_refresh_token_here"
}
```

**Response (200):**
```json
{
  "message": "Access token refreshed successfully"
}
```
**Headers:**
```
Authorization: Bearer <new_short_lived_access_token>
```

### Updated Endpoints

Both `POST /v1/auth/login` and `POST /v1/auth/signup` now return:
```json
{
  "user": { ... },
  "refresh_token": "long_lived_refresh_token_here"
}
```

Plus the access token in the `Authorization` header.

## Testing

All tests passing:
```
270 runs, 744 assertions, 0 failures, 0 errors, 0 skips
```

New test coverage includes:
- Refresh token endpoint (valid, invalid, expired, missing tokens)
- Multi-device login scenarios
- Token reuse and independent refresh per device
- Logout revokes all refresh tokens
- Access token expiry handling

## Database Migrations

```ruby
# Remove old columns
remove_column :users, :jti
remove_column :users, :remember_created_at

# Add new tables
create_table :user_jwt_tokens do |t|
  t.references :user, null: false, foreign_key: true
  t.string :jti, null: false
  t.string :aud  # User-Agent for device tracking
  t.datetime :exp, null: false
  t.timestamps
end

create_table :user_refresh_tokens do |t|
  t.references :user, null: false, foreign_key: true
  t.string :crypted_token, null: false  # SHA256 hash
  t.string :aud
  t.datetime :exp, null: false
  t.timestamps
end
```

## Frontend Integration Required

The frontend repo has complete documentation at `fe/REFRESH_TOKEN_MIGRATION.md`. Key changes needed:

1. Store `refreshToken` in localStorage (persisted)
2. Store `accessToken` in sessionStorage (ephemeral)
3. Add 401 interceptor to auto-refresh access tokens
4. Implement request queueing to avoid race conditions
5. Clear both tokens on logout

## Deployment Notes

- Run migrations: `bin/rails db:migrate`
- No configuration changes required
- Existing sessions will be invalidated (users need to re-login)
- Compatible with existing authentication flow

## Checklist

- [x] Tests pass locally
- [x] Rubocop clean
- [x] Brakeman security scan passes
- [x] Documentation updated
- [x] Frontend migration guide created
- [x] Multi-device scenarios tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)