### PR TITLE
Add public pricing endpoint for unauthenticated PPP lookups

### DIFF
--- a/app/controllers/external/pricing_controller.rb
+++ b/app/controllers/external/pricing_controller.rb
@@ -1,0 +1,17 @@
+class External::PricingController < ApplicationController
+  def show
+    country = request.headers["CF-IPCountry"].to_s.upcase[0, 2]
+    currency = COUNTRY_CURRENCIES[country]&.to_sym
+    currency = :usd unless PREMIUM_PRICES.key?(currency)
+    prices = PREMIUM_PRICES[currency]
+
+    render json: {
+      premium_prices: {
+        currency:,
+        monthly: prices[:monthly],
+        annual: prices[:annual],
+        country_code: country.presence
+      }
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
 
   # External (public, unauthenticated) endpoints
   namespace :external do
+    resource :pricing, only: [:show], controller: 'pricing'
+
     resources :concepts, only: %i[index show], param: :concept_slug
 
     resources :email_preferences, only: %i[show update], param: :token do

--- a/test/controllers/external/pricing_controller_test.rb
+++ b/test/controllers/external/pricing_controller_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class External::PricingControllerTest < ActionDispatch::IntegrationTest
+  test "returns localised prices based on CF-IPCountry header" do
+    get external_pricing_path, headers: { "CF-IPCountry" => "BR" }, as: :json
+
+    assert_response :success
+    assert_json_response({
+      premium_prices: {
+        currency: :brl,
+        monthly: PREMIUM_PRICES[:brl][:monthly],
+        annual: PREMIUM_PRICES[:brl][:annual],
+        country_code: "BR"
+      }
+    })
+  end
+
+  test "falls back to usd when header is missing" do
+    get external_pricing_path, as: :json
+
+    assert_response :success
+    assert_json_response({
+      premium_prices: {
+        currency: :usd,
+        monthly: PREMIUM_PRICES[:usd][:monthly],
+        annual: PREMIUM_PRICES[:usd][:annual],
+        country_code: nil
+      }
+    })
+  end
+
+  test "falls back to usd when country has no currency mapping" do
+    get external_pricing_path, headers: { "CF-IPCountry" => "XX" }, as: :json
+
+    assert_response :success
+    assert_json_response({
+      premium_prices: {
+        currency: :usd,
+        monthly: PREMIUM_PRICES[:usd][:monthly],
+        annual: PREMIUM_PRICES[:usd][:annual],
+        country_code: "XX"
+      }
+    })
+  end
+end


### PR DESCRIPTION
## Summary
- New `GET /external/pricing` returns localised premium prices using the `CF-IPCountry` header — no auth required.
- Mirrors the `premium_prices` shape already returned by `SerializeUser`, so the FE can reuse render logic.
- Falls back to USD when the header is absent (dev/local) or the country has no currency mapping.

## Test plan
- [x] `bin/rails test test/controllers/external/pricing_controller_test.rb`
- [ ] FE: hit `/external/pricing` pre-login and confirm the payload matches what `/internal/me` returns post-login for the same user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)