### PR TITLE
Fix Stripe checkout: ui_mode 'elements' and tolerate missing customer

### DIFF
--- a/app/commands/stripe/create_checkout_session.rb
+++ b/app/commands/stripe/create_checkout_session.rb
@@ -4,13 +4,8 @@ class Stripe::CreateCheckoutSession
   initialize_with :user, :price_id, :return_url, :currency
 
   def call
-    # Get or create Stripe customer
-    customer = Stripe::GetOrCreateCustomer.(user)
-
-    # Create checkout session
-    ::Stripe::Checkout::Session.create(
-      ui_mode: 'custom',
-      customer: customer.id,
+    args = {
+      ui_mode: 'elements',
       currency: currency,
       line_items: [
         {
@@ -20,11 +15,24 @@ class Stripe::CreateCheckoutSession
       ],
       mode: 'subscription',
       return_url: return_url,
+      metadata: {
+        user_id: user.id
+      },
       subscription_data: {
         metadata: {
           user_id: user.id
         }
       }
-    )
+    }
+
+    if user.data.stripe_customer_id.present?
+      customer = Stripe::GetOrCreateCustomer.(user)
+      args[:customer] = customer.id
+      args[:customer_update] = { address: 'auto', name: 'auto' }
+    else
+      args[:customer_email] = user.email
+    end
+
+    ::Stripe::Checkout::Session.create(**args)
   end
 end

--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -4,28 +4,22 @@ class Stripe::VerifyCheckoutSession
   initialize_with :user, :session_id
 
   def call
-    # Retrieve the session from Stripe
     session = ::Stripe::Checkout::Session.retrieve(session_id)
 
-    # Verify the session belongs to the current user
-    raise SecurityError, "Checkout session does not belong to current user" unless session.customer == user.data.stripe_customer_id
+    verify_ownership!(session)
 
-    # Check if session is complete and has a subscription
     raise ArgumentError, "Checkout session is not complete (status: #{session.status})" unless session.status == "complete"
-
     raise ArgumentError, "Checkout session has no subscription" unless session.subscription.present?
 
-    # Retrieve the full subscription object to get all details
+    persist_customer_id!(session)
+
     subscription = ::Stripe::Subscription.retrieve(session.subscription)
 
-    # Get the subscription item (should only be one for our use case)
     subscription_item = subscription.items.data.first
     raise ArgumentError, "Subscription has no items" unless subscription_item
 
-    # Determine the interval from the price ID
     interval = Stripe::DetermineSubscriptionDetails.interval_for_price_id(subscription_item.price.id)
 
-    # Sync subscription to user (handles both active and incomplete states)
     status = Stripe::SyncSubscriptionToUser.(user, subscription, interval)
 
     Rails.logger.info(
@@ -39,5 +33,25 @@ class Stripe::VerifyCheckoutSession
       payment_status: session.payment_status,
       subscription_status: status
     }
+  end
+
+  private
+  def verify_ownership!(session)
+    metadata_user_id = session.metadata&.[](:user_id) || session.metadata&.[]('user_id')
+
+    if metadata_user_id.present?
+      return if metadata_user_id.to_s == user.id.to_s
+    elsif user.data.stripe_customer_id.present? && session.customer == user.data.stripe_customer_id
+      return
+    end
+
+    raise SecurityError, "Checkout session does not belong to current user"
+  end
+
+  def persist_customer_id!(session)
+    return if user.data.stripe_customer_id.present?
+    return if session.customer.blank?
+
+    user.data.update!(stripe_customer_id: session.customer)
   end
 end

--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -49,9 +49,12 @@ class Stripe::VerifyCheckoutSession
   end
 
   def persist_customer_id!(session)
-    return if user.data.stripe_customer_id.present?
     return if session.customer.blank?
 
-    user.data.update!(stripe_customer_id: session.customer)
+    user.data.with_lock do
+      next if user.data.stripe_customer_id.present?
+
+      user.data.update!(stripe_customer_id: session.customer)
+    end
   end
 end

--- a/app/commands/stripe/webhook/checkout_completed.rb
+++ b/app/commands/stripe/webhook/checkout_completed.rb
@@ -9,11 +9,15 @@ class Stripe::Webhook::CheckoutCompleted
       return
     end
 
-    # Update user's subscription ID
-    user.data.update!(
-      stripe_subscription_id: subscription_id,
-      stripe_subscription_status: 'active'
-    )
+    user.data.with_lock do
+      updates = {
+        stripe_subscription_id: subscription_id,
+        stripe_subscription_status: 'active'
+      }
+      updates[:stripe_customer_id] = session.customer if user.data.stripe_customer_id.blank? && session.customer.present?
+
+      user.data.update!(**updates)
+    end
 
     Rails.logger.info("Checkout completed for user #{user.id}, subscription: #{subscription_id}")
   end
@@ -31,6 +35,17 @@ class Stripe::Webhook::CheckoutCompleted
 
   memoize
   def user
+    user_from_customer || user_from_metadata
+  end
+
+  def user_from_customer
+    return nil if session.customer.blank?
+
     User.joins(:data).find_by(user_data: { stripe_customer_id: session.customer })
+  end
+
+  def user_from_metadata
+    user_id = session.metadata&.[](:user_id) || session.metadata&.[]('user_id')
+    user_id.present? ? User.find_by(id: user_id) : nil
   end
 end

--- a/test/commands/stripe/create_checkout_session_test.rb
+++ b/test/commands/stripe/create_checkout_session_test.rb
@@ -1,8 +1,9 @@
 require "test_helper"
 
 class Stripe::CreateCheckoutSessionTest < ActiveSupport::TestCase
-  test "creates checkout session with correct parameters" do
+  test "creates checkout session with existing customer" do
     user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
     price_id = "price_123"
     return_url = "#{Jiki.config.frontend_base_url}/subscribe/complete"
 
@@ -13,8 +14,7 @@ class Stripe::CreateCheckoutSessionTest < ActiveSupport::TestCase
     session = mock
 
     ::Stripe::Checkout::Session.expects(:create).with(
-      ui_mode: 'custom',
-      customer: "cus_123",
+      ui_mode: 'elements',
       currency: :usd,
       line_items: [
         {
@@ -24,11 +24,52 @@ class Stripe::CreateCheckoutSessionTest < ActiveSupport::TestCase
       ],
       mode: 'subscription',
       return_url: return_url,
+      metadata: {
+        user_id: user.id
+      },
       subscription_data: {
         metadata: {
           user_id: user.id
         }
-      }
+      },
+      customer: "cus_123",
+      customer_update: { address: 'auto', name: 'auto' }
+    ).returns(session)
+
+    result = Stripe::CreateCheckoutSession.(user, price_id, return_url, :usd)
+
+    assert_equal session, result
+  end
+
+  test "passes customer_email when user has no stripe_customer_id" do
+    user = create(:user, email: "alice@example.com")
+    price_id = "price_123"
+    return_url = "#{Jiki.config.frontend_base_url}/subscribe/complete"
+
+    Stripe::GetOrCreateCustomer.expects(:call).never
+
+    session = mock
+
+    ::Stripe::Checkout::Session.expects(:create).with(
+      ui_mode: 'elements',
+      currency: :usd,
+      line_items: [
+        {
+          price: price_id,
+          quantity: 1
+        }
+      ],
+      mode: 'subscription',
+      return_url: return_url,
+      metadata: {
+        user_id: user.id
+      },
+      subscription_data: {
+        metadata: {
+          user_id: user.id
+        }
+      },
+      customer_email: "alice@example.com"
     ).returns(session)
 
     result = Stripe::CreateCheckoutSession.(user, price_id, return_url, :usd)
@@ -41,44 +82,8 @@ class Stripe::CreateCheckoutSessionTest < ActiveSupport::TestCase
     price_id = "price_123"
     return_url = "#{Jiki.config.frontend_base_url}/subscribe/complete"
 
-    customer = mock
-    customer.stubs(:id).returns("cus_123")
-    Stripe::GetOrCreateCustomer.stubs(:call).with(user).returns(customer)
+    ::Stripe::Checkout::Session.expects(:create).with(has_entry(currency: :inr)).returns(mock)
 
-    session = mock
-
-    ::Stripe::Checkout::Session.expects(:create).with(
-      ui_mode: 'custom',
-      customer: "cus_123",
-      currency: :inr,
-      line_items: [
-        {
-          price: price_id,
-          quantity: 1
-        }
-      ],
-      mode: 'subscription',
-      return_url: return_url,
-      subscription_data: {
-        metadata: {
-          user_id: user.id
-        }
-      }
-    ).returns(session)
-
-    result = Stripe::CreateCheckoutSession.(user, price_id, return_url, :inr)
-
-    assert_equal session, result
-  end
-
-  test "gets or creates customer before creating session" do
-    user = create(:user)
-    price_id = "price_123"
-    return_url = "#{Jiki.config.frontend_base_url}/subscribe/complete"
-
-    Stripe::GetOrCreateCustomer.expects(:call).with(user).returns(mock(id: "cus_123"))
-    ::Stripe::Checkout::Session.stubs(:create).returns(mock)
-
-    Stripe::CreateCheckoutSession.(user, price_id, return_url, :usd)
+    Stripe::CreateCheckoutSession.(user, price_id, return_url, :inr)
   end
 end

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -54,6 +54,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     user.data.update!(stripe_customer_id: "cus_123")
 
     stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
     stripe_session.stubs(:customer).returns("cus_different")
 
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
@@ -68,6 +69,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     user.data.update!(stripe_customer_id: "cus_123")
 
     stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("open")
 
@@ -84,6 +86,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     user.data.update!(stripe_customer_id: "cus_123")
 
     stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("complete")
     stripe_session.stubs(:subscription).returns(nil)
@@ -101,6 +104,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     user.data.update!(stripe_customer_id: "cus_123")
 
     stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("complete")
     stripe_session.stubs(:subscription).returns("sub_123")
@@ -150,9 +154,10 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
   end
 
   private
-  def mock_stripe_session(payment_status: "paid")
+  def mock_stripe_session(payment_status: "paid", user_id: nil, customer: "cus_123")
     session = mock
-    session.stubs(:customer).returns("cus_123")
+    session.stubs(:metadata).returns(user_id ? { user_id: user_id.to_s } : nil)
+    session.stubs(:customer).returns(customer)
     session.stubs(:status).returns("complete")
     session.stubs(:subscription).returns("sub_123")
     session.stubs(:payment_status).returns(payment_status)

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -128,6 +128,38 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     assert_match(/Unknown Stripe price ID/, error.message)
   end
 
+  test "verifies via metadata user_id and persists stripe_customer_id when user has none" do
+    user = create(:user)
+    assert_nil user.data.stripe_customer_id
+
+    stripe_session = mock_stripe_session(user_id: user.id, customer: "cus_new")
+    stripe_subscription = mock_stripe_subscription(price_id: Jiki.config.stripe_premium_monthly_price_id)
+
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+    ::Stripe::Subscription.expects(:retrieve).with("sub_123").returns(stripe_subscription)
+
+    result = Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+
+    assert result[:success]
+    user.data.reload
+    assert_equal "cus_new", user.data.stripe_customer_id
+    assert_equal "sub_123", user.data.stripe_subscription_id
+  end
+
+  test "raises SecurityError when metadata user_id does not match current user" do
+    user = create(:user)
+    other_user = create(:user)
+
+    stripe_session = mock
+    stripe_session.stubs(:metadata).returns({ user_id: other_user.id.to_s })
+
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+
+    assert_raises(SecurityError) do
+      Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+    end
+  end
+
   test "handles incomplete subscription for async payments" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123", membership_type: "standard")

--- a/test/commands/stripe/webhook/checkout_completed_test.rb
+++ b/test/commands/stripe/webhook/checkout_completed_test.rb
@@ -17,11 +17,32 @@ class Stripe::Webhook::CheckoutCompletedTest < ActiveSupport::TestCase
     user.data.reload
     assert_equal "sub_123", user.data.stripe_subscription_id
     assert_equal "active", user.data.stripe_subscription_status
+    assert_equal "cus_123", user.data.stripe_customer_id
+  end
+
+  test "persists stripe_customer_id when user did not have one" do
+    user = create(:user)
+    assert_nil user.data.stripe_customer_id
+
+    session = mock
+    session.stubs(:customer).returns("cus_new")
+    session.stubs(:metadata).returns({ user_id: user.id.to_s })
+    session.stubs(:subscription).returns("sub_456")
+
+    event = mock
+    event.stubs(:data).returns(mock(object: session))
+
+    Stripe::Webhook::CheckoutCompleted.(event)
+
+    user.data.reload
+    assert_equal "cus_new", user.data.stripe_customer_id
+    assert_equal "sub_456", user.data.stripe_subscription_id
   end
 
   test "logs error when user not found" do
     session = mock
     session.stubs(:customer).returns("cus_nonexistent")
+    session.stubs(:metadata).returns(nil)
 
     event = mock
     event.stubs(:data).returns(mock(object: session))


### PR DESCRIPTION
## Summary
- Stripe deprecated `ui_mode: 'custom'`; switch to `'elements'` so checkout works on accounts pinned to newer Stripe API versions.
- Stop pre-creating Stripe customers — pass `customer_email` when the user has no `stripe_customer_id`, and let Stripe create the customer at checkout. The webhook + verify endpoint persist `session.customer` back to `User::Data` afterwards. Avoids orphan Stripe customers for users who abandon checkout.
- Webhook and `VerifyCheckoutSession` now also accept `metadata.user_id` as a fallback when `stripe_customer_id` is not yet recorded.
- Webhook update is wrapped in `with_lock` to serialise against `VerifyCheckoutSession` racing on the same `User::Data` row (Stripe fires the webhook around the same time the frontend hits `/verify_checkout`).

Patterns mirror `giki/api`, which evolved the same code; Stripe Tax / EU VAT (PR #235 there) is intentionally not ported here.

## Test plan
- [x] `bin/rails test test/commands/stripe/...` — 13 runs, 56 assertions, 0 failures
- [x] `bin/rails test test/controllers/internal/subscriptions_controller_test.rb` — 48/48
- [x] Full suite via pre-commit hook — 1650 runs, 0 failures
- [x] Brakeman clean
- [ ] Manual: run a real checkout end-to-end in staging once merged (colleague was hitting this in dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)