### PR TITLE
Tweak mailer styling and copy

### DIFF
--- a/app/views/layouts/mailer.mjml
+++ b/app/views/layouts/mailer.mjml
@@ -8,8 +8,11 @@
       %mj-section{ "padding": "0 48px" }
       %mj-text{ "color": "#334155", "font-size": "16px", "line-height": "1.6", "padding": "0 0 10px 0" }
       %mj-class{ name: "h2", "font-size": "20px", "font-weight": "600", "color": "#1e293b", "padding": "8px 0" }
+    %mj-style
+      :plain
+        a { font-weight: 500; }
 
-  %mj-body{ "background-color": "#f0f1f5" }
+  %mj-body{ "background-color": "#ffffff" }
     = render 'mailers/shared/header', header_image: @header_image.presence || "jiki-header.jpg"
     = yield
     = render 'mailers/shared/footer', user: @user, unsubscribe_key: @unsubscribe_key

--- a/app/views/mailers/shared/_footer.mjml
+++ b/app/views/mailers/shared/_footer.mjml
@@ -6,20 +6,14 @@
 
 %mj-section{ "background-color": "#ffffff", "padding-bottom": "24px" }
   %mj-column
-    %mj-text{ align: "center", "font-size": "28px", "font-weight": "700", color: "#667eea" }
-      JIKI
-
     %mj-text{ align: "center", "font-size": "14px", color: "#64748b" }
-      Copyright © #{Time.current.year} Jiki. All rights reserved.
-
-    %mj-text{ align: "center", "font-size": "14px", color: "#64748b" }
-      You are receiving this email because you have registered an account at Jiki.
+      != 'You are receiving this email because you have an account at <a href="https://jiki.io" style="color: #64748b; text-decoration: underline; font-weight: 500;">Jiki</a>.'
       - if user&.unsubscribe_token
         Want to change how you receive these emails? You can
-        %a{ href: unsubscribe_url(token: user.unsubscribe_token), style: "color: #64748b; text-decoration: underline;" }
+        %a{ href: unsubscribe_url(token: user.unsubscribe_token), style: "color: #64748b; text-decoration: underline; font-weight: 500;" }
           update your preferences
         - if unsubscribe_key.present?
           or
-          %a{ href: unsubscribe_url(token: user.unsubscribe_token, key: unsubscribe_key), style: "color: #64748b; text-decoration: underline;" }
+          %a{ href: unsubscribe_url(token: user.unsubscribe_token, key: unsubscribe_key), style: "color: #64748b; text-decoration: underline; font-weight: 500;" }
             unsubscribe
           from this list.

--- a/app/views/notifications_mailer/badge_earned.mjml
+++ b/app/views/notifications_mailer/badge_earned.mjml
@@ -4,7 +4,7 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      Hi #{@user.name},
+      Hi there!
 
     - if @image_url.present?
       %mj-image{ src: @image_url, alt: @badge.name, width: "100%" }

--- a/app/views/notifications_mailer/badge_earned.text.erb
+++ b/app/views/notifications_mailer/badge_earned.text.erb
@@ -1,3 +1,3 @@
-Hi <%= @user.name %>,
+Hi there!
 
 <%= markdown_to_text(@content_markdown) %>

--- a/app/views/progression_mailer/level_completed.mjml
+++ b/app/views/progression_mailer/level_completed.mjml
@@ -4,7 +4,7 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      Hi #{@user.name},
+      Hi there!
 
     - if @image_url.present?
       %mj-image{ src: @image_url, alt: @level.title, width: "100%" }

--- a/app/views/progression_mailer/level_completed.text.erb
+++ b/app/views/progression_mailer/level_completed.text.erb
@@ -1,3 +1,3 @@
-Hi <%= @user.name %>,
+Hi there!
 
 <%= markdown_to_text(@content_markdown) %>

--- a/test/mailers/previews/account_mailer_preview.rb
+++ b/test/mailers/previews/account_mailer_preview.rb
@@ -1,6 +1,6 @@
 class AccountMailerPreview < ActionMailer::Preview
   def welcome
-    AccountMailer.welcome(preview_user, login_url: "https://jiki.dev/login")
+    AccountMailer.welcome(preview_user)
   end
 
   def account_deletion_confirmation


### PR DESCRIPTION
## Summary
- White body background; remove logo and copyright line from footer
- Replace "Hi {name}" with "Hi there!" in badge_earned and level_completed emails
- All links font-weight 500 (via mj-style + inline on footer links)
- Footer copy updated to "You are receiving this email because you have an account at Jiki." with Jiki linked to https://jiki.io
- Fix AccountMailerPreview#welcome which was passing an extra kwarg

## Test plan
- [ ] Open `/rails/mailers` and check each preview renders
- [ ] Verify body is white, footer no longer shows logo/copyright
- [ ] Verify "Hi there!" in badge_earned and level_completed previews
- [ ] Verify Jiki link goes to jiki.io and links are weight 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)