### PR TITLE
Bootstrap new users on Google signup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/jiki-education/config.git
-  revision: cff25ef7f974f0c789e9ac1b99e966e04201f648
+  revision: d939929ee64f0bc2d09f563f210d6514005c8989
   branch: main
   specs:
     jiki-config (0.1.0)

--- a/app/controllers/auth/google_oauth_controller.rb
+++ b/app/controllers/auth/google_oauth_controller.rb
@@ -3,6 +3,8 @@ module Auth
     def create
       user = Auth::AuthenticateWithGoogle.(params[:code])
 
+      User::Bootstrap.(user) if user.previously_new_record?
+
       sign_in_with_2fa_guard!(user)
     rescue InvalidGoogleTokenError => e
       render json: {

--- a/test/controllers/auth/google_oauth_controller_test.rb
+++ b/test/controllers/auth/google_oauth_controller_test.rb
@@ -11,6 +11,12 @@ class Auth::GoogleOauthControllerTest < ApplicationControllerTest
 
     Auth::VerifyGoogleToken.stubs(:call).returns(google_payload)
 
+    user_capture = nil
+    User::Bootstrap.expects(:call).with do |user|
+      user_capture = user
+      user.email == 'newuser@gmail.com'
+    end
+
     assert_difference 'User.count', 1 do
       post auth_google_path, params: { code: 'valid-google-auth-code' }, as: :json
     end
@@ -20,6 +26,7 @@ class Auth::GoogleOauthControllerTest < ApplicationControllerTest
     # Check user was created correctly
     user = User.find_by(email: 'newuser@gmail.com')
     refute_nil user
+    assert_equal user.id, user_capture&.id
     assert_equal 'google-user-id-123', user.google_id
     assert_equal 'google', user.provider
     assert user.confirmed?
@@ -48,6 +55,8 @@ class Auth::GoogleOauthControllerTest < ApplicationControllerTest
 
     Auth::VerifyGoogleToken.stubs(:call).returns(google_payload)
 
+    User::Bootstrap.expects(:call).never
+
     assert_no_difference 'User.count' do
       post auth_google_path, params: { code: 'valid-google-auth-code' }, as: :json
     end
@@ -70,6 +79,8 @@ class Auth::GoogleOauthControllerTest < ApplicationControllerTest
     }
 
     Auth::VerifyGoogleToken.stubs(:call).returns(google_payload)
+
+    User::Bootstrap.expects(:call).never
 
     assert_no_difference 'User.count' do
       post auth_google_path, params: { code: 'valid-google-auth-code' }, as: :json
@@ -132,6 +143,7 @@ class Auth::GoogleOauthControllerTest < ApplicationControllerTest
     }
 
     Auth::VerifyGoogleToken.stubs(:call).returns(google_payload)
+    User::Bootstrap.stubs(:call)
 
     post auth_google_path, params: { code: 'valid-google-auth-code' }, as: :json
 


### PR DESCRIPTION
## Summary
Pre-existing bug: `Auth::AuthenticateWithGoogle` returns a freshly-created user without ever calling `User::Bootstrap`. Google-first users were missing the welcome email, course enrollment, and member badge — only email signups got those.

Fix: in `Auth::GoogleOauthController#create`, call `User::Bootstrap.(user) if user.previously_new_record?`. Existing-user paths (find by `google_id`, find by `email` to link an account) are unaffected.

## Test plan
- [x] `bin/rails test` — 1682 runs, 0 failures
- [x] Brakeman clean
- [ ] Manual: sign up a fresh Google account in staging → confirm welcome email arrives, course is enrolled, member badge awarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)