### PR TITLE
Wire up concept unlocks and align lesson slugs with videos repo

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,82 +46,79 @@ puts "  ✓ Bootstrapped test user"
 # Load concepts
 puts "\nLoading concepts..."
 concepts_file = File.join(Rails.root, "db", "seeds", "concepts.json")
-if File.exist?(concepts_file)
-  concepts_data = JSON.parse(File.read(concepts_file), symbolize_names: true)
+raise "Missing concepts seed file at #{concepts_file}" unless File.exist?(concepts_file)
 
-  # First pass: Create all concepts without parents
-  concepts_data.each do |concept_data|
-    concept = Concept.find_or_initialize_by(slug: concept_data[:slug])
-    concept.title = concept_data[:title]
-    concept.description = concept_data[:description]
-    concept.content_markdown = concept_data[:content_markdown]
+concepts_data = JSON.parse(File.read(concepts_file), symbolize_names: true)
 
-    # Link to lesson if specified
-    if concept_data[:unlocked_by_lesson_slug]
-      lesson = Lesson.find_by(slug: concept_data[:unlocked_by_lesson_slug])
-      concept.unlocked_by_lesson = lesson if lesson
-    end
+# First pass: Create all concepts without parents
+concepts_data.each do |concept_data|
+  concept = Concept.find_or_initialize_by(slug: concept_data[:slug])
+  concept.title = concept_data[:title]
+  concept.description = concept_data[:description]
+  concept.content_markdown = concept_data[:content_markdown]
 
-    concept.save!
-    puts "  ✓ Loaded concept: #{concept.title}"
+  # Link to lesson if specified
+  if concept_data[:unlocked_by_lesson_slug]
+    lesson = Lesson.find_by(slug: concept_data[:unlocked_by_lesson_slug])
+    raise "Concept '#{concept_data[:slug]}' references missing lesson '#{concept_data[:unlocked_by_lesson_slug]}'" unless lesson
+
+    concept.unlocked_by_lesson = lesson
   end
 
-  # Second pass: Link parents (iterative until all resolved)
-  unresolved = concepts_data.select { |c| c[:parent_slug].present? }
-  while unresolved.any?
-    resolved_count = 0
-    unresolved.each do |concept_data|
-      parent = Concept.find_by(slug: concept_data[:parent_slug])
-      next unless parent
-
-      concept = Concept.find_by!(slug: concept_data[:slug])
-      next if concept.parent_concept_id.present?
-
-      concept.update!(parent: parent)
-      resolved_count += 1
-      puts "  ✓ Linked #{concept.title} → #{parent.title}"
-    end
-
-    unresolved.reject! { |c| Concept.find_by(slug: c[:slug])&.parent_concept_id.present? }
-    break if resolved_count.zero? && unresolved.any?
-  end
-
-  # Warn about any unresolved
-  unresolved.each do |c|
-    puts "  ⚠ Could not resolve parent '#{c[:parent_slug]}' for concept '#{c[:slug]}'"
-  end
-
-  puts "✓ Successfully loaded #{concepts_data.size} concept(s)!"
-else
-  puts "⚠ No concepts.json found at #{concepts_file}"
+  concept.save!
+  puts "  ✓ Loaded concept: #{concept.title}"
 end
+
+# Second pass: Link parents (iterative until all resolved)
+unresolved = concepts_data.select { |c| c[:parent_slug].present? }
+while unresolved.any?
+  resolved_count = 0
+  unresolved.each do |concept_data|
+    parent = Concept.find_by(slug: concept_data[:parent_slug])
+    next unless parent
+
+    concept = Concept.find_by!(slug: concept_data[:slug])
+    next if concept.parent_concept_id.present?
+
+    concept.update!(parent: parent)
+    resolved_count += 1
+    puts "  ✓ Linked #{concept.title} → #{parent.title}"
+  end
+
+  unresolved.reject! { |c| Concept.find_by(slug: c[:slug])&.parent_concept_id.present? }
+  break if resolved_count.zero? && unresolved.any?
+end
+
+raise "Could not resolve parents for concepts: #{unresolved.map { |c| "#{c[:slug]} → #{c[:parent_slug]}" }.join(', ')}" if unresolved.any?
+
+puts "✓ Successfully loaded #{concepts_data.size} concept(s)!"
 
 # Load projects
 puts "\nLoading projects..."
 projects_file = File.join(Rails.root, "db", "seeds", "projects.json")
-if File.exist?(projects_file)
-  projects_data = JSON.parse(File.read(projects_file), symbolize_names: true)
+raise "Missing projects seed file at #{projects_file}" unless File.exist?(projects_file)
 
-  projects_data.each do |project_data|
-    project = Project.find_or_initialize_by(slug: project_data[:slug])
-    project.title = project_data[:title]
-    project.description = project_data[:description]
-    project.exercise_slug = project_data[:exercise_slug]
+projects_data = JSON.parse(File.read(projects_file), symbolize_names: true)
 
-    # Link to lesson if specified
-    if project_data[:unlocked_by_lesson_slug]
-      lesson = Lesson.find_by(slug: project_data[:unlocked_by_lesson_slug])
-      project.unlocked_by_lesson = lesson if lesson
-    end
+projects_data.each do |project_data|
+  project = Project.find_or_initialize_by(slug: project_data[:slug])
+  project.title = project_data[:title]
+  project.description = project_data[:description]
+  project.exercise_slug = project_data[:exercise_slug]
 
-    project.save!
-    puts "  ✓ Loaded project: #{project.title}"
+  # Link to lesson if specified
+  if project_data[:unlocked_by_lesson_slug]
+    lesson = Lesson.find_by(slug: project_data[:unlocked_by_lesson_slug])
+    raise "Project '#{project_data[:slug]}' references missing lesson '#{project_data[:unlocked_by_lesson_slug]}'" unless lesson
+
+    project.unlocked_by_lesson = lesson
   end
 
-  puts "✓ Successfully loaded #{projects_data.size} project(s)!"
-else
-  puts "⚠ No projects.json found at #{projects_file}"
+  project.save!
+  puts "  ✓ Loaded project: #{project.title}"
 end
+
+puts "✓ Successfully loaded #{projects_data.size} project(s)!"
 
 # Create some user progress data for testing
 puts "\nCreating sample user progress..."
@@ -129,35 +126,34 @@ puts "\nCreating sample user progress..."
 # Get first few levels and lessons
 first_level = course.levels.first
 second_level = course.levels.second
+raise "Cannot create sample progress: course has fewer than 2 levels" unless first_level && second_level
 
-if first_level && second_level
-  # Create user_course enrollment
-  user_course = UserCourse.find_or_create_by!(user: user, course: course)
+# Create user_course enrollment
+user_course = UserCourse.find_or_create_by!(user: user, course: course)
 
-  # Create user_level records
-  user_level_1 = UserLevel.find_or_create_by!(user: user, level: first_level)
-  user_level_2 = UserLevel.find_or_create_by!(user: user, level: second_level)
+# Create user_level records
+user_level_1 = UserLevel.find_or_create_by!(user: user, level: first_level)
+user_level_2 = UserLevel.find_or_create_by!(user: user, level: second_level)
 
-  # Update user_course to point to current level
-  user_course.update!(current_user_level: user_level_2)
+# Update user_course to point to current level
+user_course.update!(current_user_level: user_level_2)
 
-  # Create user_lesson records for first level (mix of completed and started)
-  first_level.lessons.limit(3).each_with_index do |lesson, index|
-    UserLesson.find_or_create_by!(user: user, lesson: lesson) do |ul|
-      ul.completed_at = index < 2 ? Time.current : nil
-    end
+# Create user_lesson records for first level (mix of completed and started)
+first_level.lessons.limit(3).each_with_index do |lesson, index|
+  UserLesson.find_or_create_by!(user: user, lesson: lesson) do |ul|
+    ul.completed_at = index < 2 ? Time.current : nil
   end
-
-  # Create user_lesson records for second level (only started)
-  second_level.lessons.limit(2).each do |lesson|
-    UserLesson.find_or_create_by!(user: user, lesson: lesson)
-  end
-
-  puts "✓ Created sample progress for user #{user.email}"
-  puts "  - Enrolled in course: #{course.title}"
-  puts "  - #{user.user_levels.count} user_levels"
-  puts "  - #{user.user_lessons.count} user_lessons (#{user.user_lessons.where.not(completed_at: nil).count} completed)"
 end
+
+# Create user_lesson records for second level (only started)
+second_level.lessons.limit(2).each do |lesson|
+  UserLesson.find_or_create_by!(user: user, lesson: lesson)
+end
+
+puts "✓ Created sample progress for user #{user.email}"
+puts "  - Enrolled in course: #{course.title}"
+puts "  - #{user.user_levels.count} user_levels"
+puts "  - #{user.user_lessons.count} user_lessons (#{user.user_lessons.where.not(completed_at: nil).count} completed)"
 
 # Create badges
 puts "\nCreating badges..."
@@ -184,86 +180,75 @@ puts "✓ Successfully created #{badge_classes.count} badges!"
 # Create user badge acquisitions to demonstrate all possible states
 puts "\nCreating user badge acquisitions (all states)..."
 
-# Get admin user (the one you're probably logged in as)
-admin_user = User.find_by(email: "ihid@jiki.io")
-
 member_badge = Badges::MemberBadge.first
-maze_badge = Badges::MazeNavigatorBadge.first  
+maze_badge = Badges::MazeNavigatorBadge.first
 first_lesson_badge = Badges::FirstLessonBadge.first
 early_bird_badge = Badges::EarlyBirdBadge.first
 
-if admin_user
-  # State 1: LOCKED badges (no User::AcquiredBadge record exists)
-  puts "  ✓ Maze Navigator badge: LOCKED (hasn't completed maze lesson)"
-  
-  # State 2: NEW/UNREVEALED badges (earned but not seen - revealed: false)
-  User::AcquiredBadge.find_or_create_by!(user: admin_user, badge: member_badge) do |ab|
-    ab.revealed = false
-    ab.created_at = 1.day.ago
-  end
-  puts "  ✓ Member badge: NEW/UNREVEALED (earned but not seen)"
-  
-  User::AcquiredBadge.find_or_create_by!(user: admin_user, badge: first_lesson_badge) do |ab|
-    ab.revealed = false
-    ab.created_at = 1.hour.ago
-  end
-  puts "  ✓ First Steps badge: NEW/UNREVEALED (just earned)"
-  
-  # State 3: SEEN/REVEALED badges (earned and seen - revealed: true)
-  User::AcquiredBadge.find_or_create_by!(user: admin_user, badge: early_bird_badge) do |ab|
-    ab.revealed = true
-    ab.created_at = 3.days.ago
-  end
-  puts "  ✓ Early Bird badge: SEEN/REVEALED (secret early access badge)"
-  
-  puts "✓ Successfully created badge acquisitions demonstrating all states!"
-  puts "\n  Badge States Summary for user #{admin_user.email}:"
-  puts "    LOCKED (not earned):"
-  puts "       - Maze Navigator (needs to complete maze lesson)"
-  puts "    NEW/UNREVEALED (earned, not seen):"
-  puts "       - Member (just joined)"
-  puts "       - First Steps (just completed first lesson)"
-  puts "    SEEN/REVEALED (earned and seen):"
-  puts "       - Early Bird (secret early access badge, revealed)"
-else
-  puts "⚠ Could not create badge acquisitions - missing admin user"
+# State 1: LOCKED badges (no User::AcquiredBadge record exists)
+puts "  ✓ Maze Navigator badge: LOCKED (hasn't completed maze lesson)"
+
+# State 2: NEW/UNREVEALED badges (earned but not seen - revealed: false)
+User::AcquiredBadge.find_or_create_by!(user: admin_user, badge: member_badge) do |ab|
+  ab.revealed = false
+  ab.created_at = 1.day.ago
 end
+puts "  ✓ Member badge: NEW/UNREVEALED (earned but not seen)"
+
+User::AcquiredBadge.find_or_create_by!(user: admin_user, badge: first_lesson_badge) do |ab|
+  ab.revealed = false
+  ab.created_at = 1.hour.ago
+end
+puts "  ✓ First Steps badge: NEW/UNREVEALED (just earned)"
+
+# State 3: SEEN/REVEALED badges (earned and seen - revealed: true)
+User::AcquiredBadge.find_or_create_by!(user: admin_user, badge: early_bird_badge) do |ab|
+  ab.revealed = true
+  ab.created_at = 3.days.ago
+end
+puts "  ✓ Early Bird badge: SEEN/REVEALED (secret early access badge)"
+
+puts "✓ Successfully created badge acquisitions demonstrating all states!"
+puts "\n  Badge States Summary for user #{admin_user.email}:"
+puts "    LOCKED (not earned):"
+puts "       - Maze Navigator (needs to complete maze lesson)"
+puts "    NEW/UNREVEALED (earned, not seen):"
+puts "       - Member (just joined)"
+puts "       - First Steps (just completed first lesson)"
+puts "    SEEN/REVEALED (earned and seen):"
+puts "       - Early Bird (secret early access badge, revealed)"
 
 # Create sample payments for admin user
 puts "\nCreating sample payments..."
 
-if admin_user
-  # Create 4 payments for admin user spanning several months
-  [
-    { months_ago: 4, product: "premium", amount: 1999 },
-    { months_ago: 3, product: "premium", amount: 1999 },
-    { months_ago: 2, product: "premium", amount: 1999 },
-    { months_ago: 1, product: "premium", amount: 1999 }
-  ].each_with_index do |payment_data, index|
-    payment_date = payment_data[:months_ago].months.ago
-    Payment.find_or_create_by!(payment_processor_id: "in_seed_#{index + 1}") do |p|
-      p.user = admin_user
-      p.amount_in_cents = payment_data[:amount]
-      p.currency = "usd"
-      p.product = payment_data[:product]
-      p.external_receipt_url = "https://invoice.stripe.com/i/seed_receipt_#{index + 1}"
-      p.data = {
-        stripe_invoice_id: "in_seed_#{index + 1}",
-        stripe_charge_id: "ch_seed_#{index + 1}",
-        stripe_subscription_id: "sub_seed_admin",
-        stripe_customer_id: "cus_seed_admin",
-        billing_reason: index.zero? ? "subscription_create" : "subscription_cycle",
-        period_start: payment_date.iso8601,
-        period_end: (payment_date + 1.month).iso8601
-      }
-      p.created_at = payment_date
-    end
+# Create 4 payments for admin user spanning several months
+[
+  { months_ago: 4, product: "premium", amount: 1999 },
+  { months_ago: 3, product: "premium", amount: 1999 },
+  { months_ago: 2, product: "premium", amount: 1999 },
+  { months_ago: 1, product: "premium", amount: 1999 }
+].each_with_index do |payment_data, index|
+  payment_date = payment_data[:months_ago].months.ago
+  Payment.find_or_create_by!(payment_processor_id: "in_seed_#{index + 1}") do |p|
+    p.user = admin_user
+    p.amount_in_cents = payment_data[:amount]
+    p.currency = "usd"
+    p.product = payment_data[:product]
+    p.external_receipt_url = "https://invoice.stripe.com/i/seed_receipt_#{index + 1}"
+    p.data = {
+      stripe_invoice_id: "in_seed_#{index + 1}",
+      stripe_charge_id: "ch_seed_#{index + 1}",
+      stripe_subscription_id: "sub_seed_admin",
+      stripe_customer_id: "cus_seed_admin",
+      billing_reason: index.zero? ? "subscription_create" : "subscription_cycle",
+      period_start: payment_date.iso8601,
+      period_end: (payment_date + 1.month).iso8601
+    }
+    p.created_at = payment_date
   end
-
-  puts "  ✓ Created 4 payments for admin user (#{admin_user.email})"
-  puts "    - 4 premium payments ($19.99 each)"
-else
-  puts "⚠ Could not create payments - missing admin user"
 end
+
+puts "  ✓ Created 4 payments for admin user (#{admin_user.email})"
+puts "    - 4 premium payments ($19.99 each)"
 
 # Note: test user has no payments (deliberately left without payments for testing)

--- a/db/seeds/concepts.json
+++ b/db/seeds/concepts.json
@@ -1,247 +1,354 @@
 [
   {
-    "slug": "loops",
-    "title": "Loops",
-    "description": "Direct how your program runs and makes decisions. Use loops to repeat code and conditionals to choose paths.",
-    "content_markdown": "# Loops\n\nLoops are fundamental programming constructs that allow you to repeat a block of code multiple times. They're essential for processing collections of data, automating repetitive tasks, and implementing algorithms.\n\n## Why Use Loops?\n\n1. **Efficiency**: Execute code multiple times without writing it repeatedly\n2. **Automation**: Process large amounts of data automatically\n3. **Flexibility**: Control how many times code runs based on conditions",
-    "parent_slug": null
+    "slug": "using-functions",
+    "title": "Using Functions",
+    "description": "Call built-in functions to make things happen.",
+    "content_markdown": "# Using Functions\n\nFunctions are little machines you call to make things happen. You'll learn how to invoke them in your code.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "using-functions"
   },
   {
-    "slug": "for-loops",
-    "title": "For Loops",
-    "description": "Iterate through sequences with for loops. Learn basic iteration patterns and loop control.",
-    "content_markdown": "# For Loops\n\nFor loops are used when you know in advance how many times you want to execute a block of code. They're perfect for iterating over arrays, ranges of numbers, or any countable sequence.\n\n## Basic Syntax\n\n```javascript\nfor (let i = 0; i < 5; i++) {\n  console.log(i);\n}\n```\n\n## Common Use Cases\n\n- Iterating through array elements\n- Counting from one number to another\n- Repeating an action a specific number of times",
-    "parent_slug": "loops"
+    "slug": "using-functions-with-inputs",
+    "title": "Using Functions With Inputs",
+    "description": "Pass inputs (arguments) to functions to control their behaviour.",
+    "content_markdown": "# Using Functions With Inputs\n\nMany functions take inputs that change what they do. You'll learn how to pass values into a function when you call it.",
+    "parent_slug": "using-functions",
+    "unlocked_by_lesson_slug": "function-inputs"
   },
   {
-    "slug": "while-loops",
-    "title": "While Loops",
-    "description": "Execute code while conditions are true. Master conditional iteration and loop termination.",
-    "content_markdown": "# While Loops\n\nWhile loops continue executing as long as a specified condition remains true. They're ideal when you don't know in advance how many iterations you'll need.\n\n## Basic Syntax\n\n```javascript\nlet count = 0;\nwhile (count < 5) {\n  console.log(count);\n  count++;\n}\n```\n\n## When to Use While Loops\n\n- Reading data until end of file\n- Waiting for user input\n- Processing until a condition is met",
-    "parent_slug": "loops"
+    "slug": "using-functions-with-return-values",
+    "title": "Using Functions With Return Values",
+    "description": "Use the values that functions give back to you.",
+    "content_markdown": "# Using Functions With Return Values\n\nSome functions hand a value back when they're done. You'll learn how to capture and use that value.",
+    "parent_slug": "using-functions",
+    "unlocked_by_lesson_slug": "functions-that-return-things"
   },
   {
-    "slug": "nested-loops",
-    "title": "Nested Loops",
-    "description": "Work with loops inside loops. Understand complexity and multi-dimensional iteration.",
-    "content_markdown": "# Nested Loops\n\nNested loops are loops inside other loops. They're essential for working with multi-dimensional data structures like matrices or grids.\n\n## Example\n\n```javascript\nfor (let i = 0; i < 3; i++) {\n  for (let j = 0; j < 3; j++) {\n    console.log(`Position: ${i}, ${j}`);\n  }\n}\n```\n\n## Common Applications\n\n- Processing 2D arrays/matrices\n- Generating combinations\n- Pattern printing",
-    "parent_slug": "loops"
+    "slug": "creating-functions",
+    "title": "Creating Functions",
+    "description": "Write your own reusable functions.",
+    "content_markdown": "# Creating Functions\n\nWhen built-in functions aren't enough, you can write your own. You'll learn how to define a function from scratch.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "making-functions"
   },
   {
-    "slug": "loop-control",
-    "title": "Loop Control",
-    "description": "Control loop execution with break and continue. Learn advanced loop manipulation techniques.",
-    "content_markdown": "# Loop Control\n\nLoop control statements let you alter the normal flow of loop execution. The two main control statements are `break` and `continue`.\n\n## Break Statement\n\nExits the loop immediately:\n\n```javascript\nfor (let i = 0; i < 10; i++) {\n  if (i === 5) break;\n  console.log(i);\n}\n```\n\n## Continue Statement\n\nSkips to the next iteration:\n\n```javascript\nfor (let i = 0; i < 5; i++) {\n  if (i === 2) continue;\n  console.log(i);\n}\n```",
-    "parent_slug": "loops"
+    "slug": "creating-functions-with-inputs",
+    "title": "Creating Functions With Inputs",
+    "description": "Define functions that accept inputs (parameters).",
+    "content_markdown": "# Creating Functions With Inputs\n\nYou'll learn how to declare parameters on your own functions so callers can pass values in.",
+    "parent_slug": "creating-functions",
+    "unlocked_by_lesson_slug": "making-functions-with-inputs"
   },
   {
-    "slug": "infinite-loops",
-    "title": "Infinite Loops",
-    "description": "Understand and avoid infinite loops. Learn debugging techniques and safe iteration patterns.",
-    "content_markdown": "# Infinite Loops\n\nAn infinite loop runs forever because its termination condition is never met. While usually unintentional bugs, they can be useful in certain situations like game loops or server processes.\n\n## Common Causes\n\n- Forgetting to update the loop variable\n- Condition that can never become false\n- Logic errors in loop conditions\n\n## Intentional Infinite Loops\n\n```javascript\nwhile (true) {\n  // Server listening for requests\n  if (shouldExit) break;\n}\n```",
-    "parent_slug": "loops"
-  },
-  {
-    "slug": "loop-optimization",
-    "title": "Loop Optimization",
-    "description": "Optimize loop performance and efficiency. Master advanced iteration techniques.",
-    "content_markdown": "# Loop Optimization\n\nOptimizing loops is crucial for performance, especially when processing large datasets. Small improvements in loops can lead to significant performance gains.\n\n## Optimization Techniques\n\n1. **Cache array length**: Store length in a variable\n2. **Minimize work inside loops**: Move invariant calculations outside\n3. **Use appropriate loop type**: Choose the right loop for the task\n4. **Consider early termination**: Use break when possible",
-    "parent_slug": "loops"
-  },
-  {
-    "slug": "variables",
-    "title": "Variables",
-    "description": "Store and manipulate data in your programs. Learn about different data types and how to use them effectively.",
-    "content_markdown": "# Variables\n\nVariables are like labeled boxes where you can store information to use later in your program.\n\n## What are Variables?\n\nThink of a variable as a container with a name. You can put a value inside it, and then refer to that value by the container's name whenever you need it.\n\n```javascript\nlet age = 25;\nlet name = \"Alex\";\n```\n\n## Why Use Variables?\n\n1. **Reusability**: Store a value once and use it many times\n2. **Clarity**: Give meaningful names to values\n3. **Flexibility**: Change the value in one place, update everywhere",
-    "parent_slug": null
-  },
-  {
-    "slug": "functions",
-    "title": "Functions",
-    "description": "Organize your code into reusable blocks. Master parameters, return values, and function composition.",
-    "content_markdown": "# Functions\n\nFunctions are reusable blocks of code that perform specific tasks. They help organize code, reduce repetition, and make programs easier to understand and maintain.\n\n## Why Use Functions?\n\n1. **Reusability**: Write once, use many times\n2. **Organization**: Break complex problems into smaller pieces\n3. **Abstraction**: Hide implementation details\n4. **Testing**: Easier to test isolated pieces of code",
-    "parent_slug": null
-  },
-  {
-    "slug": "function-basics",
-    "title": "Function Basics",
-    "description": "Create and call functions. Learn parameters, return values, and function scope.",
-    "content_markdown": "# Function Basics\n\nA function is a named block of code that performs a specific task. You define it once and can call it whenever you need that task performed.\n\n## Defining a Function\n\n```javascript\nfunction greet(name) {\n  return `Hello, ${name}!`;\n}\n```\n\n## Calling a Function\n\n```javascript\nconst message = greet(\"Alice\");\nconsole.log(message); // Hello, Alice!\n```",
-    "parent_slug": "functions"
-  },
-  {
-    "slug": "parameters-arguments",
-    "title": "Parameters & Arguments",
-    "description": "Pass data to functions effectively. Master parameter types and argument handling.",
-    "content_markdown": "# Parameters & Arguments\n\nParameters are variables listed in a function's definition. Arguments are the actual values passed to the function when it's called.\n\n## Parameters vs Arguments\n\n```javascript\n// name is a parameter\nfunction greet(name) {\n  return `Hello, ${name}!`;\n}\n\n// \"Alice\" is an argument\ngreet(\"Alice\");\n```\n\n## Default Parameters\n\n```javascript\nfunction greet(name = \"World\") {\n  return `Hello, ${name}!`;\n}\n```",
-    "parent_slug": "functions"
-  },
-  {
-    "slug": "return-values",
-    "title": "Return Values",
-    "description": "Return data from functions. Understand different return patterns and value types.",
-    "content_markdown": "# Return Values\n\nFunctions can send data back to the code that called them using the `return` statement. This allows functions to produce results that can be used elsewhere.\n\n## Basic Return\n\n```javascript\nfunction add(a, b) {\n  return a + b;\n}\n\nconst sum = add(3, 5); // sum is 8\n```\n\n## Multiple Return Points\n\n```javascript\nfunction getGrade(score) {\n  if (score >= 90) return \"A\";\n  if (score >= 80) return \"B\";\n  return \"C\";\n}\n```",
-    "parent_slug": "functions"
-  },
-  {
-    "slug": "function-scope",
-    "title": "Function Scope",
-    "description": "Understand variable scope in functions. Learn about local vs global variables.",
-    "content_markdown": "# Function Scope\n\nScope determines where variables are accessible in your code. Variables declared inside a function are local to that function and cannot be accessed outside.\n\n## Local vs Global Scope\n\n```javascript\nlet globalVar = \"I'm global\";\n\nfunction example() {\n  let localVar = \"I'm local\";\n  console.log(globalVar); // Works\n  console.log(localVar);  // Works\n}\n\nconsole.log(globalVar); // Works\nconsole.log(localVar);  // Error!\n```",
-    "parent_slug": "functions"
-  },
-  {
-    "slug": "higher-order-functions",
-    "title": "Higher-Order Functions",
-    "description": "Functions that work with other functions. Master callbacks and functional programming.",
-    "content_markdown": "# Higher-Order Functions\n\nHigher-order functions are functions that take other functions as arguments or return functions. They're a powerful tool for writing flexible, reusable code.\n\n## Functions as Arguments\n\n```javascript\nfunction doTwice(fn, value) {\n  return fn(fn(value));\n}\n\nfunction double(x) {\n  return x * 2;\n}\n\ndoTwice(double, 5); // 20\n```\n\n## Common Examples\n\n- `map()`, `filter()`, `reduce()`\n- Event handlers\n- Callbacks",
-    "parent_slug": "functions"
-  },
-  {
-    "slug": "recursion",
-    "title": "Recursion",
-    "description": "Functions that call themselves. Learn recursive patterns and problem solving.",
-    "content_markdown": "# Recursion\n\nRecursion is when a function calls itself to solve a problem. It's useful for problems that can be broken down into smaller, similar sub-problems.\n\n## Basic Example\n\n```javascript\nfunction factorial(n) {\n  if (n <= 1) return 1; // Base case\n  return n * factorial(n - 1); // Recursive case\n}\n\nfactorial(5); // 120\n```\n\n## Key Components\n\n1. **Base case**: Condition that stops recursion\n2. **Recursive case**: The function calling itself with modified input",
-    "parent_slug": "functions"
-  },
-  {
-    "slug": "arrow-functions",
-    "title": "Arrow Functions",
-    "description": "Modern function syntax and behavior. Understand lexical scoping and concise syntax.",
-    "content_markdown": "# Arrow Functions\n\nArrow functions provide a concise syntax for writing functions. They also have different behavior regarding the `this` keyword.\n\n## Syntax Comparison\n\n```javascript\n// Traditional function\nfunction add(a, b) {\n  return a + b;\n}\n\n// Arrow function\nconst add = (a, b) => a + b;\n```\n\n## Concise Body\n\n```javascript\n// Single expression - implicit return\nconst double = x => x * 2;\n\n// Multiple statements - need explicit return\nconst process = x => {\n  const result = x * 2;\n  return result + 1;\n};\n```",
-    "parent_slug": "functions"
+    "slug": "creating-functions-with-return-values",
+    "title": "Creating Functions With Return Values",
+    "description": "Make your own functions hand a value back to the caller.",
+    "content_markdown": "# Creating Functions With Return Values\n\nYou'll learn how to use `return` so your own functions give a result back.",
+    "parent_slug": "creating-functions",
+    "unlocked_by_lesson_slug": "making-functions-with-return-values"
   },
   {
     "slug": "function-composition",
     "title": "Function Composition",
-    "description": "Combine functions to create complex operations. Learn modular programming techniques.",
-    "content_markdown": "# Function Composition\n\nFunction composition is combining simple functions to build more complex ones. The output of one function becomes the input of the next.\n\n## Basic Composition\n\n```javascript\nconst add5 = x => x + 5;\nconst multiply2 = x => x * 2;\n\n// Manual composition\nconst result = multiply2(add5(10)); // 30\n\n// Compose function\nconst compose = (f, g) => x => f(g(x));\nconst add5ThenDouble = compose(multiply2, add5);\nadd5ThenDouble(10); // 30\n```",
-    "parent_slug": "functions"
+    "description": "Combine multiple functions together to solve bigger problems.",
+    "content_markdown": "# Function Composition\n\nYou'll learn how to use the output of one function as the input of another, building bigger solutions from smaller pieces.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "using-multiple-functions-together"
   },
   {
-    "slug": "arrays",
-    "title": "Arrays",
-    "description": "Organize and store collections of data efficiently. Learn to manipulate lists and iterate through elements.",
-    "content_markdown": "# Arrays\n\nArrays are ordered collections of values. They're one of the most commonly used data structures for storing and organizing multiple pieces of data.\n\n## Creating Arrays\n\n```javascript\nconst numbers = [1, 2, 3, 4, 5];\nconst mixed = [\"hello\", 42, true];\nconst empty = [];\n```\n\n## Why Use Arrays?\n\n1. **Store multiple values**: Keep related data together\n2. **Ordered**: Elements maintain their position\n3. **Flexible**: Add, remove, and modify elements",
-    "parent_slug": null
+    "slug": "variables",
+    "title": "Variables",
+    "description": "Store and reuse values by giving them names.",
+    "content_markdown": "# Variables\n\nVariables let you save a value and refer to it by name later.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "creating-variables"
   },
   {
-    "slug": "array-basics",
-    "title": "Array Basics",
-    "description": "Create and manipulate arrays. Learn indexing, length, and basic array operations.",
-    "content_markdown": "# Array Basics\n\nArrays store multiple values in a single variable. Each value has an index (position) starting from 0.\n\n## Accessing Elements\n\n```javascript\nconst fruits = [\"apple\", \"banana\", \"cherry\"];\nconsole.log(fruits[0]); // apple\nconsole.log(fruits[2]); // cherry\nconsole.log(fruits.length); // 3\n```\n\n## Modifying Arrays\n\n```javascript\nfruits[1] = \"blueberry\"; // Replace element\nfruits.push(\"date\"); // Add to end\nfruits.pop(); // Remove from end\n```",
-    "parent_slug": "arrays"
+    "slug": "arithmetic",
+    "title": "Arithmetic",
+    "description": "Do maths with numbers and variables.",
+    "content_markdown": "# Arithmetic\n\nUse `+`, `-`, `*`, `/` and friends to do calculations.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "variables-together"
   },
   {
-    "slug": "array-methods",
-    "title": "Array Methods",
-    "description": "Use built-in array methods. Master map, filter, reduce, and other powerful operations.",
-    "content_markdown": "# Array Methods\n\nJavaScript arrays come with powerful built-in methods for transforming and processing data.\n\n## Map\n\nTransform each element:\n\n```javascript\nconst numbers = [1, 2, 3];\nconst doubled = numbers.map(n => n * 2); // [2, 4, 6]\n```\n\n## Filter\n\nSelect elements that match a condition:\n\n```javascript\nconst evens = numbers.filter(n => n % 2 === 0); // [2]\n```\n\n## Reduce\n\nCombine all elements into a single value:\n\n```javascript\nconst sum = numbers.reduce((acc, n) => acc + n, 0); // 6\n```",
-    "parent_slug": "arrays"
-  },
-  {
-    "slug": "multidimensional-arrays",
-    "title": "Multidimensional Arrays",
-    "description": "Work with arrays of arrays. Understand matrices and complex data structures.",
-    "content_markdown": "# Multidimensional Arrays\n\nMultidimensional arrays are arrays that contain other arrays. They're useful for representing grids, matrices, and hierarchical data.\n\n## 2D Arrays\n\n```javascript\nconst matrix = [\n  [1, 2, 3],\n  [4, 5, 6],\n  [7, 8, 9]\n];\n\nconsole.log(matrix[0][0]); // 1\nconsole.log(matrix[1][2]); // 6\n```\n\n## Common Uses\n\n- Game boards\n- Spreadsheet data\n- Image pixels",
-    "parent_slug": "arrays"
-  },
-  {
-    "slug": "array-iteration",
-    "title": "Array Iteration",
-    "description": "Loop through arrays efficiently. Learn different iteration patterns and techniques.",
-    "content_markdown": "# Array Iteration\n\nThere are several ways to loop through array elements, each with its own advantages.\n\n## For Loop\n\n```javascript\nconst arr = [1, 2, 3];\nfor (let i = 0; i < arr.length; i++) {\n  console.log(arr[i]);\n}\n```\n\n## For...of Loop\n\n```javascript\nfor (const item of arr) {\n  console.log(item);\n}\n```\n\n## forEach Method\n\n```javascript\narr.forEach(item => console.log(item));\n```",
-    "parent_slug": "arrays"
-  },
-  {
-    "slug": "array-sorting",
-    "title": "Array Sorting",
-    "description": "Sort arrays by different criteria. Understand sorting algorithms and custom comparisons.",
-    "content_markdown": "# Array Sorting\n\nThe `sort()` method arranges array elements in place. By default, it converts elements to strings and sorts alphabetically.\n\n## Basic Sorting\n\n```javascript\nconst fruits = [\"cherry\", \"apple\", \"banana\"];\nfruits.sort(); // [\"apple\", \"banana\", \"cherry\"]\n```\n\n## Numeric Sorting\n\n```javascript\nconst numbers = [10, 2, 5, 1];\nnumbers.sort((a, b) => a - b); // [1, 2, 5, 10]\n```\n\n## Custom Sorting\n\n```javascript\nconst users = [{name: \"Bob\"}, {name: \"Alice\"}];\nusers.sort((a, b) => a.name.localeCompare(b.name));\n```",
-    "parent_slug": "arrays"
-  },
-  {
-    "slug": "conditionals",
-    "title": "Conditionals",
-    "description": "Make decisions in your code based on different conditions. Learn if statements, switch cases, and logical operators.",
-    "content_markdown": "# Conditionals\n\nConditionals allow your program to make decisions and execute different code based on different conditions. They're essential for creating dynamic, responsive programs.\n\n## Why Use Conditionals?\n\n1. **Decision making**: Choose what code to run\n2. **Input validation**: Check if data is valid\n3. **Flow control**: Direct program execution\n4. **Error handling**: Respond to different situations",
-    "parent_slug": null
-  },
-  {
-    "slug": "if-statements",
-    "title": "If Statements",
-    "description": "Make decisions with if statements. Learn basic conditional logic and branching.",
-    "content_markdown": "# If Statements\n\nThe `if` statement executes code only when a condition is true. It's the most basic form of conditional logic.\n\n## Basic Syntax\n\n```javascript\nif (condition) {\n  // Code runs if condition is true\n}\n```\n\n## Example\n\n```javascript\nconst age = 18;\n\nif (age >= 18) {\n  console.log(\"You can vote!\");\n}\n```",
-    "parent_slug": "conditionals"
-  },
-  {
-    "slug": "else-statements",
-    "title": "Else Statements",
-    "description": "Handle alternative conditions. Master if-else chains and default behaviors.",
-    "content_markdown": "# Else Statements\n\nThe `else` clause provides an alternative path when the `if` condition is false.\n\n## If-Else\n\n```javascript\nif (age >= 18) {\n  console.log(\"Adult\");\n} else {\n  console.log(\"Minor\");\n}\n```\n\n## Else-If Chain\n\n```javascript\nif (score >= 90) {\n  console.log(\"A\");\n} else if (score >= 80) {\n  console.log(\"B\");\n} else if (score >= 70) {\n  console.log(\"C\");\n} else {\n  console.log(\"F\");\n}\n```",
-    "parent_slug": "conditionals"
-  },
-  {
-    "slug": "logical-operators",
-    "title": "Logical Operators",
-    "description": "Combine conditions with AND, OR, and NOT. Learn complex conditional expressions.",
-    "content_markdown": "# Logical Operators\n\nLogical operators combine multiple conditions into a single boolean expression.\n\n## AND (&&)\n\nBoth conditions must be true:\n\n```javascript\nif (age >= 18 && hasLicense) {\n  console.log(\"Can drive\");\n}\n```\n\n## OR (||)\n\nAt least one condition must be true:\n\n```javascript\nif (isStudent || isSenior) {\n  console.log(\"Discount applies\");\n}\n```\n\n## NOT (!)\n\nInverts the boolean value:\n\n```javascript\nif (!isLoggedIn) {\n  console.log(\"Please log in\");\n}\n```",
-    "parent_slug": "conditionals"
-  },
-  {
-    "slug": "switch-statements",
-    "title": "Switch Statements",
-    "description": "Handle multiple conditions elegantly. Learn when to use switch vs if-else.",
-    "content_markdown": "# Switch Statements\n\nSwitch statements provide a clean way to handle multiple possible values of a single variable.\n\n## Basic Syntax\n\n```javascript\nswitch (day) {\n  case \"Monday\":\n    console.log(\"Start of week\");\n    break;\n  case \"Friday\":\n    console.log(\"Almost weekend!\");\n    break;\n  default:\n    console.log(\"Regular day\");\n}\n```\n\n## When to Use Switch\n\n- Multiple conditions checking the same variable\n- Checking against specific values (not ranges)\n- Cleaner than long if-else chains",
-    "parent_slug": "conditionals"
-  },
-  {
-    "slug": "ternary-operators",
-    "title": "Ternary Operators",
-    "description": "Write concise conditional expressions. Master the conditional operator syntax.",
-    "content_markdown": "# Ternary Operators\n\nThe ternary operator is a concise way to write simple if-else statements in a single line.\n\n## Syntax\n\n```javascript\ncondition ? valueIfTrue : valueIfFalse\n```\n\n## Examples\n\n```javascript\nconst status = age >= 18 ? \"adult\" : \"minor\";\n\nconst message = isLoggedIn \n  ? \"Welcome back!\" \n  : \"Please log in\";\n```\n\n## When to Use\n\n- Simple true/false decisions\n- Assigning values based on conditions\n- Keep it simple - avoid nesting ternaries",
-    "parent_slug": "conditionals"
-  },
-  {
-    "slug": "comparison-operators",
-    "title": "Comparison Operators",
-    "description": "Compare values effectively. Understand equality, inequality, and relational operators.",
-    "content_markdown": "# Comparison Operators\n\nComparison operators compare two values and return a boolean (true or false).\n\n## Equality Operators\n\n```javascript\n5 === 5    // true (strict equality)\n5 == \"5\"   // true (loose equality)\n5 !== 3    // true (strict inequality)\n```\n\n## Relational Operators\n\n```javascript\n5 > 3      // true\n5 < 3      // false\n5 >= 5     // true\n5 <= 4     // false\n```\n\n## Best Practice\n\nAlways use strict equality (`===`) to avoid type coercion surprises.",
-    "parent_slug": "conditionals"
-  },
-  {
-    "slug": "conditional-logic",
-    "title": "Conditional Logic",
-    "description": "Design complex decision-making logic. Learn to structure conditional flows effectively.",
-    "content_markdown": "# Conditional Logic\n\nConditional logic involves combining and structuring conditions to make complex decisions in your programs.\n\n## Nested Conditions\n\n```javascript\nif (isLoggedIn) {\n  if (isAdmin) {\n    showAdminPanel();\n  } else {\n    showUserDashboard();\n  }\n}\n```\n\n## Guard Clauses\n\nReturn early to simplify logic:\n\n```javascript\nfunction processOrder(order) {\n  if (!order) return \"No order\";\n  if (!order.items.length) return \"Empty order\";\n  \n  // Main logic here\n  return processItems(order.items);\n}\n```",
-    "parent_slug": "conditionals"
-  },
-  {
-    "slug": "classes",
-    "title": "Classes",
-    "description": "Model real-world entities using classes and objects. Understand inheritance, encapsulation, and polymorphism.",
-    "content_markdown": "# Classes\n\nClasses are blueprints for creating objects with shared properties and methods. They're fundamental to object-oriented programming.\n\n## Basic Class\n\n```javascript\nclass Person {\n  constructor(name, age) {\n    this.name = name;\n    this.age = age;\n  }\n  \n  greet() {\n    return `Hello, I'm ${this.name}`;\n  }\n}\n\nconst alice = new Person(\"Alice\", 30);\nconsole.log(alice.greet());\n```",
-    "parent_slug": null
+    "slug": "state",
+    "title": "State",
+    "description": "Update variables to track changing values over time.",
+    "content_markdown": "# State\n\nAs your program runs, the values stored in variables can change. That changing data is called state.",
+    "parent_slug": "variables",
+    "unlocked_by_lesson_slug": "updating-variables"
   },
   {
     "slug": "strings",
     "title": "Strings",
-    "description": "Work with text data in your programs. Learn string manipulation, formatting, and text processing techniques.",
-    "content_markdown": "# Strings\n\nStrings are sequences of characters used to represent text. They're one of the most commonly used data types in programming.\n\n## Creating Strings\n\n```javascript\nconst single = 'Hello';\nconst double = \"World\";\nconst template = `Hello, ${name}!`;\n```\n\n## Common Operations\n\n- Concatenation: joining strings together\n- Searching: finding text within strings\n- Manipulation: changing, splitting, replacing text",
-    "parent_slug": null
+    "description": "Work with text in your programs.",
+    "content_markdown": "# Strings\n\nStrings are pieces of text. You'll learn how to create and use them.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "strings"
   },
   {
-    "slug": "objects",
-    "title": "Objects",
-    "description": "Create and work with complex data structures. Learn about object properties, methods, and data modeling.",
-    "content_markdown": "# Objects\n\nObjects are collections of key-value pairs. They're used to group related data and functionality together.\n\n## Creating Objects\n\n```javascript\nconst person = {\n  name: \"Alice\",\n  age: 30,\n  greet() {\n    return `Hello, I'm ${this.name}`;\n  }\n};\n```\n\n## Accessing Properties\n\n```javascript\nconsole.log(person.name);       // Alice\nconsole.log(person[\"age\"]);     // 30\nconsole.log(person.greet());    // Hello, I'm Alice\n```",
-    "parent_slug": null
+    "slug": "string-concatenation",
+    "title": "String Concatenation",
+    "description": "Join strings together with `+`.",
+    "content_markdown": "# String Concatenation\n\nYou'll learn how to glue strings together end to end.",
+    "parent_slug": "strings",
+    "unlocked_by_lesson_slug": "string-concatenation"
   },
   {
-    "slug": "async",
-    "title": "Asynchronous Programming",
-    "description": "Handle time-dependent operations and concurrent execution. Master promises, async/await, and event handling.",
-    "content_markdown": "# Asynchronous Programming\n\nAsynchronous programming allows your code to start operations and continue running while waiting for results. It's essential for handling network requests, file operations, and user interactions.\n\n## Why Async?\n\n1. **Non-blocking**: Don't freeze the program while waiting\n2. **Efficiency**: Handle multiple operations concurrently\n3. **User experience**: Keep interfaces responsive\n\n## Key Concepts\n\n- Callbacks\n- Promises\n- Async/await",
-    "parent_slug": null
+    "slug": "string-templates",
+    "title": "String Templates",
+    "description": "Build strings by interpolating values into a template.",
+    "content_markdown": "# String Templates\n\nTemplates let you slot variables and expressions into a string without lots of `+`s.",
+    "parent_slug": "strings",
+    "unlocked_by_lesson_slug": "string-concatenation"
+  },
+  {
+    "slug": "string-indexing",
+    "title": "String Indexing",
+    "description": "Access individual characters by position.",
+    "content_markdown": "# String Indexing\n\nEach character in a string has a position. You'll learn how to grab the one you want.",
+    "parent_slug": "strings",
+    "unlocked_by_lesson_slug": "string-indexing"
+  },
+  {
+    "slug": "string-iteration",
+    "title": "String Iteration",
+    "description": "Loop through a string one character at a time.",
+    "content_markdown": "# String Iteration\n\nYou'll learn how to walk through a string character by character.",
+    "parent_slug": "strings",
+    "unlocked_by_lesson_slug": "string-iteration"
+  },
+  {
+    "slug": "colors",
+    "title": "Colors",
+    "description": "Specify and use colours in your drawings.",
+    "content_markdown": "# Colors\n\nYou'll learn how to pick and use colours when drawing.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "colors"
+  },
+  {
+    "slug": "hsl",
+    "title": "HSL Colors",
+    "description": "Describe colours by hue, saturation and lightness.",
+    "content_markdown": "# HSL Colors\n\nHSL is one way to specify a colour by its hue, saturation, and lightness.",
+    "parent_slug": "colors",
+    "unlocked_by_lesson_slug": "colors"
+  },
+  {
+    "slug": "rgb",
+    "title": "RGB Colors",
+    "description": "Describe colours by mixing red, green and blue.",
+    "content_markdown": "# RGB Colors\n\nRGB is another way to specify a colour, by mixing red, green, and blue.",
+    "parent_slug": "colors",
+    "unlocked_by_lesson_slug": "colors"
+  },
+  {
+    "slug": "loops",
+    "title": "Loops",
+    "description": "Repeat actions in your code without rewriting them.",
+    "content_markdown": "# Loops\n\nLoops let you do the same thing many times without repeating yourself.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "repeat-loop"
+  },
+  {
+    "slug": "repeat",
+    "title": "Repeat Loop",
+    "description": "Repeat a block of code a fixed number of times.",
+    "content_markdown": "# Repeat Loop\n\nThe repeat loop runs the same block a set number of times.",
+    "parent_slug": "loops",
+    "unlocked_by_lesson_slug": "repeat-loop"
+  },
+  {
+    "slug": "nested-loops",
+    "title": "Nested Loops",
+    "description": "Put loops inside other loops.",
+    "content_markdown": "# Nested Loops\n\nA loop inside another loop is a nested loop, useful for grids and 2D problems.",
+    "parent_slug": "loops",
+    "unlocked_by_lesson_slug": "nested-loops"
+  },
+  {
+    "slug": "repeat-while",
+    "title": "Repeat While",
+    "description": "Repeat code until a condition stops being true.",
+    "content_markdown": "# Repeat While\n\nUse repeat-while when you don't know in advance how many times to loop.",
+    "parent_slug": "loops",
+    "unlocked_by_lesson_slug": "repeat-without-count"
+  },
+  {
+    "slug": "for-loops",
+    "title": "For Loops",
+    "description": "Loop with a counter, with full control over start, stop and step.",
+    "content_markdown": "# For Loops\n\nFor loops give you fine control over how a counter advances each iteration.",
+    "parent_slug": "loops",
+    "unlocked_by_lesson_slug": "for-while-loops"
+  },
+  {
+    "slug": "break",
+    "title": "Break",
+    "description": "Exit a loop early.",
+    "content_markdown": "# Break\n\n`break` stops a loop immediately, even if the condition is still true.",
+    "parent_slug": "loops",
+    "unlocked_by_lesson_slug": "for-while-loops"
+  },
+  {
+    "slug": "continue",
+    "title": "Continue",
+    "description": "Skip the rest of the current loop iteration and move to the next.",
+    "content_markdown": "# Continue\n\n`continue` skips the rest of this iteration and jumps to the next one.",
+    "parent_slug": "loops",
+    "unlocked_by_lesson_slug": "for-while-loops"
+  },
+  {
+    "slug": "conditionals",
+    "title": "Conditionals",
+    "description": "Make decisions in code based on whether something is true.",
+    "content_markdown": "# Conditionals\n\nConditionals let your program take different paths depending on the situation.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "if-statements"
+  },
+  {
+    "slug": "if",
+    "title": "If Statements",
+    "description": "Run code only when a condition is true.",
+    "content_markdown": "# If Statements\n\n`if` runs a block of code only when its condition is true.",
+    "parent_slug": "conditionals",
+    "unlocked_by_lesson_slug": "if-statements"
+  },
+  {
+    "slug": "else",
+    "title": "Else",
+    "description": "Run alternative code when an `if` condition is false.",
+    "content_markdown": "# Else\n\n`else` runs when the `if` condition wasn't true.",
+    "parent_slug": "conditionals",
+    "unlocked_by_lesson_slug": "else-statements"
+  },
+  {
+    "slug": "else-if",
+    "title": "Else If",
+    "description": "Chain multiple conditions in order.",
+    "content_markdown": "# Else If\n\n`else if` lets you check additional conditions in sequence.",
+    "parent_slug": "conditionals",
+    "unlocked_by_lesson_slug": "else-statements"
+  },
+  {
+    "slug": "logical-and",
+    "title": "Logical And",
+    "description": "Combine conditions that must all be true.",
+    "content_markdown": "# Logical And\n\n`and` is true only when both sides are true.",
+    "parent_slug": "conditionals",
+    "unlocked_by_lesson_slug": "and-or"
+  },
+  {
+    "slug": "logical-or",
+    "title": "Logical Or",
+    "description": "Combine conditions where at least one must be true.",
+    "content_markdown": "# Logical Or\n\n`or` is true when either side is true.",
+    "parent_slug": "conditionals",
+    "unlocked_by_lesson_slug": "and-or"
+  },
+  {
+    "slug": "logical-not",
+    "title": "Logical Not",
+    "description": "Flip a condition's truth value.",
+    "content_markdown": "# Logical Not\n\n`not` turns true into false and false into true.",
+    "parent_slug": "conditionals",
+    "unlocked_by_lesson_slug": "remainder"
+  },
+  {
+    "slug": "modulo",
+    "title": "Modulo",
+    "description": "Get the remainder of a division.",
+    "content_markdown": "# Modulo\n\nThe modulo operator gives you what's left over after dividing.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "remainder"
+  },
+  {
+    "slug": "conditionals-and-state",
+    "title": "Using If and State",
+    "description": "Combining if statements with variables that change over time so your program reacts and behaves differently as it runs.",
+    "content_markdown": "# Conditionals and State\n\nMixing conditionals with state lets your program respond differently as values change.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "using-if-and-state"
+  },
+  {
+    "slug": "scope",
+    "title": "Scope",
+    "description": "Understand where variables exist and where they don't.",
+    "content_markdown": "# Scope\n\nVariables defined inside a block only exist inside that block.",
+    "parent_slug": "variables",
+    "unlocked_by_lesson_slug": "scope"
+  },
+  {
+    "slug": "random",
+    "title": "Random",
+    "description": "Add randomness to your programs.",
+    "content_markdown": "# Random\n\nRandom values let your programs behave differently each time they run.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "random-numbers"
+  },
+  {
+    "slug": "animation",
+    "title": "Animation",
+    "description": "Make things move on screen.",
+    "content_markdown": "# Animation\n\nAnimation is what happens when you draw, change something, and redraw, repeatedly.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "animation"
+  },
+  {
+    "slug": "scenarios",
+    "title": "Scenarios",
+    "description": "Run your code against different starting conditions.",
+    "content_markdown": "# Scenarios\n\nScenarios let you verify your code works in lots of different situations, not just one.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "scenarios"
+  },
+  {
+    "slug": "methods",
+    "title": "Methods",
+    "description": "Call functions that come attached to a value.",
+    "content_markdown": "# Methods\n\nMethods are functions that belong to a value, like `.length` or `.toUpperCase()`.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "methods-and-strings"
+  },
+  {
+    "slug": "properties",
+    "title": "Properties",
+    "description": "Access named values attached to a thing.",
+    "content_markdown": "# Properties\n\nProperties are named values that hang off another value.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "methods-and-strings"
+  },
+  {
+    "slug": "arrays",
+    "title": "Arrays",
+    "description": "Store an ordered collection of values.",
+    "content_markdown": "# Arrays\n\nArrays let you store and work with lists of values.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "arrays"
+  },
+  {
+    "slug": "building-arrays",
+    "title": "Building Arrays",
+    "description": "Build up an array piece by piece, often by appending in a loop.",
+    "content_markdown": "# Building Arrays\n\nStart with an empty array and grow it as you go.",
+    "parent_slug": "arrays",
+    "unlocked_by_lesson_slug": "building-arrays"
+  },
+  {
+    "slug": "dictionaries",
+    "title": "Dictionaries",
+    "description": "Store values under named keys.",
+    "content_markdown": "# Dictionaries\n\nDictionaries (also called maps) store data under named keys.",
+    "parent_slug": null,
+    "unlocked_by_lesson_slug": "dictionaries"
+  },
+  {
+    "slug": "updating-dictionaries",
+    "title": "Updating Dictionaries",
+    "description": "Add, change and remove keys in a dictionary.",
+    "content_markdown": "# Updating Dictionaries\n\nDictionaries aren't fixed once created — you can add new keys, change values, and remove entries.",
+    "parent_slug": "dictionaries",
+    "unlocked_by_lesson_slug": "updating-dictionaries"
   }
 ]

--- a/db/seeds/concepts.json
+++ b/db/seeds/concepts.json
@@ -2,8 +2,8 @@
   {
     "slug": "using-functions",
     "title": "Using Functions",
-    "description": "Call built-in functions to make things happen.",
-    "content_markdown": "# Using Functions\n\nFunctions are little machines you call to make things happen. You'll learn how to invoke them in your code.",
+    "description": "Use built-in functions to make things happen.",
+    "content_markdown": "# Using Functions\n\nFunctions are little machines you use to make things happen. You'll learn how to use them in your code.",
     "parent_slug": null,
     "unlocked_by_lesson_slug": "using-functions"
   },
@@ -11,7 +11,7 @@
     "slug": "using-functions-with-inputs",
     "title": "Using Functions With Inputs",
     "description": "Pass inputs (arguments) to functions to control their behaviour.",
-    "content_markdown": "# Using Functions With Inputs\n\nMany functions take inputs that change what they do. You'll learn how to pass values into a function when you call it.",
+    "content_markdown": "# Using Functions With Inputs\n\nMany functions take inputs that change what they do. You'll learn how to pass values into a function when you use it.",
     "parent_slug": "using-functions",
     "unlocked_by_lesson_slug": "function-inputs"
   },
@@ -306,7 +306,7 @@
   {
     "slug": "methods",
     "title": "Methods",
-    "description": "Call functions that come attached to a value.",
+    "description": "Use functions that come attached to a value.",
     "content_markdown": "# Methods\n\nMethods are functions that belong to a value, like `.length` or `.toUpperCase()`.",
     "parent_slug": null,
     "unlocked_by_lesson_slug": "methods-and-strings"

--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -5,7 +5,7 @@
       "title": "Using Functions",
       "description": "Learn how to use functions with and without inputs.",
       "milestone_summary": "Congratulations! You've completed your first level and learned how to use functions with and without inputs.",
-      "milestone_content": "# You Did It! 🎉\n\nYou've completed your first level and taken your first steps into the world of programming!\n\n## What you've learned:\n- How to call functions to make things happen\n- How to use functions without inputs\n- How to use functions with inputs to control their behavior\n- How to solve problems by breaking them down into steps\n\n## Next steps:\n- Continue to the next level to build on these skills\n- Practice what you've learned\n- Keep experimenting and having fun!\n\nYou're on your way to becoming a great programmer. Keep going!",
+      "milestone_content": "# You Did It! 🎉\n\nYou've completed your first level and taken your first steps into the world of programming!\n\n## What you've learned:\n- How to use functions to make things happen\n- How to use functions without inputs\n- How to use functions with inputs to control their behavior\n- How to solve problems by breaking them down into steps\n\n## Next steps:\n- Continue to the next level to build on these skills\n- Practice what you've learned\n- Keep experimenting and having fun!\n\nYou're on your way to becoming a great programmer. Keep going!",
       "lessons": [
         {
           "slug": "welcome-to-jiki",

--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -24,7 +24,7 @@
           "data": {"slug": "maze-solve-basic"}
         },
         {
-          "slug": "using-functions-video",
+          "slug": "using-functions",
           "title": "Using Functions",
           "description": "Learn about functions, the little machines that make things happen.",
           "type": "video",
@@ -40,7 +40,7 @@
           "data": {"slug": "space-invaders-solve-basic"}
         },
         {
-          "slug": "functions-taking-inputs",
+          "slug": "function-inputs",
           "title": "Functions Taking Inputs (Numbers)",
           "description": "Learn how to give extra information to functions.",
           "type": "video",
@@ -79,7 +79,7 @@
       "milestone_content": "# Great Progress! 🎨\n\nYou've mastered using strings and colors in your programs!\n\n## What you've learned:\n- How to use strings to work with text and names\n- How to use colors to make your drawings more vibrant\n- How to combine shapes and colors to create complex images\n\n## Next steps:\n- Continue building on these skills\n- Create even more complex and colorful programs\n- Keep experimenting with different combinations!\n\nYou're becoming a skilled programmer. Keep it up!",
       "lessons": [
         {
-          "slug": "strings-intro",
+          "slug": "strings",
           "title": "Strings",
           "description": "Learn how to use text in your programs.",
           "type": "video",
@@ -125,7 +125,7 @@
       "milestone_content": "# Fantastic Work! 🔁\n\nYou've mastered the repeat loop - one of the most powerful tools in programming!\n\n## What you've learned:\n- How to use loops to repeat actions\n- How to write more efficient code with less repetition\n- How to solve problems that require doing the same thing multiple times\n\n## Next steps:\n- Apply loops to more complex challenges\n- Combine loops with everything else you've learned\n- Keep building your programming skills!\n\nYou're making excellent progress. Keep going!",
       "lessons": [
         {
-          "slug": "introducing-repeat-loop",
+          "slug": "repeat-loop",
           "title": "Repeat Loop",
           "description": "Learn how to tell Jiki to do things multiple times.",
           "type": "video",
@@ -165,7 +165,7 @@
       "milestone_content": "# Outstanding Work! 📦\n\nYou've mastered variables - a fundamental building block of programming!\n\n## What you've learned:\n- How to create and use variables to store values\n- How to make your code more flexible and reusable\n- How to change values in one place and see results everywhere\n- How variables make complex programs easier to manage\n\n## Next steps:\n- Use variables in more complex programs\n- Combine variables with loops and functions\n- Keep building your programming toolkit!\n\nYou're becoming a real programmer now. Keep going!",
       "lessons": [
         {
-          "slug": "creating-and-using-variables",
+          "slug": "creating-variables",
           "title": "Creating/Using Variables",
           "description": "Learn how to save and retrieve information in your programs.",
           "type": "video",
@@ -188,7 +188,7 @@
           "data": {"slug": "traffic-lights"}
         },
         {
-          "slug": "arithmetic-and-variables",
+          "slug": "variables-together",
           "title": "Arithmetic + Variables",
           "description": "Learn how to do maths with variables.",
           "type": "video",
@@ -266,7 +266,7 @@
       "milestone_content": "# Level Complete!\n\nYou've completed the Functions That Return Things level. Keep going!",
       "lessons": [
         {
-          "slug": "functions-that-return-things-video",
+          "slug": "functions-that-return-things",
           "title": "Functions That Return Things",
           "description": "Learn how functions can give information back to you.",
           "type": "video",
@@ -289,7 +289,7 @@
           "data": {"slug": "gold-panning"}
         },
         {
-          "slug": "colors-hsl-and-rgb",
+          "slug": "colors",
           "title": "Colors (HSL and RGB)",
           "description": "Learn different ways to specify exact colours.",
           "type": "video",
@@ -305,7 +305,7 @@
           "data": {"slug": "rainbow"}
         },
         {
-          "slug": "animation-intro",
+          "slug": "animation",
           "title": "Animation",
           "description": "Learn how to make things move on screen.",
           "type": "video",
@@ -337,7 +337,7 @@
           "data": {"slug": "random-salad"}
         },
         {
-          "slug": "scope-intro",
+          "slug": "scope",
           "title": "Scope",
           "description": "Learn what happens to variables inside and outside of code blocks.",
           "type": "video",
@@ -360,7 +360,7 @@
           "data": {"slug": "stock-market"}
         },
         {
-          "slug": "scenarios-intro",
+          "slug": "scenarios",
           "title": "Scenarios",
           "description": "Learn how to run your code with different starting conditions.",
           "type": "video",
@@ -390,7 +390,7 @@
           "data": {"slug": "cityscape-skyscraper"}
         },
         {
-          "slug": "loops-in-loops",
+          "slug": "nested-loops",
           "title": "Loops in Loops",
           "description": "Learn how to put loops inside other loops.",
           "type": "video",
@@ -415,7 +415,7 @@
       "milestone_content": "# Level Complete!\n\nYou've completed the Conditionals level. Keep going!",
       "lessons": [
         {
-          "slug": "if-statements-video",
+          "slug": "if-statements",
           "title": "If Statements",
           "description": "Learn how to make your code do different things in different situations.",
           "type": "video",
@@ -438,7 +438,7 @@
           "data": {"slug": "space-invaders-conditional"}
         },
         {
-          "slug": "else-and-else-if",
+          "slug": "else-statements",
           "title": "Else and Else If",
           "description": "Learn how to handle multiple different conditions.",
           "type": "video",
@@ -470,7 +470,7 @@
       "milestone_content": "# Level Complete!\n\nYou've completed the Complex Conditionals level. Keep going!",
       "lessons": [
         {
-          "slug": "and-or-video",
+          "slug": "and-or",
           "title": "And / Or",
           "description": "Learn how to combine conditions together.",
           "type": "video",
@@ -493,7 +493,7 @@
           "data": {"slug": "golf-shot-checker"}
         },
         {
-          "slug": "modulo-and-not",
+          "slug": "remainder",
           "title": "Modulo and Not",
           "description": "Learn about remainders and how to flip conditions.",
           "type": "video",
@@ -509,7 +509,7 @@
           "data": {"slug": "rock-paper-scissors-determine-winner"}
         },
         {
-          "slug": "repeat-without-input",
+          "slug": "repeat-without-count",
           "title": "Repeat Without an Input",
           "description": "Learn how to loop without knowing how many times upfront.",
           "type": "video",
@@ -566,7 +566,7 @@
       "milestone_content": "# Level Complete!\n\nYou've completed the Make Your Own Functions level. Keep going!",
       "lessons": [
         {
-          "slug": "writing-your-own-functions",
+          "slug": "making-functions",
           "title": "Writing Your Own Functions",
           "description": "Learn how to create your own reusable machines.",
           "type": "video",
@@ -589,7 +589,7 @@
           "data": {"slug": "battle-procedures"}
         },
         {
-          "slug": "adding-inputs-to-functions",
+          "slug": "making-functions-with-inputs",
           "title": "Adding Inputs to Your Functions",
           "description": "Learn how to make your functions accept inputs.",
           "type": "video",
@@ -605,7 +605,7 @@
           "data": {"slug": "maze-walk"}
         },
         {
-          "slug": "adding-returns-to-functions",
+          "slug": "making-functions-with-return-values",
           "title": "Adding Returns to Your Functions",
           "description": "Learn how to make your functions give back results.",
           "type": "video",
@@ -658,7 +658,7 @@
       "milestone_content": "# Level Complete!\n\nYou've completed the String Manipulation level. Keep going!",
       "lessons": [
         {
-          "slug": "string-concatenation-and-templates",
+          "slug": "string-concatenation",
           "title": "String Concatenation and Templates",
           "description": "Learn how to join bits of text together.",
           "type": "video",
@@ -713,7 +713,7 @@
           "data": {"slug": "three-letter-acronym"}
         },
         {
-          "slug": "iterating-through-strings",
+          "slug": "string-iteration",
           "title": "Iterating Through Strings",
           "description": "Learn how to go through text one character at a time.",
           "type": "video",
@@ -812,7 +812,7 @@
       "milestone_content": "# Level Complete!\n\nYou've completed the Methods and Properties level. Keep going!",
       "lessons": [
         {
-          "slug": "methods-and-properties-video",
+          "slug": "methods-and-strings",
           "title": "Methods and Properties",
           "description": "Learn how to use built-in tools that come attached to data.",
           "type": "video",
@@ -844,7 +844,7 @@
       "milestone_content": "# Level Complete!\n\nYou've completed the Advanced Loops level. Keep going!",
       "lessons": [
         {
-          "slug": "advanced-loops-video",
+          "slug": "for-while-loops",
           "title": "Advanced Loops",
           "description": "Learn proper JavaScript loops with more control and flexibility.",
           "type": "video",
@@ -869,7 +869,7 @@
       "milestone_content": "# Level Complete!\n\nYou've completed the Lists level. Keep going!",
       "lessons": [
         {
-          "slug": "arrays-intro",
+          "slug": "arrays",
           "title": "Arrays",
           "description": "Learn how to store collections of things in lists.",
           "type": "video",
@@ -944,7 +944,7 @@
         },
         {
           "slug": "wordle-process-guess",
-          "title": "Wordle Process Guess",
+          "title": "Wordle: Process Guess",
           "description": "Check a Wordle guess and work out which letters are correct.",
           "type": "exercise",
           "data": {"slug": "wordle-process-guess"}
@@ -965,7 +965,7 @@
         },
         {
           "slug": "wordle-process-game",
-          "title": "Wordle Introduction",
+          "title": "Wordle: Play a Game",
           "description": "Process a whole Wordle game, colouring each guess row by row.",
           "type": "exercise",
           "data": {"slug": "wordle-process-game"}
@@ -980,7 +980,7 @@
       "milestone_content": "# Level Complete!\n\nYou've completed the Dictionaries level. Keep going!",
       "lessons": [
         {
-          "slug": "dictionaries-intro",
+          "slug": "dictionaries",
           "title": "Dictionaries",
           "description": "Learn how to store data with named labels.",
           "type": "video",
@@ -1003,7 +1003,7 @@
           "data": {"slug": "scrabble-score"}
         },
         {
-          "slug": "changing-dictionaries",
+          "slug": "updating-dictionaries",
           "title": "Changing Dictionaries",
           "description": "Learn how to update and modify dictionaries.",
           "type": "video",


### PR DESCRIPTION
## Summary
- Replaces `db/seeds/concepts.json` with 44 concepts matching the FE concept set, each linked to its unlocking video lesson via `unlocked_by_lesson_slug`.
- Renames video lesson slugs in `db/seeds/curriculum.json` to the canonical slugs in the videos repo (e.g. `if-statements-video` → `if-statements`, `colors-hsl-and-rgb` → `colors`, `modulo-and-not` → `remainder`).
- Renames the two Wordle exercises: `Wordle: Process Guess` and `Wordle: Play a Game`.

## Test plan
- [ ] `bin/rails db:seed` runs cleanly on a fresh DB.
- [ ] `GET /internal/concepts/:slug` returns `video_data` populated from the unlocking lesson for every concept.
- [ ] Completing a video lesson with an `unlocked_concept` correctly unlocks the concept for the user (existing `Concept::UnlockForUser` behaviour).
- [ ] Sanity-check curriculum slug renames don't break any external consumers (FE exercise loaders, video repo references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)