### PR TITLE
Add avatar_url to SerializeUser

### DIFF
--- a/app/serializers/serialize_user.rb
+++ b/app/serializers/serialize_user.rb
@@ -9,6 +9,7 @@ class SerializeUser
       membership_type: user.data.membership_type,
       email: user.email,
       name: user.name,
+      avatar_url: user.avatar_url,
       provider: user.provider,
       email_confirmed: user.confirmed?,
       subscription_status: user.data.subscription_status,

--- a/test/serializers/serialize_user_test.rb
+++ b/test/serializers/serialize_user_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 class SerializeUserTest < ActiveSupport::TestCase
   test "serializes user with standard membership and never_subscribed status" do
-    user = create(:user, handle: "test_user", email: "test@example.com", name: "Test User")
+    user = create(:user, handle: "test_user", email: "test@example.com", name: "Test User",
+      avatar_url: "https://example.com/avatar.png")
 
     result = SerializeUser.(user)
 
@@ -10,6 +11,7 @@ class SerializeUserTest < ActiveSupport::TestCase
     assert_equal "standard", result[:membership_type]
     assert_equal "test@example.com", result[:email]
     assert_equal "Test User", result[:name]
+    assert_equal "https://example.com/avatar.png", result[:avatar_url]
     assert_equal "never_subscribed", result[:subscription_status]
     assert_nil result[:subscription]
     assert_equal :usd, result[:premium_prices][:currency]


### PR DESCRIPTION
## Summary
- Add `avatar_url` to `SerializeUser` so clients (e.g. `/internal/me`) can render the user's avatar.
- Update serializer test to assert the new field.

## Test plan
- [x] `bin/rails test test/serializers/serialize_user_test.rb`
- [x] Full suite + brakeman pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)