### PR TITLE
Add UserVideo to track watch progress for client-side videos

### DIFF
--- a/app/commands/user_video/set_watched_percentage.rb
+++ b/app/commands/user_video/set_watched_percentage.rb
@@ -1,0 +1,22 @@
+class UserVideo::SetWatchedPercentage
+  include Mandate
+
+  initialize_with :user, :slug, :percentage
+
+  def call
+    clamped = percentage.to_i.clamp(0, 100)
+
+    return user_video if user_video.watched_percentage >= clamped
+
+    attrs = { watched_percentage: clamped }
+    attrs[:completed_at] = Time.current if clamped == 100 && user_video.completed_at.nil?
+    user_video.update!(attrs)
+    user_video
+  end
+
+  private
+  memoize
+  def user_video
+    UserVideo.find_or_create_by!(user:, slug:)
+  end
+end

--- a/app/controllers/internal/user_videos_controller.rb
+++ b/app/controllers/internal/user_videos_controller.rb
@@ -1,0 +1,15 @@
+class Internal::UserVideosController < Internal::BaseController
+  def index
+    user_videos = current_user.user_videos.order(:slug)
+
+    render json: {
+      user_videos: user_videos.map { SerializeUserVideo.(_1) }
+    }
+  end
+
+  def update
+    user_video = UserVideo::SetWatchedPercentage.(current_user, params[:slug], params[:watched_percentage])
+
+    render json: { user_video: SerializeUserVideo.(user_video) }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
   has_many :levels, through: :user_levels
   has_many :user_projects, dependent: :destroy
   has_many :projects, through: :user_projects
+  has_many :user_videos, dependent: :destroy
   has_many :acquired_badges, class_name: "User::AcquiredBadge", dependent: :destroy
   has_many :badges, through: :acquired_badges
   has_many :assistant_conversations, dependent: :destroy

--- a/app/models/user_video.rb
+++ b/app/models/user_video.rb
@@ -1,0 +1,8 @@
+class UserVideo < ApplicationRecord
+  belongs_to :user
+
+  validates :slug, presence: true, uniqueness: { scope: :user_id }
+  validates :watched_percentage, presence: true, inclusion: { in: 0..100 }
+
+  scope :completed, -> { where.not(completed_at: nil) }
+end

--- a/app/serializers/serialize_user_video.rb
+++ b/app/serializers/serialize_user_video.rb
@@ -1,0 +1,14 @@
+class SerializeUserVideo
+  include Mandate
+
+  initialize_with :user_video
+
+  def call
+    {
+      slug: user_video.slug,
+      watched_percentage: user_video.watched_percentage,
+      status: user_video.completed_at ? "completed" : "started",
+      completed_at: user_video.completed_at&.iso8601
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,8 @@ Rails.application.routes.draw do
 
     resources :user_projects, only: [:show], param: :project_slug
 
+    resources :user_videos, only: %i[index update], param: :slug
+
     resources :concepts, only: %i[index show], param: :concept_slug do
       collection do
         get :unlocked

--- a/db/migrate/20260508163016_create_user_videos.rb
+++ b/db/migrate/20260508163016_create_user_videos.rb
@@ -1,0 +1,13 @@
+class CreateUserVideos < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_videos do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :slug, null: false
+      t.integer :watched_percentage, null: false, default: 0
+      t.datetime :completed_at
+      t.timestamps
+    end
+
+    add_index :user_videos, [:user_id, :slug], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_21_215424) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_163016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -478,6 +478,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_21_215424) do
     t.index ["user_id", "project_id"], name: "index_user_projects_on_user_id_and_project_id", unique: true
   end
 
+  create_table "user_videos", force: :cascade do |t|
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.integer "watched_percentage", default: 0, null: false
+    t.index ["user_id", "slug"], name: "index_user_videos_on_user_id_and_slug", unique: true
+    t.index ["user_id"], name: "index_user_videos_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.boolean "admin", default: false, null: false
     t.string "avatar_url"
@@ -538,4 +549,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_21_215424) do
   add_foreign_key "user_levels", "users"
   add_foreign_key "user_projects", "projects"
   add_foreign_key "user_projects", "users"
+  add_foreign_key "user_videos", "users"
 end

--- a/test/commands/user_video/set_watched_percentage_test.rb
+++ b/test/commands/user_video/set_watched_percentage_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class UserVideo::SetWatchedPercentageTest < ActiveSupport::TestCase
+  test "creates user_video on first call" do
+    user = create(:user)
+
+    assert_difference "UserVideo.count", 1 do
+      UserVideo::SetWatchedPercentage.(user, "building-basics-01", 30)
+    end
+
+    user_video = UserVideo.find_by!(user:, slug: "building-basics-01")
+    assert_equal 30, user_video.watched_percentage
+    assert_nil user_video.completed_at
+  end
+
+  test "updates existing user_video" do
+    user = create(:user)
+    create(:user_video, user:, slug: "intro", watched_percentage: 20)
+
+    UserVideo::SetWatchedPercentage.(user, "intro", 50)
+
+    assert_equal 50, UserVideo.find_by!(user:, slug: "intro").watched_percentage
+  end
+
+  test "does not go backwards" do
+    user = create(:user)
+    create(:user_video, user:, slug: "intro", watched_percentage: 75)
+
+    UserVideo::SetWatchedPercentage.(user, "intro", 50)
+
+    assert_equal 75, UserVideo.find_by!(user:, slug: "intro").watched_percentage
+  end
+
+  test "clamps over 100 to 100" do
+    user = create(:user)
+
+    UserVideo::SetWatchedPercentage.(user, "intro", 150)
+
+    assert_equal 100, UserVideo.find_by!(user:, slug: "intro").watched_percentage
+  end
+
+  test "clamps negative to 0" do
+    user = create(:user)
+
+    UserVideo::SetWatchedPercentage.(user, "intro", -10)
+
+    assert_equal 0, UserVideo.find_by!(user:, slug: "intro").watched_percentage
+  end
+
+  test "sets completed_at on first reach of 100" do
+    user = create(:user)
+    freeze_time = Time.utc(2026, 5, 8, 12)
+
+    travel_to(freeze_time) do
+      UserVideo::SetWatchedPercentage.(user, "intro", 100)
+    end
+
+    user_video = UserVideo.find_by!(user:, slug: "intro")
+    assert_equal 100, user_video.watched_percentage
+    assert_equal freeze_time, user_video.completed_at
+  end
+
+  test "does not change completed_at on subsequent 100 calls" do
+    user = create(:user)
+    original = Time.utc(2026, 5, 8, 12)
+    create(:user_video, user:, slug: "intro", watched_percentage: 100, completed_at: original)
+
+    travel_to(Time.utc(2026, 6, 1, 12)) do
+      UserVideo::SetWatchedPercentage.(user, "intro", 100)
+    end
+
+    assert_equal original, UserVideo.find_by!(user:, slug: "intro").completed_at
+  end
+
+  test "does not set completed_at when below 100" do
+    user = create(:user)
+
+    UserVideo::SetWatchedPercentage.(user, "intro", 99)
+
+    assert_nil UserVideo.find_by!(user:, slug: "intro").completed_at
+  end
+
+  test "isolates progress between users" do
+    user1 = create(:user)
+    user2 = create(:user)
+
+    UserVideo::SetWatchedPercentage.(user1, "intro", 60)
+    UserVideo::SetWatchedPercentage.(user2, "intro", 30)
+
+    assert_equal 60, UserVideo.find_by!(user: user1, slug: "intro").watched_percentage
+    assert_equal 30, UserVideo.find_by!(user: user2, slug: "intro").watched_percentage
+  end
+end

--- a/test/controllers/internal/user_videos_controller_test.rb
+++ b/test/controllers/internal/user_videos_controller_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class Internal::UserVideosControllerTest < ApplicationControllerTest
+  setup { setup_user }
+
+  guard_incorrect_token! :internal_user_videos_path, method: :get
+  guard_incorrect_token! :internal_user_video_path, args: ["building-basics-01"], method: :patch
+
+  # GET /v1/user_videos
+  test "GET index returns user's videos" do
+    v1 = create(:user_video, user: @current_user, slug: "intro", watched_percentage: 50)
+    v2 = create(:user_video, user: @current_user, slug: "auth", watched_percentage: 100, completed_at: Time.current)
+    create(:user_video, user: create(:user), slug: "intro", watched_percentage: 10) # other user
+
+    get internal_user_videos_path, as: :json
+
+    assert_response :success
+    assert_json_response({
+      user_videos: [
+        SerializeUserVideo.(v2),
+        SerializeUserVideo.(v1)
+      ]
+    })
+  end
+
+  test "GET index returns empty when user has no videos" do
+    get internal_user_videos_path, as: :json
+
+    assert_response :success
+    assert_json_response({ user_videos: [] })
+  end
+
+  # PATCH /v1/user_videos/:slug
+  test "PATCH update delegates to command and returns serialized payload" do
+    UserVideo::SetWatchedPercentage.expects(:call).with(@current_user, "building-basics-01", 40).returns(
+      build_stubbed(:user_video, slug: "building-basics-01", watched_percentage: 40)
+    )
+
+    patch internal_user_video_path(slug: "building-basics-01"),
+      params: { watched_percentage: 40 },
+      as: :json
+
+    assert_response :success
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    assert_equal "building-basics-01", response_body[:user_video][:slug]
+    assert_equal 40, response_body[:user_video][:watched_percentage]
+  end
+
+  test "PATCH update creates user_video when not present" do
+    assert_difference "UserVideo.count", 1 do
+      patch internal_user_video_path(slug: "building-basics-01"),
+        params: { watched_percentage: 30 },
+        as: :json
+    end
+
+    assert_response :success
+    user_video = UserVideo.find_by!(user: @current_user, slug: "building-basics-01")
+    assert_equal 30, user_video.watched_percentage
+  end
+
+  test "PATCH update ratchets watched_percentage" do
+    create(:user_video, user: @current_user, slug: "intro", watched_percentage: 80)
+
+    patch internal_user_video_path(slug: "intro"),
+      params: { watched_percentage: 50 },
+      as: :json
+
+    assert_response :success
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    assert_equal 80, response_body[:user_video][:watched_percentage]
+  end
+
+  test "PATCH update sets completed status when reaching 100" do
+    patch internal_user_video_path(slug: "intro"),
+      params: { watched_percentage: 100 },
+      as: :json
+
+    assert_response :success
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    assert_equal "completed", response_body[:user_video][:status]
+    refute_nil response_body[:user_video][:completed_at]
+  end
+end

--- a/test/factories/user_videos.rb
+++ b/test/factories/user_videos.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user_video do
+    user
+    sequence(:slug) { |n| "video-slug-#{n}" }
+    watched_percentage { 0 }
+  end
+end

--- a/test/models/user_video_test.rb
+++ b/test/models/user_video_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class UserVideoTest < ActiveSupport::TestCase
+  test "valid factory" do
+    assert build(:user_video).valid?
+  end
+
+  test "requires slug" do
+    user_video = build(:user_video, slug: nil)
+    refute user_video.valid?
+  end
+
+  test "unique user and slug combination" do
+    user = create(:user)
+    create(:user_video, user:, slug: "building-basics-01")
+    duplicate = build(:user_video, user:, slug: "building-basics-01")
+
+    refute duplicate.valid?
+  end
+
+  test "same slug allowed for different users" do
+    create(:user_video, user: create(:user), slug: "building-basics-01")
+    other = build(:user_video, user: create(:user), slug: "building-basics-01")
+
+    assert other.valid?
+  end
+
+  test "watched_percentage must be 0..100" do
+    refute build(:user_video, watched_percentage: -1).valid?
+    refute build(:user_video, watched_percentage: 101).valid?
+    assert build(:user_video, watched_percentage: 0).valid?
+    assert build(:user_video, watched_percentage: 100).valid?
+  end
+
+  test "completed scope returns only videos with completed_at" do
+    completed = create(:user_video, completed_at: Time.current)
+    create(:user_video, completed_at: nil)
+
+    assert_equal [completed], UserVideo.completed.to_a
+  end
+end

--- a/test/serializers/serialize_user_video_test.rb
+++ b/test/serializers/serialize_user_video_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class SerializeUserVideoTest < ActiveSupport::TestCase
+  test "serializes started user_video" do
+    user_video = create(:user_video, slug: "building-basics-01", watched_percentage: 42, completed_at: nil)
+
+    expected = {
+      slug: "building-basics-01",
+      watched_percentage: 42,
+      status: "started",
+      completed_at: nil
+    }
+
+    assert_equal(expected, SerializeUserVideo.(user_video))
+  end
+
+  test "serializes completed user_video" do
+    completed_at = Time.utc(2026, 5, 8, 12)
+    user_video = create(:user_video,
+      slug: "building-basics-01",
+      watched_percentage: 100,
+      completed_at:)
+
+    expected = {
+      slug: "building-basics-01",
+      watched_percentage: 100,
+      status: "completed",
+      completed_at: completed_at.iso8601
+    }
+
+    assert_equal(expected, SerializeUserVideo.(user_video))
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a `UserVideo` model keyed by `(user_id, slug)` for tracking watch progress on the new "building content" videos (Building Basics, How Things Work, Q&A). Series/episodes live client-side for now, so we identify videos by client-supplied slug rather than via a server-side association.
- Mirrors the existing ratcheting `walkthrough_video_watched_percentage` pattern on `UserLesson` — `watched_percentage` only goes up, never down. `completed_at` is set the first time progress hits 100 and is sticky thereafter.
- Exposes `GET /v1/internal/user_videos` (bulk hydrate) and `PATCH /v1/internal/user_videos/:slug` (upsert progress).

## Test plan

- [x] `bin/rails test` — full suite green (1636 runs, 0 failures)
- [x] Brakeman clean
- [ ] Manual: `PATCH /internal/user_videos/<slug>` ratchets up only and sets `completed_at` once on first 100
- [ ] Manual: `GET /internal/user_videos` returns the current user's progress map

🤖 Generated with [Claude Code](https://claude.com/claude-code)