### PR TITLE
Add rake task to dump curriculum tables for PostHog DW

### DIFF
--- a/lib/tasks/posthog.rake
+++ b/lib/tasks/posthog.rake
@@ -3,7 +3,7 @@ require "csv"
 namespace :posthog do
   desc "Dump curriculum tables to CSV for upload to PostHog Data Warehouse"
   task dump_warehouse: :environment do
-    output_dir = Rails.root.join("tmp/posthog")
+    output_dir = Rails.root.join("tmp", "posthog")
     FileUtils.mkdir_p(output_dir)
 
     dump_to_csv(output_dir.join("lessons.csv"), Lesson.all, %i[id slug title type position level_id])

--- a/lib/tasks/posthog.rake
+++ b/lib/tasks/posthog.rake
@@ -1,0 +1,26 @@
+require "csv"
+
+namespace :posthog do
+  desc "Dump curriculum tables to CSV for upload to PostHog Data Warehouse"
+  task dump_warehouse: :environment do
+    output_dir = Rails.root.join("tmp/posthog")
+    FileUtils.mkdir_p(output_dir)
+
+    dump_to_csv(output_dir.join("lessons.csv"), Lesson.all, %i[id slug title type position level_id])
+    dump_to_csv(output_dir.join("levels.csv"),  Level.all,  %i[id slug title position course_id])
+    dump_to_csv(output_dir.join("projects.csv"), Project.all, %i[id slug title exercise_slug])
+
+    puts "CSVs written to #{output_dir}"
+    puts "Next: upload them to Cloudflare R2 and re-sync the linked sources in PostHog."
+  end
+
+  def dump_to_csv(path, scope, columns)
+    CSV.open(path, "w") do |csv|
+      csv << columns
+      scope.find_each do |record|
+        csv << columns.map { |col| record.public_send(col) }
+      end
+    end
+    puts "Wrote #{scope.count} rows to #{path}"
+  end
+end

--- a/lib/tasks/posthog.rake
+++ b/lib/tasks/posthog.rake
@@ -15,12 +15,14 @@ namespace :posthog do
   end
 
   def dump_to_csv(path, scope, columns)
+    row_count = 0
     CSV.open(path, "w") do |csv|
       csv << columns
       scope.find_each do |record|
         csv << columns.map { |col| record.public_send(col) }
+        row_count += 1
       end
     end
-    puts "Wrote #{scope.count} rows to #{path}"
+    puts "Wrote #{row_count} rows to #{path}"
   end
 end


### PR DESCRIPTION
## Summary
Adds \`bin/rails posthog:dump_warehouse\` which writes \`lessons.csv\`, \`levels.csv\`, \`projects.csv\` to \`tmp/posthog/\`. Columns chosen for analytics joins: \`id\`, \`slug\`, \`title\`, and the foreign-key columns relevant for cross-table HogQL queries.

Why: lets us run HogQL Insights that group events by id (stable join key from event properties like \`lesson_id\`) but label them by current \`title\` from the warehouse table — without bloating every event with denormalized title strings.

## Manual followup (one-time, can do later)
1. Create a Cloudflare R2 bucket (e.g. \`posthog-warehouse\`)
2. \`bin/rails posthog:dump_warehouse\` → upload CSVs to the bucket
3. In PostHog: Data Pipelines → Sources → add R2 source pointing at each CSV
4. Re-run + re-upload when curriculum changes (rare)

## Test plan
- [x] Ran locally: 120 lessons + 17 levels + 11 projects dumped
- [x] \`bin/rails test\` — 1682 runs, 0 failures
- [x] Brakeman clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)