### PR TITLE
Add Premium badge awarded on upgrade

### DIFF
--- a/app/commands/user/upgrade_to_premium.rb
+++ b/app/commands/user/upgrade_to_premium.rb
@@ -10,10 +10,15 @@ class User::UpgradeToPremium
       user.data.update!(membership_type: 'premium')
     end
 
+    award_badge!
     send_welcome_email!
   end
 
   private
+  def award_badge!
+    AwardBadgeJob.perform_later(user, 'premium')
+  end
+
   def send_welcome_email!
     PremiumMailer.welcome_to_premium(user).deliver_later
   end

--- a/app/models/badges/premium_badge.rb
+++ b/app/models/badges/premium_badge.rb
@@ -1,0 +1,10 @@
+module Badges
+  class PremiumBadge < Badge
+    seed "Premium", "Became a Premium member",
+      fun_fact: "Thanks for supporting Jiki! Your premium membership helps us keep building."
+
+    def award_to?(user)
+      user.premium?
+    end
+  end
+end

--- a/test/commands/user/upgrade_to_premium_test.rb
+++ b/test/commands/user/upgrade_to_premium_test.rb
@@ -28,4 +28,12 @@ class User::UpgradeToPremiumTest < ActiveSupport::TestCase
 
     assert user.data.reload.premium?
   end
+
+  test "enqueues premium badge award when upgrading" do
+    user = create(:user)
+
+    assert_enqueued_with(job: AwardBadgeJob, args: [user, 'premium']) do
+      User::UpgradeToPremium.(user)
+    end
+  end
 end

--- a/test/models/badges/premium_badge_test.rb
+++ b/test/models/badges/premium_badge_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class Badges::PremiumBadgeTest < ActiveSupport::TestCase
+  test "has correct seed data" do
+    badge = Badge.find_by_slug!('premium') # rubocop:disable Rails/DynamicFindBy
+
+    assert_equal 'Premium', badge.name
+    assert_equal 'Became a Premium member', badge.description
+    refute badge.secret
+  end
+
+  test "award_to? returns true for premium users" do
+    badge = Badge.find_by_slug!('premium') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.data.update!(membership_type: 'premium')
+
+    assert badge.award_to?(user)
+  end
+
+  test "award_to? returns false for standard users" do
+    badge = Badge.find_by_slug!('premium') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+
+    refute badge.award_to?(user)
+  end
+end


### PR DESCRIPTION
## Summary
- New `Badges::PremiumBadge`, awarded when a user upgrades to premium
- `User::UpgradeToPremium` enqueues `AwardBadgeJob` for the `premium` slug after upgrade

## Test plan
- [ ] `bin/rails test test/models/badges/premium_badge_test.rb test/commands/user/upgrade_to_premium_test.rb`
- [ ] Upgrade a user to premium and confirm the badge is acquired

Note: front-end badge icon added separately at `front-end/curriculum/images/badge-icons/premium.svg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)