### PR TITLE
Clear jiki_user_id cookie on Warden auth failures

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::API
   include ActionController::Cookies
   include MetaResponseWrapper
 
+  USER_ID_COOKIE_NAME = :jiki_user_id
+
   before_action :set_current_user_agent
   before_action :set_locale
   before_action :set_country_code
@@ -15,7 +17,7 @@ class ApplicationController < ActionController::API
   # Next.js frontend for server-side auth checks.
   def set_user_id_cookie
     if user_signed_in?
-      cookies.signed[:jiki_user_id] = {
+      cookies.signed[USER_ID_COOKIE_NAME] = {
         value: current_user.id,
         domain: :all,
         expires: 10.years,
@@ -24,7 +26,7 @@ class ApplicationController < ActionController::API
         secure: Rails.env.production?
       }
     else
-      cookies.delete(:jiki_user_id, domain: :all)
+      cookies.delete(USER_ID_COOKIE_NAME, domain: :all)
     end
   end
 

--- a/app/controllers/auth/account_deletions_controller.rb
+++ b/app/controllers/auth/account_deletions_controller.rb
@@ -17,7 +17,7 @@ class Auth::AccountDeletionsController < ApplicationController
 
     # Sign out if logged in and clear cookies
     sign_out(current_user) if user_signed_in?
-    cookies.delete(:jiki_user_id, domain: :all)
+    cookies.delete(ApplicationController::USER_ID_COOKIE_NAME, domain: :all)
 
     render json: {}, status: :ok
   rescue AccountDeletion::ValidateDeletionToken::InvalidTokenError

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -29,9 +29,9 @@ class Auth::SessionsController < Devise::SessionsController
   def respond_to_on_destroy(non_navigational_status: :no_content)
     # By the time this is called, Devise has already signed out the user
     # so current_user is nil. We just return success.
-    # Clear the jiki_user_id cookie explicitly since the ApplicationController's
+    # Clear the user id cookie explicitly since the ApplicationController's
     # after_action doesn't run when Devise's verify_signed_out_user halts the chain.
-    cookies.delete(:jiki_user_id, domain: :all)
+    cookies.delete(ApplicationController::USER_ID_COOKIE_NAME, domain: :all)
     render json: {}, status: non_navigational_status
   end
 

--- a/app/lib/custom_auth_failure.rb
+++ b/app/lib/custom_auth_failure.rb
@@ -3,6 +3,11 @@ class CustomAuthFailure < Devise::FailureApp
     self.status = 401
     self.content_type = "application/json"
     self.response_body = error_response.to_json
+
+    # The controller's after_action :set_user_id_cookie never runs on Warden
+    # failures because Warden bypasses the controller dispatch entirely. Clear
+    # the cookie here so stale clients (and CloudFlare) stay in sync.
+    response.delete_cookie(ApplicationController::USER_ID_COOKIE_NAME.to_s, domain: :all)
   end
 
   private

--- a/app/lib/custom_auth_failure.rb
+++ b/app/lib/custom_auth_failure.rb
@@ -1,16 +1,34 @@
 class CustomAuthFailure < Devise::FailureApp
   def respond
-    self.status = 401
-    self.content_type = "application/json"
-    self.response_body = error_response.to_json
-
     # The controller's after_action :set_user_id_cookie never runs on Warden
     # failures because Warden bypasses the controller dispatch entirely. Clear
     # the cookie here so stale clients (and CloudFlare) stay in sync.
-    response.delete_cookie(ApplicationController::USER_ID_COOKIE_NAME.to_s, domain: :all)
+    delete_user_id_cookie!
+
+    self.status = 401
+    self.content_type = "application/json"
+    self.response_body = error_response.to_json
   end
 
   private
+  # Mirrors what `ActionDispatch::Cookies` does for `domain: :all` so the
+  # browser actually accepts our deletion header. Rack's delete_cookie has no
+  # special handling for `:all` and would emit the literal string "all".
+  def delete_user_id_cookie!
+    options = { path: "/" }
+    cookie_domain = resolve_cookie_domain
+    options[:domain] = cookie_domain if cookie_domain
+    response.delete_cookie(ApplicationController::USER_ID_COOKIE_NAME.to_s, options)
+  end
+
+  def resolve_cookie_domain
+    host = request.host
+    parts = host.split(".", -1)
+    return nil if host.match?(/\A[\d.]+\z/) || parts.include?("") || parts.length == 1
+
+    parts.last(2).join(".")
+  end
+
   def error_response
     if warden_message == :unconfirmed
       { error: { type: "unconfirmed", message: I18n.t("api_errors.unconfirmed"), email: attempted_email } }

--- a/test/controllers/user_id_cookie_test.rb
+++ b/test/controllers/user_id_cookie_test.rb
@@ -50,7 +50,17 @@ class UserIdCookieTest < ApplicationControllerTest
   test "cookie is cleared when logging out without an active session" do
     # If the browser still has a stale jiki_user_id cookie but no Rails session,
     # hitting logout must still send a deletion cookie so the client clears it.
-    cookies[ApplicationController::USER_ID_COOKIE_NAME] = "stale-value"
+    # Get a real signed cookie with the right domain by logging in, then
+    # discard the session so we're in the "stale cookie, no session" state.
+    post user_session_path, params: {
+      user: { email: "test@example.com", password: "password123" }
+    }, as: :json
+    assert_response :ok
+    set_cookie = jiki_user_id_cookie
+    set_domain = set_cookie[/domain=([^;]+)/, 1]
+
+    reset!
+    cookies[ApplicationController::USER_ID_COOKIE_NAME] = set_cookie[/\Ajiki_user_id=([^;]*)/, 1]
     delete destroy_user_session_path, as: :json
 
     delete_cookie = jiki_user_id_cookie
@@ -61,11 +71,23 @@ class UserIdCookieTest < ApplicationControllerTest
       delete_cookie.match?(/expires=.*1970/i),
       "Expected cookie to be deleted, got: #{delete_cookie}"
     )
+    delete_domain = delete_cookie[/domain=([^;]+)/, 1]
+    assert_equal set_domain, delete_domain, "Deletion cookie domain should match set cookie domain (got #{delete_domain.inspect})"
   end
 
   test "cookie is cleared on 401 from authenticated endpoint" do
-    # If the browser has a stale jiki_user_id cookie, hitting an authenticated
-    # endpoint must send a deletion cookie so CloudFlare/frontend stay in sync.
+    # First, log in to get a real signed cookie with the right domain set.
+    post user_session_path, params: {
+      user: { email: "test@example.com", password: "password123" }
+    }, as: :json
+    assert_response :ok
+    set_cookie = jiki_user_id_cookie
+    set_domain = set_cookie[/domain=([^;]+)/, 1]
+
+    # Now hit an authenticated endpoint with no session (simulating expired
+    # session but stale cookie still in the browser).
+    reset!
+    cookies[ApplicationController::USER_ID_COOKIE_NAME] = set_cookie[/\Ajiki_user_id=([^;]*)/, 1]
     get internal_me_path, as: :json
     assert_response :unauthorized
 
@@ -77,6 +99,8 @@ class UserIdCookieTest < ApplicationControllerTest
       delete_cookie.match?(/expires=.*1970/i),
       "Expected cookie to be deleted, got: #{delete_cookie}"
     )
+    delete_domain = delete_cookie[/domain=([^;]+)/, 1]
+    assert_equal set_domain, delete_domain, "Deletion cookie domain should match set cookie domain (got #{delete_domain.inspect})"
   end
 
   test "cookie is set when user confirms email" do

--- a/test/controllers/user_id_cookie_test.rb
+++ b/test/controllers/user_id_cookie_test.rb
@@ -47,6 +47,38 @@ class UserIdCookieTest < ApplicationControllerTest
     )
   end
 
+  test "cookie is cleared when logging out without an active session" do
+    # If the browser still has a stale jiki_user_id cookie but no Rails session,
+    # hitting logout must still send a deletion cookie so the client clears it.
+    cookies[ApplicationController::USER_ID_COOKIE_NAME] = "stale-value"
+    delete destroy_user_session_path, as: :json
+
+    delete_cookie = jiki_user_id_cookie
+    assert delete_cookie.present?, "Expected deletion cookie in Set-Cookie header"
+    assert(
+      delete_cookie.include?("jiki_user_id=;") ||
+      delete_cookie.include?("max-age=0") ||
+      delete_cookie.match?(/expires=.*1970/i),
+      "Expected cookie to be deleted, got: #{delete_cookie}"
+    )
+  end
+
+  test "cookie is cleared on 401 from authenticated endpoint" do
+    # If the browser has a stale jiki_user_id cookie, hitting an authenticated
+    # endpoint must send a deletion cookie so CloudFlare/frontend stay in sync.
+    get internal_me_path, as: :json
+    assert_response :unauthorized
+
+    delete_cookie = jiki_user_id_cookie
+    assert delete_cookie.present?, "Expected deletion cookie in Set-Cookie header"
+    assert(
+      delete_cookie.include?("jiki_user_id=;") ||
+      delete_cookie.include?("max-age=0") ||
+      delete_cookie.match?(/expires=.*1970/i),
+      "Expected cookie to be deleted, got: #{delete_cookie}"
+    )
+  end
+
   test "cookie is set when user confirms email" do
     unconfirmed_user = create(:user, :unconfirmed, email: "unconfirmed@example.com")
     token = unconfirmed_user.confirmation_token


### PR DESCRIPTION
## Summary
- Warden's failure app bypasses controller dispatch, so `ApplicationController`'s `after_action :set_user_id_cookie` never runs on 401s. Stale `jiki_user_id` cookies were left on clients (and stale CloudFlare cache decisions) after sessions expired or when hitting an authenticated endpoint with no session.
- `CustomAuthFailure#respond` now deletes the cookie on every Warden failure via `Rack::Response#delete_cookie` (always emits, unlike `ActionDispatch::Cookies#delete` which is a no-op when the cookie isn't in the request).
- Extracts `USER_ID_COOKIE_NAME` as a shared constant on `ApplicationController` and uses it everywhere the cookie is referenced.

## Test plan
- [x] New test: `GET /internal/me` unauthenticated returns a deletion cookie.
- [x] New test: `DELETE /auth/logout` without an active session (but with a stale cookie) returns a deletion cookie.
- [x] Existing cookie tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)