### PR TITLE
Make UserLesson::Start idempotent for existing lessons

### DIFF
--- a/app/commands/user_lesson/start.rb
+++ b/app/commands/user_lesson/start.rb
@@ -4,15 +4,18 @@ class UserLesson::Start
   initialize_with :user, :lesson
 
   def call
-    ActiveRecord::Base.transaction do
-      validate_can_start_lesson!
+    # Short-circuit before validation: re-starting an existing UserLesson
+    # (started or completed) is an idempotent no-op, regardless of where
+    # the user currently is in the course.
+    existing = UserLesson.find_by(user:, lesson:)
+    return existing if existing
 
-      UserLesson.find_create_or_find_by!(user:, lesson:) { |ul| ul.started_at = Time.current }.tap do |user_lesson|
-        # Only update tracking pointers on first creation
-        if user_lesson.just_created?
-          user_level.update!(current_user_lesson: user_lesson)
-          user_course.update!(current_user_level: user_level)
-        end
+    validate_can_start_lesson!
+
+    ActiveRecord::Base.transaction do
+      UserLesson.create_or_find_by!(user:, lesson:) { |ul| ul.started_at = Time.current }.tap do |user_lesson|
+        user_level.update!(current_user_lesson: user_lesson)
+        user_course.update!(current_user_level: user_level)
       end
     end
   end

--- a/app/commands/user_lesson/start.rb
+++ b/app/commands/user_lesson/start.rb
@@ -14,8 +14,11 @@ class UserLesson::Start
 
     ActiveRecord::Base.transaction do
       UserLesson.create_or_find_by!(user:, lesson:) { |ul| ul.started_at = Time.current }.tap do |user_lesson|
-        user_level.update!(current_user_lesson: user_lesson)
-        user_course.update!(current_user_level: user_level)
+        # Guard against a concurrent request winning the race in create_or_find_by!
+        if user_lesson.just_created?
+          user_level.update!(current_user_lesson: user_lesson)
+          user_course.update!(current_user_level: user_level)
+        end
       end
     end
   end

--- a/test/commands/user_lesson/start_test.rb
+++ b/test/commands/user_lesson/start_test.rb
@@ -111,10 +111,11 @@ class UserLesson::StartTest < ActiveSupport::TestCase
     completed_user_lesson2 = create(:user_lesson, user: user_course.user, lesson: lesson2, completed_at: Time.current)
     user_course.update!(current_user_level: user_level1)
 
+    result = nil
     assert_nothing_raised do
-      UserLesson::Start.(user_course.user, lesson2)
+      result = UserLesson::Start.(user_course.user, lesson2)
     end
-    assert_equal completed_user_lesson2.id, UserLesson.find_by(user: user_course.user, lesson: lesson2).id
+    assert_equal completed_user_lesson2.id, result.id
   end
 
   test "allows starting lesson in current level" do

--- a/test/commands/user_lesson/start_test.rb
+++ b/test/commands/user_lesson/start_test.rb
@@ -99,6 +99,24 @@ class UserLesson::StartTest < ActiveSupport::TestCase
     assert_equal "Complete the current level before starting lessons in the next level", error.message
   end
 
+  test "is idempotent for a completed lesson in a different level than current" do
+    user_course = create(:user_course)
+    level1 = create(:level, course: user_course.course, position: 1)
+    level2 = create(:level, course: user_course.course, position: 2)
+    lesson1 = create(:lesson, :exercise, level: level1)
+    lesson2 = create(:lesson, :exercise, level: level2)
+    user_level1 = create(:user_level, user: user_course.user, level: level1)
+    create(:user_level, user: user_course.user, level: level2)
+    create(:user_lesson, user: user_course.user, lesson: lesson1, completed_at: Time.current)
+    completed_user_lesson2 = create(:user_lesson, user: user_course.user, lesson: lesson2, completed_at: Time.current)
+    user_course.update!(current_user_level: user_level1)
+
+    assert_nothing_raised do
+      UserLesson::Start.(user_course.user, lesson2)
+    end
+    assert_equal completed_user_lesson2.id, UserLesson.find_by(user: user_course.user, lesson: lesson2).id
+  end
+
   test "allows starting lesson in current level" do
     user_level = create(:user_level)
     lesson = create(:lesson, :exercise, level: user_level.level)


### PR DESCRIPTION
## Summary
- Short-circuit `UserLesson::Start` when a `UserLesson` already exists for `(user, lesson)`, returning the existing record without running the level/lesson validation guards.
- Fixes a bug where re-hitting `POST /internal/user_lessons/:slug/start` on an already-completed lesson could raise `LevelNotCompletedError` (→ 422) when the user had moved on to a different level whose lessons were all complete.
- Adds a regression test covering this scenario.

## Test plan
- [x] `bin/rails test test/commands/user_lesson/start_test.rb` (all 15 tests pass)
- [x] Full suite via pre-commit hook (1673 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)