### PR TITLE
Rename maze-walk exercise title to "Take a Walk"

### DIFF
--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -599,7 +599,7 @@
         },
         {
           "slug": "maze-walk",
-          "title": "Walk",
+          "title": "Take a Walk",
           "description": "Create a walk function that moves multiple steps at once.",
           "type": "exercise",
           "data": {"slug": "maze-walk"}


### PR DESCRIPTION
## Summary
- Update the `maze-walk` exercise title from "Walk" to "Take a Walk" in the curriculum seed.

## Test plan
- [ ] Re-seed curriculum and verify lesson title renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)