### PR TITLE
Add Collaborator badge for first message to Jiki

### DIFF
--- a/app/commands/assistant_conversation/add_user_message.rb
+++ b/app/commands/assistant_conversation/add_user_message.rb
@@ -5,6 +5,7 @@ class AssistantConversation::AddUserMessage
 
   def call
     AssistantConversation::AddMessage.(conversation, "user", content, timestamp)
+    AwardBadgeJob.perform_later(user, 'collaborator')
   end
 
   memoize

--- a/app/models/badges/collaborator_badge.rb
+++ b/app/models/badges/collaborator_badge.rb
@@ -1,0 +1,12 @@
+module Badges
+  class CollaboratorBadge < Badge
+    seed "Collaborator", "Sent your first message to Jiki",
+      fun_fact: "Two heads are better than one. Thanks for chatting with Jiki!"
+
+    def award_to?(user)
+      user.assistant_conversations.any? do |conversation|
+        conversation.messages.any? { |message| message["role"] == "user" }
+      end
+    end
+  end
+end

--- a/test/commands/assistant_conversation/add_user_message_test.rb
+++ b/test/commands/assistant_conversation/add_user_message_test.rb
@@ -13,4 +13,16 @@ class AssistantConversation::AddUserMessageTest < ActiveSupport::TestCase
 
     AssistantConversation::AddUserMessage.(user, lesson, content, timestamp)
   end
+
+  test "enqueues collaborator badge award" do
+    user = create(:user)
+    lesson = create(:lesson, :exercise, slug: "basic-movement")
+    conversation = build_stubbed(:assistant_conversation)
+    AssistantConversation::FindOrCreate.stubs(:call).returns(conversation)
+    AssistantConversation::AddMessage.stubs(:call)
+
+    assert_enqueued_with(job: AwardBadgeJob, args: [user, 'collaborator']) do
+      AssistantConversation::AddUserMessage.(user, lesson, "hi", "2026-01-01T00:00:00Z")
+    end
+  end
 end

--- a/test/models/badges/collaborator_badge_test.rb
+++ b/test/models/badges/collaborator_badge_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Badges::CollaboratorBadgeTest < ActiveSupport::TestCase
+  test "has correct seed data" do
+    badge = Badge.find_by_slug!('collaborator') # rubocop:disable Rails/DynamicFindBy
+
+    assert_equal 'Collaborator', badge.name
+    assert_equal 'Sent your first message to Jiki', badge.description
+    refute badge.secret
+  end
+
+  test "award_to? returns true when user has sent a message" do
+    badge = Badge.find_by_slug!('collaborator') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    lesson = create(:lesson, :exercise)
+    create(:assistant_conversation, user:, context: lesson,
+      messages: [{ role: "user", content: "hi", timestamp: "2026-01-01T00:00:00Z" }])
+
+    assert badge.award_to?(user)
+  end
+
+  test "award_to? returns false when user has no conversations" do
+    badge = Badge.find_by_slug!('collaborator') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+
+    refute badge.award_to?(user)
+  end
+
+  test "award_to? returns false when only assistant messages exist" do
+    badge = Badge.find_by_slug!('collaborator') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    lesson = create(:lesson, :exercise)
+    create(:assistant_conversation, user:, context: lesson,
+      messages: [{ role: "assistant", content: "hello", timestamp: "2026-01-01T00:00:00Z" }])
+
+    refute badge.award_to?(user)
+  end
+end


### PR DESCRIPTION
## Summary
- New `Badges::CollaboratorBadge`, awarded when a user has any user-role message in an `AssistantConversation`
- `AssistantConversation::AddUserMessage` enqueues `AwardBadgeJob` for the `collaborator` slug

## Test plan
- [ ] `bin/rails test test/models/badges/collaborator_badge_test.rb test/commands/assistant_conversation/add_user_message_test.rb`
- [ ] Send a chat message in a lesson and confirm the badge is acquired

Note: front-end badge icon added separately at `front-end/curriculum/images/badge-icons/collaborator.png` (copy of Jiki's avatar). Existing badge icons are SVG, so the front-end may need to accept `.png` for this slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)