### PR TITLE
Move alphanumeric exercise to advanced-loops level

### DIFF
--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -794,13 +794,6 @@
           "description": "Check if a sentence uses every letter of the alphabet.",
           "type": "exercise",
           "data": {"slug": "lower-pangram"}
-        },
-        {
-          "slug": "alphanumeric",
-          "title": "Alphanumeric",
-          "description": "Build functions to classify text as letters, numbers or both.",
-          "type": "exercise",
-          "data": {"slug": "alphanumeric"}
         }
       ]
     },
@@ -858,6 +851,13 @@
           "description": "Check whether a book's ISBN number is valid.",
           "type": "exercise",
           "data": {"slug": "isbn-verifier"}
+        },
+        {
+          "slug": "alphanumeric",
+          "title": "Alphanumeric",
+          "description": "Build functions to classify text as letters, numbers or both.",
+          "type": "exercise",
+          "data": {"slug": "alphanumeric"}
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Moves the `alphanumeric` exercise from the `multiple-functions` level to the end of the `advanced-loops` level in `curriculum.json`.

## Test plan
- [ ] Run `bin/rails db:seed` (or re-seed) and confirm `alphanumeric` appears after `isbn-verifier` in `advanced-loops`, and `multiple-functions` no longer contains it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)