### PR TITLE
Include walkthrough_video_watched_percentage in SerializeUserLevels

### DIFF
--- a/app/serializers/serialize_user_levels.rb
+++ b/app/serializers/serialize_user_levels.rb
@@ -15,7 +15,8 @@ class SerializeUserLevels
         user_lessons: rows.map do |row|
           {
             lesson_slug: row[:lesson_slug],
-            status: row[:completed_at].present? ? "completed" : "started"
+            status: row[:completed_at].present? ? "completed" : "started",
+            walkthrough_video_watched_percentage: row[:walkthrough_video_watched_percentage]
           }
         end
       }
@@ -41,15 +42,17 @@ class SerializeUserLevels
         "levels.slug",
         "lessons.slug",
         "user_lessons.completed_at",
+        "user_lessons.walkthrough_video_watched_percentage",
         "user_levels.completed_at"
       )
 
     # Map pluck results (arrays) to hashes for easier access
-    results.map do |level_slug, lesson_slug, lesson_completed_at, user_level_completed_at|
+    results.map do |level_slug, lesson_slug, lesson_completed_at, walkthrough_video_watched_percentage, user_level_completed_at|
       {
         level_slug: level_slug,
         lesson_slug: lesson_slug,
         completed_at: lesson_completed_at,
+        walkthrough_video_watched_percentage: walkthrough_video_watched_percentage,
         user_level_completed_at: user_level_completed_at
       }
     end

--- a/test/serializers/serialize_user_levels_test.rb
+++ b/test/serializers/serialize_user_levels_test.rb
@@ -13,8 +13,8 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
     create(:user_level, user: user, level: level1, completed_at: Time.current)
     create(:user_level, user: user, level: level2)
 
-    create(:user_lesson, user: user, lesson: lesson1, completed_at: Time.current)
-    create(:user_lesson, user: user, lesson: lesson2, completed_at: nil)
+    create(:user_lesson, user: user, lesson: lesson1, completed_at: Time.current, walkthrough_video_watched_percentage: 100)
+    create(:user_lesson, user: user, lesson: lesson2, completed_at: nil, walkthrough_video_watched_percentage: 42)
     create(:user_lesson, user: user, lesson: lesson3, completed_at: Time.current)
 
     expected = [
@@ -22,15 +22,15 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
         level_slug: "basics",
         status: "completed",
         user_lessons: [
-          { lesson_slug: "lesson-1", status: "completed" },
-          { lesson_slug: "lesson-2", status: "started" }
+          { lesson_slug: "lesson-1", status: "completed", walkthrough_video_watched_percentage: 100 },
+          { lesson_slug: "lesson-2", status: "started", walkthrough_video_watched_percentage: 42 }
         ]
       },
       {
         level_slug: "advanced",
         status: "started",
         user_lessons: [
-          { lesson_slug: "lesson-3", status: "completed" }
+          { lesson_slug: "lesson-3", status: "completed", walkthrough_video_watched_percentage: nil }
         ]
       }
     ]
@@ -72,9 +72,12 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
     create(:user_lesson, user: user, lesson: lesson3)
 
     expected = [
-      { level_slug: "level-a", status: "started", user_lessons: [{ lesson_slug: "lesson-a", status: "started" }] },
-      { level_slug: "level-b", status: "started", user_lessons: [{ lesson_slug: "lesson-b", status: "started" }] },
-      { level_slug: "level-c", status: "started", user_lessons: [{ lesson_slug: "lesson-c", status: "started" }] }
+      { level_slug: "level-a", status: "started",
+        user_lessons: [{ lesson_slug: "lesson-a", status: "started", walkthrough_video_watched_percentage: nil }] },
+      { level_slug: "level-b", status: "started",
+        user_lessons: [{ lesson_slug: "lesson-b", status: "started", walkthrough_video_watched_percentage: nil }] },
+      { level_slug: "level-c", status: "started",
+        user_lessons: [{ lesson_slug: "lesson-c", status: "started", walkthrough_video_watched_percentage: nil }] }
     ]
 
     assert_equal(expected, SerializeUserLevels.(user.user_levels))
@@ -98,9 +101,9 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
         level_slug: "basics",
         status: "started",
         user_lessons: [
-          { lesson_slug: "lesson-a", status: "started" },
-          { lesson_slug: "lesson-b", status: "started" },
-          { lesson_slug: "lesson-c", status: "started" }
+          { lesson_slug: "lesson-a", status: "started", walkthrough_video_watched_percentage: nil },
+          { lesson_slug: "lesson-b", status: "started", walkthrough_video_watched_percentage: nil },
+          { lesson_slug: "lesson-c", status: "started", walkthrough_video_watched_percentage: nil }
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- Adds `walkthrough_video_watched_percentage` to each `user_lessons[]` entry returned by `GET /internal/user_levels?course_slug=…` so the front end can show walkthrough progress alongside lesson status.
- Pulls the column in the existing single-query pluck to avoid N+1.

## Test plan
- [x] `bin/rails test test/serializers/serialize_user_levels_test.rb`
- [x] `bin/rails test test/controllers/internal/user_levels_controller_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)