### PR TITLE
Rename Collaborator badge to Sidekick

### DIFF
--- a/app/commands/assistant_conversation/add_user_message.rb
+++ b/app/commands/assistant_conversation/add_user_message.rb
@@ -5,7 +5,7 @@ class AssistantConversation::AddUserMessage
 
   def call
     AssistantConversation::AddMessage.(conversation, "user", content, timestamp)
-    AwardBadgeJob.perform_later(user, 'collaborator')
+    AwardBadgeJob.perform_later(user, 'sidekick')
   end
 
   memoize

--- a/app/models/badges/sidekick_badge.rb
+++ b/app/models/badges/sidekick_badge.rb
@@ -1,6 +1,6 @@
 module Badges
-  class CollaboratorBadge < Badge
-    seed "Collaborator", "Sent your first message to Jiki",
+  class SidekickBadge < Badge
+    seed "Sidekick", "Sent your first message to Jiki",
       fun_fact: "Two heads are better than one. Thanks for chatting with Jiki!"
 
     def award_to?(user)

--- a/test/commands/assistant_conversation/add_user_message_test.rb
+++ b/test/commands/assistant_conversation/add_user_message_test.rb
@@ -14,14 +14,14 @@ class AssistantConversation::AddUserMessageTest < ActiveSupport::TestCase
     AssistantConversation::AddUserMessage.(user, lesson, content, timestamp)
   end
 
-  test "enqueues collaborator badge award" do
+  test "enqueues sidekick badge award" do
     user = create(:user)
     lesson = create(:lesson, :exercise, slug: "basic-movement")
     conversation = build_stubbed(:assistant_conversation)
     AssistantConversation::FindOrCreate.stubs(:call).returns(conversation)
     AssistantConversation::AddMessage.stubs(:call)
 
-    assert_enqueued_with(job: AwardBadgeJob, args: [user, 'collaborator']) do
+    assert_enqueued_with(job: AwardBadgeJob, args: [user, 'sidekick']) do
       AssistantConversation::AddUserMessage.(user, lesson, "hi", "2026-01-01T00:00:00Z")
     end
   end

--- a/test/models/badges/sidekick_badge_test.rb
+++ b/test/models/badges/sidekick_badge_test.rb
@@ -1,16 +1,16 @@
 require "test_helper"
 
-class Badges::CollaboratorBadgeTest < ActiveSupport::TestCase
+class Badges::SidekickBadgeTest < ActiveSupport::TestCase
   test "has correct seed data" do
-    badge = Badge.find_by_slug!('collaborator') # rubocop:disable Rails/DynamicFindBy
+    badge = Badge.find_by_slug!('sidekick') # rubocop:disable Rails/DynamicFindBy
 
-    assert_equal 'Collaborator', badge.name
+    assert_equal 'Sidekick', badge.name
     assert_equal 'Sent your first message to Jiki', badge.description
     refute badge.secret
   end
 
   test "award_to? returns true when user has sent a message" do
-    badge = Badge.find_by_slug!('collaborator') # rubocop:disable Rails/DynamicFindBy
+    badge = Badge.find_by_slug!('sidekick') # rubocop:disable Rails/DynamicFindBy
     user = create(:user)
     lesson = create(:lesson, :exercise)
     create(:assistant_conversation, user:, context: lesson,
@@ -20,14 +20,14 @@ class Badges::CollaboratorBadgeTest < ActiveSupport::TestCase
   end
 
   test "award_to? returns false when user has no conversations" do
-    badge = Badge.find_by_slug!('collaborator') # rubocop:disable Rails/DynamicFindBy
+    badge = Badge.find_by_slug!('sidekick') # rubocop:disable Rails/DynamicFindBy
     user = create(:user)
 
     refute badge.award_to?(user)
   end
 
   test "award_to? returns false when only assistant messages exist" do
-    badge = Badge.find_by_slug!('collaborator') # rubocop:disable Rails/DynamicFindBy
+    badge = Badge.find_by_slug!('sidekick') # rubocop:disable Rails/DynamicFindBy
     user = create(:user)
     lesson = create(:lesson, :exercise)
     create(:assistant_conversation, user:, context: lesson,


### PR DESCRIPTION
## Summary
- Renames `Badges::CollaboratorBadge` → `Badges::SidekickBadge` (slug `collaborator` → `sidekick`)
- Updates `AssistantConversation::AddUserMessage` to enqueue the new slug
- Front-end badge icon renamed to `sidekick.svg`

## Test plan
- [ ] `bin/rails test test/models/badges/sidekick_badge_test.rb test/commands/assistant_conversation/add_user_message_test.rb`
- [ ] Confirm the badge displays with the new name on the achievements page

Note: production will need the old `Badges::CollaboratorBadge` row + its acquired records cleaned up (done locally via raw SQL because STI can't instantiate the orphan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)