### PR TITLE
Rename maze-solve-walk exercise title to "Take a Walk"

### DIFF
--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -50,7 +50,7 @@
         },
         {
           "slug": "maze-solve-walk",
-          "title": "Maze Solve Walk",
+          "title": "Take a Walk",
           "description": "Navigate the maze using a function that walks multiple steps.",
           "type": "exercise",
           "data": {"slug": "maze-solve-walk"}


### PR DESCRIPTION
## Summary
- Update the `maze-solve-walk` exercise title from "Maze Solve Walk" to "Take a Walk" in the curriculum seed.

## Test plan
- [ ] Re-seed curriculum and verify lesson title renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)