### PR TITLE
Make projects a premium-only feature

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,6 +76,10 @@ class ApplicationController < ActionController::API
     Rails.logger.warn "[DEV AUTH] Authenticated as user #{user.id} via URL parameter"
   end
 
+  def require_premium!
+    render_403(:premium_required) unless current_user&.premium?
+  end
+
   def use_lesson!
     @lesson = Lesson.find_by!(slug: params[:lesson_slug])
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/internal/projects/exercise_submissions_controller.rb
+++ b/app/controllers/internal/projects/exercise_submissions_controller.rb
@@ -1,4 +1,5 @@
 class Internal::Projects::ExerciseSubmissionsController < Internal::BaseController
+  before_action :require_premium!
   before_action :use_project!
 
   rescue_from DuplicateFilenameError, with: :render_duplicate_filename_error

--- a/app/controllers/internal/projects_controller.rb
+++ b/app/controllers/internal/projects_controller.rb
@@ -1,4 +1,5 @@
 class Internal::ProjectsController < Internal::BaseController
+  before_action :require_premium!, only: [:show]
   before_action :use_project!, only: [:show]
 
   def index

--- a/app/controllers/internal/user_projects_controller.rb
+++ b/app/controllers/internal/user_projects_controller.rb
@@ -1,4 +1,5 @@
 class Internal::UserProjectsController < Internal::BaseController
+  before_action :require_premium!
   before_action :use_project!
 
   def show

--- a/config/locales/api_errors.en.yml
+++ b/config/locales/api_errors.en.yml
@@ -6,6 +6,7 @@ en:
     unconfirmed: "Please confirm your email address"
     forbidden: "Admin access required"
     access_denied: "Access denied"
+    premium_required: "This feature is only available to premium members"
     invalid_signature: "Invalid signature"
 
     # Token errors

--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -936,15 +936,6 @@
           "data": {"slug": "stars"}
         },
         {
-          "slug": "collecting-from-arrays",
-          "title": "Collecting from Arrays",
-          "description": "Learn how to pick out the items you need from a list.",
-          "type": "video",
-          "data": {
-            "sources": [{"provider": "mux", "id": "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU"}]
-          }
-        },
-        {
           "slug": "meal-prep",
           "title": "Meal Prep",
           "description": "Work out which ingredients you need to buy for your recipe.",
@@ -1040,15 +1031,6 @@
           "description": "Parse your listening data from Spotify.",
           "type": "exercise",
           "data": {"slug": "spotify"}
-        },
-        {
-          "slug": "building-dictionaries",
-          "title": "Building Dictionaries",
-          "description": "Learn how to build up dictionaries from scratch.",
-          "type": "video",
-          "data": {
-            "sources": [{"provider": "mux", "id": "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU"}]
-          }
         },
         {
           "slug": "word-count",

--- a/test/commands/level/create_all_from_json_test.rb
+++ b/test/commands/level/create_all_from_json_test.rb
@@ -41,9 +41,9 @@ class Level::CreateAllFromJsonTest < ActiveSupport::TestCase
     # Second run
     Level::CreateAllFromJson.(course, file_path.to_s)
 
-    # Verify counts haven't changed (17 levels, 121 lessons total)
+    # Verify counts haven't changed (17 levels, 119 lessons total)
     assert_equal 17, Level.count
-    assert_equal 121, Lesson.count
+    assert_equal 119, Lesson.count
   end
 
   test "raises error for non-existent file" do

--- a/test/controllers/internal/projects/exercise_submissions_controller_test.rb
+++ b/test/controllers/internal/projects/exercise_submissions_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class Internal::Projects::ExerciseSubmissionsControllerTest < ApplicationControllerTest
   setup do
     setup_user
+    @current_user.data.update!(membership_type: "premium")
     @project = create(:project)
     # Pre-create UserProject so it doesn't emit events during tests
     create(:user_project, user: @current_user, project: @project)
@@ -138,6 +139,17 @@ class Internal::Projects::ExerciseSubmissionsControllerTest < ApplicationControl
         message: /File 'large.rb' is too large/
       }
     })
+  end
+
+  test "POST create returns 403 for non-premium user" do
+    @current_user.data.update!(membership_type: "standard")
+    files = [{ filename: "main.rb", code: "puts 'hello'" }]
+
+    post internal_project_exercise_submissions_path(project_slug: @project.slug),
+      params: { submission: { files: } },
+      as: :json
+
+    assert_json_error(:forbidden, error_type: :premium_required)
   end
 
   test "POST create returns 422 for empty files array" do

--- a/test/controllers/internal/projects_controller_test.rb
+++ b/test/controllers/internal/projects_controller_test.rb
@@ -175,6 +175,25 @@ class Internal::ProjectsControllerTest < ApplicationControllerTest
     })
   end
 
+  test "GET index is accessible to non-premium users" do
+    Prosopite.finish
+    @current_user.data.update!(membership_type: "standard")
+    project = create(:project, title: "Calculator")
+
+    get internal_projects_path, as: :json
+
+    assert_response :success
+    assert_json_response({
+      results: SerializeProjects.([project], for_user: @current_user),
+      meta: {
+        current_page: 1,
+        total_pages: 1,
+        total_count: 1,
+        events: []
+      }
+    })
+  end
+
   # GET /v1/projects/:slug (show) tests
   test "GET show returns project by slug" do
     Prosopite.finish

--- a/test/controllers/internal/projects_controller_test.rb
+++ b/test/controllers/internal/projects_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class Internal::ProjectsControllerTest < ApplicationControllerTest
   setup do
     setup_user
+    @current_user.data.update!(membership_type: "premium")
   end
 
   # Authentication guards
@@ -193,5 +194,15 @@ class Internal::ProjectsControllerTest < ApplicationControllerTest
     get internal_project_path(project_slug: "non-existent"), as: :json
 
     assert_json_error(:not_found, error_type: :project_not_found)
+  end
+
+  test "GET show returns 403 for non-premium user" do
+    Prosopite.finish
+    @current_user.data.update!(membership_type: "standard")
+    project = create(:project, slug: "calculator")
+
+    get internal_project_path(project_slug: project.slug), as: :json
+
+    assert_json_error(:forbidden, error_type: :premium_required)
   end
 end

--- a/test/controllers/internal/user_projects_controller_test.rb
+++ b/test/controllers/internal/user_projects_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class Internal::UserProjectsControllerTest < ApplicationControllerTest
   setup do
     setup_user
+    @current_user.data.update!(membership_type: "premium")
     @project = create(:project)
   end
 
@@ -35,5 +36,14 @@ class Internal::UserProjectsControllerTest < ApplicationControllerTest
       as: :json
 
     assert_json_error(:not_found, error_type: :project_not_found)
+  end
+
+  test "GET show returns 403 for non-premium user" do
+    @current_user.data.update!(membership_type: "standard")
+
+    get internal_user_project_path(project_slug: @project.slug),
+      as: :json
+
+    assert_json_error(:forbidden, error_type: :premium_required)
   end
 end


### PR DESCRIPTION
## Summary
- Gates project show, user project show, and project exercise submission endpoints behind premium membership via a new `require_premium!` helper that returns 403 `:premium_required`
- Project index remains open so non-premium users can still browse the project list
- Drops two stub video lessons (`collecting-from-arrays`, `building-dictionaries`) from the curriculum seed and updates the idempotency test count from 121 to 119 lessons

## Test plan
- [x] `bin/rails test test/controllers/internal/projects_controller_test.rb test/controllers/internal/user_projects_controller_test.rb test/controllers/internal/projects/exercise_submissions_controller_test.rb`
- [x] Full test suite (via pre-commit hook)
- [x] Brakeman clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)