### PR TITLE
Return nil last_submission when file blob is missing

### DIFF
--- a/app/serializers/serialize_user_lesson.rb
+++ b/app/serializers/serialize_user_lesson.rb
@@ -52,5 +52,7 @@ class SerializeUserLesson
         }
       end
     }
+  rescue ActiveStorage::FileNotFoundError
+    nil
   end
 end

--- a/app/serializers/serialize_user_lesson.rb
+++ b/app/serializers/serialize_user_lesson.rb
@@ -52,7 +52,8 @@ class SerializeUserLesson
         }
       end
     }
-  rescue ActiveStorage::FileNotFoundError
+  rescue ActiveStorage::FileNotFoundError => e
+    Sentry.capture_exception(e, extra: { exercise_submission_id: last_submission&.id })
     nil
   end
 end

--- a/test/serializers/serialize_user_lesson_test.rb
+++ b/test/serializers/serialize_user_lesson_test.rb
@@ -149,6 +149,8 @@ class SerializeUserLessonTest < ActiveSupport::TestCase
     file.content.attach(io: StringIO.new("puts 'Hello'"), filename: "solution.rb")
 
     ActiveStorage::Blob.any_instance.stubs(:download).raises(ActiveStorage::FileNotFoundError)
+    Sentry.expects(:capture_exception).with(instance_of(ActiveStorage::FileNotFoundError),
+      extra: { exercise_submission_id: submission.id })
 
     result = SerializeUserLesson.(user_lesson)
 

--- a/test/serializers/serialize_user_lesson_test.rb
+++ b/test/serializers/serialize_user_lesson_test.rb
@@ -141,6 +141,20 @@ class SerializeUserLessonTest < ActiveSupport::TestCase
     assert_equal "main code", result[:data][:last_submission][:files][1][:content]
   end
 
+  test "returns nil last_submission when a file blob is missing from storage" do
+    lesson = create(:lesson, :exercise, slug: "hello-world")
+    user_lesson = create(:user_lesson, lesson:)
+    submission = create(:exercise_submission, context: user_lesson)
+    file = create(:exercise_submission_file, exercise_submission: submission, filename: "solution.rb")
+    file.content.attach(io: StringIO.new("puts 'Hello'"), filename: "solution.rb")
+
+    ActiveStorage::Blob.any_instance.stubs(:download).raises(ActiveStorage::FileNotFoundError)
+
+    result = SerializeUserLesson.(user_lesson)
+
+    assert_nil result[:data][:last_submission]
+  end
+
   test "includes conversation messages when conversation exists" do
     lesson = create(:lesson, :video, slug: "hello-world")
     user_lesson = create(:user_lesson, lesson:)


### PR DESCRIPTION
## Summary
- Rescue `ActiveStorage::FileNotFoundError` in `SerializeUserLesson#exercise_data_last_submission` so a missing S3 object no longer crashes the user_lesson endpoint.
- When any file blob in the latest submission is unreachable, `last_submission` is returned as `nil`.

## Test plan
- [x] New serializer test stubs `ActiveStorage::Blob#download` to raise `FileNotFoundError` and asserts `last_submission` is `nil`.
- [x] Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)