### PR TITLE
Unify mailer layout, copy, and add missing previews

### DIFF
--- a/app/views/account_mailer/account_deletion_confirmation.mjml
+++ b/app/views/account_mailer/account_deletion_confirmation.mjml
@@ -4,10 +4,8 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      = t('.greeting', name: @user.name || @user.email)
-
-    %mj-text
+      = t('.greeting')
       = markdown_to_html(t('.body_markdown'))
 
-    %mj-button{ "background-color": "#cc0000", "color": "#ffffff", "font-size": "16px", "font-weight": "bold", "border-radius": "4px", "padding": "15px 30px", "href": @confirmation_url }
+    %mj-button{ "background-color": "#cc0000", "color": "#ffffff", "font-size": "16px", "font-weight": "500", "border-radius": "8px", "padding": "15px 30px", "href": @confirmation_url }
       = t('.cta')

--- a/app/views/account_mailer/account_deletion_confirmation.text.erb
+++ b/app/views/account_mailer/account_deletion_confirmation.text.erb
@@ -1,4 +1,4 @@
-<%= t('.greeting', name: @user.name || @user.email) %>
+<%= t('.greeting') %>
 
 <%= markdown_to_text(t('.body_markdown')) %>
 

--- a/app/views/account_mailer/welcome.mjml
+++ b/app/views/account_mailer/welcome.mjml
@@ -4,7 +4,5 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      = t('.greeting', name: @user.name)
-
-    %mj-text
+      = t('.greeting')
       = markdown_to_html(t('.body_markdown'))

--- a/app/views/account_mailer/welcome.text.erb
+++ b/app/views/account_mailer/welcome.text.erb
@@ -1,3 +1,3 @@
-<%= t('.greeting', name: @user.name) %>
+<%= t('.greeting') %>
 
 <%= markdown_to_text(t('.body_markdown')) %>

--- a/app/views/devise/mailer/confirmation_instructions.mjml
+++ b/app/views/devise/mailer/confirmation_instructions.mjml
@@ -4,12 +4,10 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      = t('devise.mailer.confirmation_instructions.greeting', name: @user.name || @user.email)
-
-    %mj-text
+      = t('devise.mailer.confirmation_instructions.greeting')
       = markdown_to_html(t('devise.mailer.confirmation_instructions.body_markdown'))
 
-    %mj-button{ "background-color": "#7c3aed", "color": "#ffffff", "font-size": "16px", "font-weight": "bold", "border-radius": "4px", "padding": "15px 30px", "href": @confirmation_url }
+    %mj-button{ "background-color": "#7c3aed", "color": "#ffffff", "font-size": "16px", "font-weight": "500", "border-radius": "8px", "padding": "15px 30px", "href": @confirmation_url }
       = t('devise.mailer.confirmation_instructions.cta')
 
     %mj-text{ "padding-top": "20px", color: "#64748b", "font-size": "14px" }

--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -1,4 +1,4 @@
-<%= t('devise.mailer.confirmation_instructions.greeting', name: @user.name || @user.email) %>
+<%= t('devise.mailer.confirmation_instructions.greeting') %>
 
 <%= markdown_to_text(t('devise.mailer.confirmation_instructions.body_markdown')) %>
 

--- a/app/views/devise/mailer/reset_password_instructions.mjml
+++ b/app/views/devise/mailer/reset_password_instructions.mjml
@@ -4,12 +4,10 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      = t('devise.mailer.reset_password_instructions.greeting', name: @user.name || @user.email)
-
-    %mj-text
+      = t('devise.mailer.reset_password_instructions.greeting')
       = markdown_to_html(t('devise.mailer.reset_password_instructions.body_markdown'))
 
-    %mj-button{ "background-color": "#7c3aed", "color": "#ffffff", "font-size": "16px", "font-weight": "bold", "border-radius": "4px", "padding": "15px 30px", "href": @reset_password_url }
+    %mj-button{ "background-color": "#7c3aed", "color": "#ffffff", "font-size": "16px", "font-weight": "500", "border-radius": "8px", "padding": "15px 30px", "href": @reset_password_url }
       = t('devise.mailer.reset_password_instructions.cta')
 
     %mj-text{ "padding-top": "20px", color: "#64748b", "font-size": "14px" }

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,4 +1,4 @@
-<%= t('devise.mailer.reset_password_instructions.greeting', name: @user.name || @user.email) %>
+<%= t('devise.mailer.reset_password_instructions.greeting') %>
 
 <%= markdown_to_text(t('devise.mailer.reset_password_instructions.body_markdown')) %>
 

--- a/app/views/notifications_mailer/badge_earned.mjml
+++ b/app/views/notifications_mailer/badge_earned.mjml
@@ -4,10 +4,14 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      Hi there!
+      Hi there,
 
     - if @image_url.present?
       %mj-image{ src: @image_url, alt: @badge.name, width: "100%" }
 
     %mj-text
       = markdown_to_html(@content_markdown)
+      %p
+        Cheers,
+        %br
+        Jeremy &amp; Team

--- a/app/views/notifications_mailer/badge_earned.text.erb
+++ b/app/views/notifications_mailer/badge_earned.text.erb
@@ -1,3 +1,6 @@
-Hi there!
+Hi there,
 
 <%= markdown_to_text(@content_markdown) %>
+
+Cheers,
+Jeremy & Team

--- a/app/views/premium_mailer/subscription_ended.mjml
+++ b/app/views/premium_mailer/subscription_ended.mjml
@@ -4,7 +4,5 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      = t('.greeting', name: @user.name)
-
-    %mj-text
+      = t('.greeting')
       = markdown_to_html(t('.body_markdown'))

--- a/app/views/premium_mailer/subscription_ended.text.erb
+++ b/app/views/premium_mailer/subscription_ended.text.erb
@@ -1,3 +1,3 @@
-<%= t('.greeting', name: @user.name) %>
+<%= t('.greeting') %>
 
 <%= markdown_to_text(t('.body_markdown')) %>

--- a/app/views/premium_mailer/welcome_to_premium.mjml
+++ b/app/views/premium_mailer/welcome_to_premium.mjml
@@ -4,7 +4,5 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      = t('.greeting', name: @user.name)
-
-    %mj-text
+      = t('.greeting')
       = markdown_to_html(t('.body_markdown'))

--- a/app/views/premium_mailer/welcome_to_premium.text.erb
+++ b/app/views/premium_mailer/welcome_to_premium.text.erb
@@ -1,3 +1,3 @@
-<%= t('.greeting', name: @user.name) %>
+<%= t('.greeting') %>
 
 <%= markdown_to_text(t('.body_markdown')) %>

--- a/app/views/progression_mailer/level_completed.mjml
+++ b/app/views/progression_mailer/level_completed.mjml
@@ -4,10 +4,14 @@
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      Hi there!
+      Hi there,
 
     - if @image_url.present?
       %mj-image{ src: @image_url, alt: @level.title, width: "100%" }
 
     %mj-text
       = markdown_to_html(@content_markdown)
+      %p
+        Cheers,
+        %br
+        Jeremy &amp; Team

--- a/app/views/progression_mailer/level_completed.text.erb
+++ b/app/views/progression_mailer/level_completed.text.erb
@@ -1,3 +1,6 @@
-Hi there!
+Hi there,
 
 <%= markdown_to_text(@content_markdown) %>
+
+Cheers,
+Jeremy & Team

--- a/config/locales/mailers/account_mailer.en.yml
+++ b/config/locales/mailers/account_mailer.en.yml
@@ -2,25 +2,26 @@ en:
   account_mailer:
     welcome:
       subject: "Welcome to Jiki!"
-      greeting: "Hi %{name},"
+      greeting: "Hi there,"
       body_markdown: |
-        Welcome to [Jiki](https://jiki.io)! I'm really excited to have you here.
+        Welcome to [Jiki](https://jiki.io)! We're really excited to have you here.
 
-        Jiki is designed to take you from complete beginner to confident coder. You'll be working on fun projects and solving interesting problems, making progress one small step at a time.
+        Jiki has been designed to take you from complete beginner to confident coder. You'll be working on fun projects and solving interesting problems, making progress one small step at a time, and learning tons on the journey.
 
         If you ever get stuck or have questions, don't hesitate to reach out. Learning to code can feel overwhelming at first, but you've got this!
 
         Have fun, and enjoy the journey!
 
-        Jeremy
+        Cheers,  
+        Jeremy & Team
     account_deletion_confirmation:
       subject: "Confirm Your Account Deletion"
       preview: "Please confirm that you want to permanently delete your Jiki account"
-      greeting: "Hi %{name},"
+      greeting: "Hi there,"
       body_markdown: |
         We received a request to delete your Jiki account.
 
-        If this was you, click the button below to confirm. This action is permanent and cannot be undone — all your progress and data will be deleted.
+        If this is a legitimate request, click the button below to confirm. This action is permanent and cannot be undone. All your progress and data will be deleted.
 
         If you didn't request this, you can safely ignore this email and your account will remain unchanged.
       cta: "Delete My Account"

--- a/config/locales/mailers/account_mailer.hu.yml
+++ b/config/locales/mailers/account_mailer.hu.yml
@@ -2,7 +2,7 @@ hu:
   account_mailer:
     welcome:
       subject: "Üdvözlünk a Jiki-nél!"
-      greeting: "Szia %{name},"
+      greeting: "Szia,"
       body_markdown: |
         Üdvözlünk a [Jiki](https://jiki.io)-nél! Nagyon örülök, hogy itt vagy.
 
@@ -12,11 +12,12 @@ hu:
 
         Jó szórakozást és élvezd az utat!
 
-        Jeremy
+        Üdv,  
+        Jeremy és a csapat
     account_deletion_confirmation:
       subject: "Fiók törlésének megerősítése"
       preview: "Kérjük, erősítsd meg, hogy véglegesen törölni szeretnéd a Jiki fiókodat"
-      greeting: "Szia %{name},"
+      greeting: "Szia,"
       body_markdown: |
         Kaptunk egy kérést a Jiki fiókod törlésére.
 

--- a/config/locales/mailers/devise_mailer.en.yml
+++ b/config/locales/mailers/devise_mailer.en.yml
@@ -4,15 +4,15 @@ en:
       confirmation_instructions:
         subject: "Confirm Your Email Address"
         preview: "Confirm your email address for your Jiki account"
-        greeting: "Hi %{name},"
+        greeting: "Hi there,"
         body_markdown: |
-          Please confirm your email address by clicking the button below.
+          Please confirm your email address is real by clicking the button below.
         cta: "Confirm My Email"
         footer: "If you didn't create a Jiki account, you can safely ignore this email."
       reset_password_instructions:
         subject: "Reset Your Password"
         preview: "Reset your password for your Jiki account"
-        greeting: "Hi %{name},"
+        greeting: "Hi there,"
         body_markdown: |
           We received a request to reset your password for your Jiki account.
         cta: "Reset My Password"

--- a/config/locales/mailers/devise_mailer.hu.yml
+++ b/config/locales/mailers/devise_mailer.hu.yml
@@ -4,7 +4,7 @@ hu:
       confirmation_instructions:
         subject: "Erősítsd meg az e-mail címedet"
         preview: "Erősítsd meg az e-mail címedet a Jiki fiókodhoz"
-        greeting: "Szia %{name},"
+        greeting: "Szia,"
         body_markdown: |
           Kérjük, erősítsd meg az e-mail címedet az alábbi gombra kattintva.
         cta: "E-mail cím megerősítése"
@@ -12,7 +12,7 @@ hu:
       reset_password_instructions:
         subject: "Jelszó visszaállítása"
         preview: "Állítsd vissza jelszavadat a Jiki fiókodhoz"
-        greeting: "Szia %{name},"
+        greeting: "Szia,"
         body_markdown: |
           Kaptunk egy kérést a Jiki fiókod jelszavának visszaállítására.
         cta: "Jelszó visszaállítása"

--- a/config/locales/mailers/premium_mailer.en.yml
+++ b/config/locales/mailers/premium_mailer.en.yml
@@ -2,23 +2,25 @@ en:
   premium_mailer:
     welcome_to_premium:
       subject: "Welcome to Jiki Premium!"
-      greeting: "Hi %{name},"
+      greeting: "Hi there,"
       body_markdown: |
         Thank you for subscribing to Jiki Premium!
 
-        You've taken a key step in accelerating your learning journey. Check out the [Premium page](https://jiki.io/articles/premium) for a list of all the features you now have access to.
+        You can see all the features you have access to on the [Premium page](https://jiki.io/premium). We hope you have loads of fun using Jiki and that we'll see you on a livestream soon!
 
         If you have any questions, just reply to this email.
 
-        Jeremy
+        Cheers,  
+        Jeremy & Team
     subscription_ended:
       subject: "Your Jiki subscription has ended"
-      greeting: "Hi %{name},"
+      greeting: "Hi there,"
       body_markdown: |
         Your Jiki Premium subscription has ended and you're now on our free plan.
 
-        You still have full access to all our core content — nothing's going anywhere! If you'd like to resubscribe, you can do so anytime on your [settings page](https://jiki.io/settings).
+        You still have full access to all our core Coding Fundamentals track. If you'd like to resubscribe, you can do so anytime on your [settings page](https://jiki.io/settings).
 
         Thanks for trying Jiki Premium.
 
-        Jeremy
+        Cheers,  
+        Jeremy & Team

--- a/test/controllers/auth/passwords_controller_test.rb
+++ b/test/controllers/auth/passwords_controller_test.rb
@@ -51,7 +51,7 @@ class Auth::PasswordsControllerTest < ApplicationControllerTest
 
     mail = ActionMailer::Base.deliveries.last
     assert_equal "Jelszó visszaállítása", mail.subject
-    assert_match "Szia József,", mail.html_part.body.to_s
+    assert_match "Szia,", mail.html_part.body.to_s
   end
 
   test "POST password reset with non-existent email still returns success (security)" do

--- a/test/mailers/account_mailer_test.rb
+++ b/test/mailers/account_mailer_test.rb
@@ -9,12 +9,12 @@ class AccountMailerTest < ActionMailer::TestCase
     assert_equal ["hello@mail.jiki.io"], mail.from
     assert_equal [user.email], mail.to
 
-    assert_match "Hi John Doe,", mail.html_part.body.to_s
-    assert_match "Jiki is designed to take you from complete beginner to confident coder", mail.html_part.body.to_s
+    assert_match "Hi there,", mail.html_part.body.to_s
+    assert_match "Jiki has been designed to take you from complete beginner to confident coder", mail.html_part.body.to_s
     assert_match "https://jiki.io", mail.html_part.body.to_s
 
-    assert_match "Hi John Doe,", mail.text_part.body.to_s
-    assert_match "Jiki is designed to take you from complete beginner to confident coder", mail.text_part.body.to_s
+    assert_match "Hi there,", mail.text_part.body.to_s
+    assert_match "Jiki has been designed to take you from complete beginner to confident coder", mail.text_part.body.to_s
   end
 
   test "welcome email renders with Hungarian locale" do
@@ -25,11 +25,11 @@ class AccountMailerTest < ActionMailer::TestCase
     assert_equal ["hello@mail.jiki.io"], mail.from
     assert_equal [user.email], mail.to
 
-    assert_match "Szia János Kovács,", mail.html_part.body.to_s
+    assert_match "Szia,", mail.html_part.body.to_s
     assert_match "strukturált, lineáris tanulási útvonalat kínál", mail.html_part.body.to_s
     assert_match "https://jiki.io", mail.html_part.body.to_s
 
-    assert_match "Szia János Kovács,", mail.text_part.body.to_s
+    assert_match "Szia,", mail.text_part.body.to_s
     assert_match "strukturált, lineáris tanulási útvonalat kínál", mail.text_part.body.to_s
   end
 
@@ -62,23 +62,7 @@ class AccountMailerTest < ActionMailer::TestCase
     mail = AccountMailer.welcome(user)
 
     assert_equal "Welcome to Jiki!", mail.subject
-    assert_match "Hi #{ERB::Util.html_escape(user.name)},", mail.html_part.body.to_s
-  end
-
-  test "welcome email uses user name in greeting" do
-    user = create(:user, name: "Test User")
-    mail = AccountMailer.welcome(user)
-
-    assert_match "Hi Test User,", mail.html_part.body.to_s
-    assert_match "Hi Test User,", mail.text_part.body.to_s
-  end
-
-  test "welcome email correctly escapes user names with apostrophes in HTML" do
-    user = create(:user, name: "Graig D'Amore")
-    mail = AccountMailer.welcome(user)
-
-    assert_match "Hi Graig D&#39;Amore,", mail.html_part.body.to_s
-    assert_match "Hi Graig D'Amore,", mail.text_part.body.to_s
+    assert_match "Hi there,", mail.html_part.body.to_s
   end
 
   test "welcome email includes Jiki link" do

--- a/test/mailers/devise_mailer_test.rb
+++ b/test/mailers/devise_mailer_test.rb
@@ -12,14 +12,14 @@ class DeviseMailerTest < ActionMailer::TestCase
     assert_equal [user.email], mail.to
 
     # Check HTML body contains English text
-    assert_match "Hi John Doe,", mail.html_part.body.to_s
+    assert_match "Hi there,", mail.html_part.body.to_s
     assert_match "We received a request to reset your password", mail.html_part.body.to_s
     assert_match "Reset My Password", mail.html_part.body.to_s
     assert_match "you can safely ignore this email", mail.html_part.body.to_s
     assert_match "expire in 6 hours", mail.html_part.body.to_s
 
     # Check text body
-    assert_match "Hi John Doe,", mail.text_part.body.to_s
+    assert_match "Hi there,", mail.text_part.body.to_s
     assert_match "We received a request to reset your password", mail.text_part.body.to_s
   end
 
@@ -34,14 +34,14 @@ class DeviseMailerTest < ActionMailer::TestCase
     assert_equal [user.email], mail.to
 
     # Check HTML body contains Hungarian text
-    assert_match "Szia János Kovács,", mail.html_part.body.to_s
+    assert_match "Szia,", mail.html_part.body.to_s
     assert_match "Kaptunk egy kérést a Jiki fiókod jelszavának visszaállítására", mail.html_part.body.to_s
     assert_match "Jelszó visszaállítása", mail.html_part.body.to_s
     assert_match "figyelmen kívül hagyhatod", mail.html_part.body.to_s
     assert_match "6 óra múlva lejár", mail.html_part.body.to_s
 
     # Check text body
-    assert_match "Szia János Kovács,", mail.text_part.body.to_s
+    assert_match "Szia,", mail.text_part.body.to_s
   end
 
   test "reset_password_instructions includes frontend URL with token" do
@@ -60,16 +60,6 @@ class DeviseMailerTest < ActionMailer::TestCase
 
     # Check URL in text body
     assert_match expected_url, mail.text_part.body.to_s
-  end
-
-  test "reset_password_instructions uses email when name is nil" do
-    user = create(:user, name: nil, email: "test@example.com", locale: "en")
-    token = "abc123"
-
-    mail = DeviseMailer.reset_password_instructions(user, token)
-
-    # Should use email in greeting when name is not available
-    assert_match "Hi test@example.com,", mail.html_part.body.to_s
   end
 
   test "reset_password_instructions compiles MJML to responsive HTML" do
@@ -138,12 +128,12 @@ class DeviseMailerTest < ActionMailer::TestCase
     assert_equal [user.email], mail.to
 
     # Check HTML body contains English text
-    assert_match "Hi John Doe,", mail.html_part.body.to_s
+    assert_match "Hi there,", mail.html_part.body.to_s
     assert_match "Please confirm your email address", mail.html_part.body.to_s
     assert_match "Confirm My Email", mail.html_part.body.to_s
 
     # Check text body
-    assert_match "Hi John Doe,", mail.text_part.body.to_s
+    assert_match "Hi there,", mail.text_part.body.to_s
     assert_match "Please confirm your email address", mail.text_part.body.to_s
   end
 
@@ -158,12 +148,12 @@ class DeviseMailerTest < ActionMailer::TestCase
     assert_equal [user.email], mail.to
 
     # Check HTML body contains Hungarian text
-    assert_match "Szia János Kovács,", mail.html_part.body.to_s
+    assert_match "Szia,", mail.html_part.body.to_s
     assert_match "erősítsd meg az e-mail címedet", mail.html_part.body.to_s
     assert_match "E-mail cím megerősítése", mail.html_part.body.to_s
 
     # Check text body
-    assert_match "Szia János Kovács,", mail.text_part.body.to_s
+    assert_match "Szia,", mail.text_part.body.to_s
   end
 
   test "confirmation_instructions includes frontend URL with token" do

--- a/test/mailers/premium_mailer_test.rb
+++ b/test/mailers/premium_mailer_test.rb
@@ -10,10 +10,10 @@ class PremiumMailerTest < ActionMailer::TestCase
     assert_equal ["hello@mail.jiki.io"], mail.from
     assert_equal [user.email], mail.to
 
-    assert_match "Hi John Doe,", mail.html_part.body.to_s
+    assert_match "Hi there,", mail.html_part.body.to_s
     assert_match "Thank you for subscribing to Jiki Premium", mail.html_part.body.to_s
 
-    assert_match "Hi John Doe,", mail.text_part.body.to_s
+    assert_match "Hi there,", mail.text_part.body.to_s
     assert_match "Thank you for subscribing to Jiki Premium", mail.text_part.body.to_s
   end
 
@@ -46,10 +46,10 @@ class PremiumMailerTest < ActionMailer::TestCase
     assert_equal ["hello@mail.jiki.io"], mail.from
     assert_equal [user.email], mail.to
 
-    assert_match "Hi John Doe,", mail.html_part.body.to_s
+    assert_match "Hi there,", mail.html_part.body.to_s
     assert_match "Your Jiki Premium subscription has ended", mail.html_part.body.to_s
 
-    assert_match "Hi John Doe,", mail.text_part.body.to_s
+    assert_match "Hi there,", mail.text_part.body.to_s
     assert_match "Your Jiki Premium subscription has ended", mail.text_part.body.to_s
   end
 
@@ -71,15 +71,6 @@ class PremiumMailerTest < ActionMailer::TestCase
 
     assert_match(/<table/, html_body)
     refute_match(/<mj-/, html_body)
-  end
-
-  # Edge cases
-  test "welcome_to_premium email correctly escapes user names with apostrophes in HTML" do
-    user = create(:user, name: "Graig D'Amore")
-    mail = PremiumMailer.welcome_to_premium(user)
-
-    assert_match "Hi Graig D&#39;Amore,", mail.html_part.body.to_s
-    assert_match "Hi Graig D'Amore,", mail.text_part.body.to_s
   end
 
   test "emails do not include unsubscribe headers" do

--- a/test/mailers/previews/notifications_mailer_preview.rb
+++ b/test/mailers/previews/notifications_mailer_preview.rb
@@ -1,0 +1,17 @@
+class NotificationsMailerPreview < ActionMailer::Preview
+  def badge_earned
+    NotificationsMailer.badge_earned(preview_user, preview_badge)
+  end
+
+  private
+  def preview_user = FactoryBot.build(:user)
+
+  def preview_badge
+    FactoryBot.build(
+      :member_badge,
+      email_subject: "You earned a new badge!",
+      email_content_markdown: "Congratulations on earning the **Member** badge. Welcome to the community!",
+      email_image_url: "https://cdn.jiki.io/emails/badge-member.jpg"
+    )
+  end
+end

--- a/test/mailers/previews/progression_mailer_preview.rb
+++ b/test/mailers/previews/progression_mailer_preview.rb
@@ -1,0 +1,10 @@
+class ProgressionMailerPreview < ActionMailer::Preview
+  def level_completed
+    ProgressionMailer.level_completed(preview_user_level)
+  end
+
+  private
+  def preview_user_level
+    UserLevel.new(user: FactoryBot.build(:user), level: FactoryBot.build(:level))
+  end
+end


### PR DESCRIPTION
## Summary
- Merge the greeting into the body section across all emails so each email is a single `%mj-text` block (no separate greeting section)
- Add a shared `Cheers, / Jeremy & Team` signature to non-transactional emails (premium ×2, account welcome en+hu, badge-earned, level-completed); transactional emails (devise ×2, account deletion) intentionally left without one
- Drop the personalised `Hi {name}` greeting in favour of a generic `Hi there,` / `Szia,`
- Copy refresh: welcome, account deletion, email confirmation, subscription-ended; premium link `/articles/premium` → `/premium`
- Standardise CTA buttons: `font-weight: 500`, `border-radius: 8px`
- Add previews for `NotificationsMailer` and `ProgressionMailer` (previously missing)
- Update mailer/controller tests for the new greeting + copy

## Test plan
- [ ] `bin/rails test` (passes via pre-commit hook)
- [ ] Visually check all emails at `/rails/mailers` — greeting sits directly above the body, signature renders tight, buttons restyled