### PR TITLE
Verify Cloudflare Turnstile tokens on auth + chat endpoints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/jiki-education/config.git
-  revision: d939929ee64f0bc2d09f563f210d6514005c8989
+  revision: ce0ce13b389503a944161b41ef9781ab74ce9a99
   branch: main
   specs:
     jiki-config (0.1.0)

--- a/app/commands/captcha/verify_turnstile_token.rb
+++ b/app/commands/captcha/verify_turnstile_token.rb
@@ -1,7 +1,6 @@
 module Captcha
   class VerifyTurnstileToken
     include Mandate
-    include HTTParty
 
     SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify".freeze
 
@@ -10,7 +9,7 @@ module Captcha
     def call
       return false if token.blank?
 
-      response = self.class.post(
+      response = HTTParty.post(
         SITEVERIFY_URL,
         body: payload.to_json,
         headers: { "Content-Type" => "application/json" },

--- a/app/commands/captcha/verify_turnstile_token.rb
+++ b/app/commands/captcha/verify_turnstile_token.rb
@@ -1,0 +1,49 @@
+module Captcha
+  class VerifyTurnstileToken
+    include Mandate
+    include HTTParty
+
+    SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify".freeze
+
+    initialize_with :token, remote_ip: nil
+
+    def call
+      return false if token.blank?
+
+      response = self.class.post(
+        SITEVERIFY_URL,
+        body: payload.to_json,
+        headers: { "Content-Type" => "application/json" },
+        timeout: 5
+      )
+
+      unless response.success?
+        log_outage("siteverify returned HTTP #{response.code}")
+        return true
+      end
+
+      parsed = JSON.parse(response.body)
+      return true if parsed["success"]
+
+      Rails.logger.warn("[Turnstile] verification failed: #{parsed['error-codes']}")
+      false
+    rescue StandardError => e
+      log_outage("siteverify request raised: #{e.class}: #{e.message}")
+      true
+    end
+
+    private
+    def payload
+      { secret:, response: token }.tap do |p|
+        p[:remoteip] = remote_ip if remote_ip.present?
+      end
+    end
+
+    def secret = Jiki.secrets.turnstile_secret_key
+
+    def log_outage(message)
+      Rails.logger.error("[Turnstile] #{message} - failing open")
+      Sentry.capture_message("Turnstile siteverify outage: #{message}", level: :warning) if defined?(Sentry)
+    end
+  end
+end

--- a/app/commands/gemini/translate.rb
+++ b/app/commands/gemini/translate.rb
@@ -1,15 +1,14 @@
 class Gemini::Translate
   include Mandate
-  include HTTParty
 
-  base_uri 'https://generativelanguage.googleapis.com'
+  API_BASE_URL = 'https://generativelanguage.googleapis.com'.freeze
 
   initialize_with :prompt, :schema, model: :flash
 
   def call
     validate!
 
-    response = self.class.post(
+    response = HTTParty.post(
       api_endpoint,
       body: request_payload.to_json,
       headers: {
@@ -42,7 +41,7 @@ class Gemini::Translate
   end
 
   memoize
-  def api_endpoint = "/v1beta/models/#{model_name}:generateContent"
+  def api_endpoint = "#{API_BASE_URL}/v1beta/models/#{model_name}:generateContent"
 
   memoize
   def request_payload

--- a/app/commands/llm/exec.rb
+++ b/app/commands/llm/exec.rb
@@ -1,13 +1,12 @@
 class LLM::Exec
   include Mandate
-  include HTTParty
 
   initialize_with :service, :model, :prompt, :spi_endpoint, additional_params: {}, stream_channel: nil
 
   def call
     validate!
 
-    response = self.class.post(
+    response = HTTParty.post(
       llm_proxy_url,
       body: payload.to_json,
       headers: { 'Content-Type' => 'application/json' },

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -1,5 +1,9 @@
 class Auth::PasswordsController < Devise::PasswordsController
+  include TurnstileVerifiable
+
   respond_to :json
+
+  before_action :verify_turnstile!, only: :create
 
   def create
     self.resource = resource_class.send_reset_password_instructions(resource_params)

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -1,5 +1,9 @@
 class Auth::RegistrationsController < Devise::RegistrationsController
+  include TurnstileVerifiable
+
   respond_to :json
+
+  before_action :verify_turnstile!, only: :create
 
   def create
     super do |resource|

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -1,7 +1,11 @@
 class Auth::SessionsController < Devise::SessionsController
+  include TurnstileVerifiable
+
   respond_to :json
 
   OTP_SESSION_TIMEOUT = 5.minutes
+
+  before_action :verify_turnstile!, only: :create
 
   # Override create to intercept admin logins for 2FA
   def create

--- a/app/controllers/concerns/turnstile_verifiable.rb
+++ b/app/controllers/concerns/turnstile_verifiable.rb
@@ -1,0 +1,15 @@
+module TurnstileVerifiable
+  extend ActiveSupport::Concern
+
+  private
+  def verify_turnstile!
+    return render_403(:invalid_captcha) if params[:cf_turnstile_response].blank?
+    return if Captcha::VerifyTurnstileToken.(params[:cf_turnstile_response], remote_ip: turnstile_remote_ip)
+
+    render_403(:invalid_captcha)
+  end
+
+  def turnstile_remote_ip
+    request.headers["CF-Connecting-IP"].presence || request.remote_ip
+  end
+end

--- a/app/controllers/internal/assistant_conversations_controller.rb
+++ b/app/controllers/internal/assistant_conversations_controller.rb
@@ -1,4 +1,8 @@
 class Internal::AssistantConversationsController < Internal::BaseController
+  include TurnstileVerifiable
+
+  before_action :verify_turnstile!, only: %i[create create_user_message]
+
   def create
     context = find_context
     return render_404(context_not_found_key) unless context

--- a/config/locales/api_errors.en.yml
+++ b/config/locales/api_errors.en.yml
@@ -8,6 +8,7 @@ en:
     access_denied: "Access denied"
     premium_required: "This feature is only available to premium members"
     invalid_signature: "Invalid signature"
+    invalid_captcha: "Captcha verification failed"
 
     # Token errors
     invalid_token: "Token is invalid or has expired"

--- a/test/commands/captcha/verify_turnstile_token_test.rb
+++ b/test/commands/captcha/verify_turnstile_token_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class Captcha::VerifyTurnstileTokenTest < ActiveSupport::TestCase
+  SITEVERIFY_URL = Captcha::VerifyTurnstileToken::SITEVERIFY_URL
+
+  test "returns true when siteverify reports success" do
+    stub = stub_request(:post, SITEVERIFY_URL).
+      with(body: hash_including(secret: Jiki.secrets.turnstile_secret_key, response: "good-token")).
+      to_return(status: 200, body: { success: true }.to_json, headers: { "Content-Type" => "application/json" })
+
+    assert Captcha::VerifyTurnstileToken.("good-token")
+    assert_requested stub
+  end
+
+  test "includes remote_ip in payload when provided" do
+    stub = stub_request(:post, SITEVERIFY_URL).
+      with(body: hash_including(remoteip: "203.0.113.7")).
+      to_return(status: 200, body: { success: true }.to_json)
+
+    assert Captcha::VerifyTurnstileToken.("token", remote_ip: "203.0.113.7")
+    assert_requested stub
+  end
+
+  test "omits remote_ip from payload when blank" do
+    stub = stub_request(:post, SITEVERIFY_URL).
+      with { |req| !JSON.parse(req.body).key?("remoteip") }.
+      to_return(status: 200, body: { success: true }.to_json)
+
+    assert Captcha::VerifyTurnstileToken.("token")
+    assert_requested stub
+  end
+
+  test "returns false when token is blank without calling siteverify" do
+    stub_request(:post, SITEVERIFY_URL) # no .to_return — would fail if hit
+
+    refute Captcha::VerifyTurnstileToken.(nil)
+    refute Captcha::VerifyTurnstileToken.("")
+    assert_not_requested :post, SITEVERIFY_URL
+  end
+
+  test "returns false when siteverify returns success false" do
+    stub_request(:post, SITEVERIFY_URL).
+      to_return(status: 200, body: { success: false, "error-codes" => ["invalid-input-response"] }.to_json)
+
+    refute Captcha::VerifyTurnstileToken.("bad-token")
+  end
+
+  test "fails open (returns true) on non-2xx response from siteverify" do
+    stub_request(:post, SITEVERIFY_URL).to_return(status: 502, body: "")
+
+    assert Captcha::VerifyTurnstileToken.("token")
+  end
+
+  test "fails open (returns true) on network error" do
+    stub_request(:post, SITEVERIFY_URL).to_timeout
+
+    assert Captcha::VerifyTurnstileToken.("token")
+  end
+end

--- a/test/controllers/auth/passwords_controller_test.rb
+++ b/test/controllers/auth/passwords_controller_test.rb
@@ -6,11 +6,9 @@ class Auth::PasswordsControllerTest < ApplicationControllerTest
   end
 
   test "POST password reset sends reset instructions" do
-    post user_password_path, params: {
-      user: {
-        email: "test@example.com"
-      }
-    }, as: :json
+    post user_password_path, params: with_turnstile(
+      user: { email: "test@example.com" }
+    ), as: :json
 
     assert_response :ok
 
@@ -23,11 +21,9 @@ class Auth::PasswordsControllerTest < ApplicationControllerTest
     Jiki.config.stubs(:frontend_base_url).returns("http://test.frontend.com")
 
     assert_emails 1 do
-      post user_password_path, params: {
-        user: {
-          email: "test@example.com"
-        }
-      }, as: :json
+      post user_password_path, params: with_turnstile(
+        user: { email: "test@example.com" }
+      ), as: :json
     end
 
     mail = ActionMailer::Base.deliveries.last
@@ -43,11 +39,9 @@ class Auth::PasswordsControllerTest < ApplicationControllerTest
   test "POST password reset email respects user locale" do
     create(:user, :hungarian, email: "magyar@example.com", name: "József")
 
-    post user_password_path, params: {
-      user: {
-        email: "magyar@example.com"
-      }
-    }, as: :json
+    post user_password_path, params: with_turnstile(
+      user: { email: "magyar@example.com" }
+    ), as: :json
 
     mail = ActionMailer::Base.deliveries.last
     assert_equal "Jelszó visszaállítása", mail.subject
@@ -55,16 +49,33 @@ class Auth::PasswordsControllerTest < ApplicationControllerTest
   end
 
   test "POST password reset with non-existent email still returns success (security)" do
-    post user_password_path, params: {
-      user: {
-        email: "nonexistent@example.com"
-      }
-    }, as: :json
+    post user_password_path, params: with_turnstile(
+      user: { email: "nonexistent@example.com" }
+    ), as: :json
 
     assert_response :ok
 
     json = response.parsed_body
     assert_equal "Reset instructions sent to nonexistent@example.com", json["message"]
+  end
+
+  test "POST password reset returns 403 invalid_captcha when Turnstile token missing" do
+    post user_password_path, params: {
+      user: { email: "test@example.com" }
+    }, as: :json
+
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
+  end
+
+  test "POST password reset returns 403 invalid_captcha when siteverify rejects token" do
+    WebMock.stub_request(:post, Captcha::VerifyTurnstileToken::SITEVERIFY_URL).
+      to_return(status: 200, body: { success: false }.to_json)
+
+    post user_password_path, params: with_turnstile(
+      user: { email: "test@example.com" }
+    ), as: :json
+
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
   end
 
   test "PATCH password reset updates password with valid token" do
@@ -85,12 +96,9 @@ class Auth::PasswordsControllerTest < ApplicationControllerTest
     assert_equal "Password has been reset successfully", json["message"]
 
     # Verify the user can login with new password
-    post user_session_path, params: {
-      user: {
-        email: "test@example.com",
-        password: "newpassword123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "test@example.com", password: "newpassword123" }
+    ), as: :json
 
     assert_response :ok
   end

--- a/test/controllers/auth/registrations_controller_test.rb
+++ b/test/controllers/auth/registrations_controller_test.rb
@@ -7,7 +7,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
 
   test "POST signup creates a new user with valid params" do
     assert_difference("User.count", 1) do
-      post user_registration_path, params: {
+      post user_registration_path, params: with_turnstile(
         user: {
           email: "newuser@example.com",
           password: "password123",
@@ -15,7 +15,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
           name: "New User",
           handle: "newuser"
         }
-      }, as: :json
+      ), as: :json
     end
 
     assert_response :created
@@ -29,13 +29,13 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
   end
 
   test "POST signup does not create a session for unconfirmed user" do
-    post user_registration_path, params: {
+    post user_registration_path, params: with_turnstile(
       user: {
         email: "newuser@example.com",
         password: "password123",
         password_confirmation: "password123"
       }
-    }, as: :json
+    ), as: :json
 
     assert_response :created
 
@@ -46,13 +46,13 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
 
   test "POST signup sends confirmation email" do
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post user_registration_path, params: {
+      post user_registration_path, params: with_turnstile(
         user: {
           email: "newuser@example.com",
           password: "password123",
           password_confirmation: "password123"
         }
-      }, as: :json
+      ), as: :json
     end
 
     assert_response :created
@@ -67,7 +67,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
       job: ActionMailer::MailDeliveryJob,
       args: ->(args) { args[0] == "AccountMailer" && args[1] == "welcome" }
     ) do
-      post user_registration_path, params: {
+      post user_registration_path, params: with_turnstile(
         user: {
           email: "bootstrap@example.com",
           password: "password123",
@@ -75,7 +75,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
           name: "Bootstrap User",
           handle: "bootstrapuser"
         }
-      }, as: :json
+      ), as: :json
     end
 
     assert_response :created
@@ -83,7 +83,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
 
   test "POST signup does not call User::Bootstrap on failed registration" do
     assert_no_enqueued_jobs do
-      post user_registration_path, params: {
+      post user_registration_path, params: with_turnstile(
         user: {
           email: "invalid-email",
           password: "password123",
@@ -91,7 +91,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
           name: "Invalid User",
           handle: "invaliduser"
         }
-      }, as: :json
+      ), as: :json
     end
 
     assert_response :unprocessable_entity
@@ -99,7 +99,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
 
   test "POST signup returns error with invalid email" do
     assert_no_difference("User.count") do
-      post user_registration_path, params: {
+      post user_registration_path, params: with_turnstile(
         user: {
           email: "invalid-email",
           password: "password123",
@@ -107,7 +107,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
           name: "New User",
           handle: "newuser"
         }
-      }, as: :json
+      ), as: :json
     end
 
     assert_response :unprocessable_entity
@@ -120,7 +120,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
 
   test "POST signup returns error with password mismatch" do
     assert_no_difference("User.count") do
-      post user_registration_path, params: {
+      post user_registration_path, params: with_turnstile(
         user: {
           email: "newuser@example.com",
           password: "password123",
@@ -128,7 +128,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
           name: "New User",
           handle: "newuser"
         }
-      }, as: :json
+      ), as: :json
     end
 
     assert_response :unprocessable_entity
@@ -142,7 +142,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
     create(:user, email: "existing@example.com")
 
     assert_no_difference("User.count") do
-      post user_registration_path, params: {
+      post user_registration_path, params: with_turnstile(
         user: {
           email: "existing@example.com",
           password: "password123",
@@ -150,7 +150,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
           name: "New User",
           handle: "newuser"
         }
-      }, as: :json
+      ), as: :json
     end
 
     assert_response :unprocessable_entity
@@ -162,7 +162,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
 
   test "POST signup returns error with short password" do
     assert_no_difference("User.count") do
-      post user_registration_path, params: {
+      post user_registration_path, params: with_turnstile(
         user: {
           email: "newuser@example.com",
           password: "short",
@@ -170,7 +170,7 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
           name: "New User",
           handle: "newuser"
         }
-      }, as: :json
+      ), as: :json
     end
 
     assert_response :unprocessable_entity
@@ -182,12 +182,12 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
 
   test "POST signup auto-generates handle from email when not provided" do
     assert_difference("User.count", 1) do
-      post user_registration_path, params: {
+      post user_registration_path, params: with_turnstile(
         user: {
           email: "john.doe@example.com",
           password: "password123"
         }
-      }, as: :json
+      ), as: :json
     end
 
     assert_response :created
@@ -203,13 +203,13 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
   end
 
   test "POST signup accepts user-provided handle when provided" do
-    post user_registration_path, params: {
+    post user_registration_path, params: with_turnstile(
       user: {
         email: "john.doe@example.com",
         password: "password123",
         handle: "custom-handle"
       }
-    }, as: :json
+    ), as: :json
 
     assert_response :created
 
@@ -224,16 +224,45 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
   test "POST signup handles collision by appending random hex suffix" do
     create(:user, email: "john@other.com", handle: "john-doe")
 
-    post user_registration_path, params: {
+    post user_registration_path, params: with_turnstile(
       user: {
         email: "john.doe@example.com",
         password: "password123"
       }
-    }, as: :json
+    ), as: :json
 
     assert_response :created
 
     user = User.last
     assert_match(/\Ajohn-doe-[a-f0-9]{6}\z/, user.handle)
+  end
+
+  test "POST signup returns 403 invalid_captcha when Turnstile token missing" do
+    assert_no_difference("User.count") do
+      post user_registration_path, params: {
+        user: {
+          email: "newuser@example.com",
+          password: "password123"
+        }
+      }, as: :json
+    end
+
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
+  end
+
+  test "POST signup returns 403 invalid_captcha when Turnstile siteverify rejects token" do
+    WebMock.stub_request(:post, Captcha::VerifyTurnstileToken::SITEVERIFY_URL).
+      to_return(status: 200, body: { success: false, "error-codes" => ["invalid-input-response"] }.to_json)
+
+    assert_no_difference("User.count") do
+      post user_registration_path, params: with_turnstile(
+        user: {
+          email: "newuser@example.com",
+          password: "password123"
+        }
+      ), as: :json
+    end
+
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
   end
 end

--- a/test/controllers/auth/sessions_controller_test.rb
+++ b/test/controllers/auth/sessions_controller_test.rb
@@ -6,12 +6,9 @@ class Auth::SessionsControllerTest < ApplicationControllerTest
   end
 
   test "POST login returns user data with valid credentials" do
-    post user_session_path, params: {
-      user: {
-        email: "test@example.com",
-        password: "password123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "test@example.com", password: "password123" }
+    ), as: :json
 
     assert_response :ok
 
@@ -23,23 +20,17 @@ class Auth::SessionsControllerTest < ApplicationControllerTest
   end
 
   test "POST login returns error with invalid password" do
-    post user_session_path, params: {
-      user: {
-        email: "test@example.com",
-        password: "wrongpassword"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "test@example.com", password: "wrongpassword" }
+    ), as: :json
 
     assert_json_error(:unauthorized, error_type: :invalid_credentials)
   end
 
   test "POST login returns error with non-existent email" do
-    post user_session_path, params: {
-      user: {
-        email: "nonexistent@example.com",
-        password: "password123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "nonexistent@example.com", password: "password123" }
+    ), as: :json
 
     assert_json_error(:unauthorized, error_type: :invalid_credentials)
   end
@@ -47,12 +38,9 @@ class Auth::SessionsControllerTest < ApplicationControllerTest
   test "POST login returns unconfirmed error for unconfirmed user" do
     create(:user, :unconfirmed, email: "unconfirmed@example.com", password: "password123")
 
-    post user_session_path, params: {
-      user: {
-        email: "unconfirmed@example.com",
-        password: "password123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "unconfirmed@example.com", password: "password123" }
+    ), as: :json
 
     assert_response :unauthorized
 
@@ -64,12 +52,9 @@ class Auth::SessionsControllerTest < ApplicationControllerTest
   test "POST login does not create session for unconfirmed user" do
     create(:user, :unconfirmed, email: "unconfirmed@example.com", password: "password123")
 
-    post user_session_path, params: {
-      user: {
-        email: "unconfirmed@example.com",
-        password: "password123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "unconfirmed@example.com", password: "password123" }
+    ), as: :json
 
     assert_response :unauthorized
 
@@ -80,12 +65,9 @@ class Auth::SessionsControllerTest < ApplicationControllerTest
 
   test "DELETE logout clears session" do
     # Login first
-    post user_session_path, params: {
-      user: {
-        email: "test@example.com",
-        password: "password123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "test@example.com", password: "password123" }
+    ), as: :json
 
     assert_response :ok
 
@@ -106,16 +88,33 @@ class Auth::SessionsControllerTest < ApplicationControllerTest
     assert_response :unauthorized
   end
 
+  # Turnstile tests
+  test "POST login returns 403 invalid_captcha when token missing" do
+    post user_session_path, params: {
+      user: { email: "test@example.com", password: "password123" }
+    }, as: :json
+
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
+  end
+
+  test "POST login returns 403 invalid_captcha when siteverify rejects token" do
+    WebMock.stub_request(:post, Captcha::VerifyTurnstileToken::SITEVERIFY_URL).
+      to_return(status: 200, body: { success: false }.to_json)
+
+    post user_session_path, params: with_turnstile(
+      user: { email: "test@example.com", password: "password123" }
+    ), as: :json
+
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
+  end
+
   # 2FA Tests
   test "POST login for admin without 2FA setup returns 2fa_setup_required" do
     admin = create(:user, :admin, email: "admin@example.com", password: "password123")
 
-    post user_session_path, params: {
-      user: {
-        email: "admin@example.com",
-        password: "password123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "admin@example.com", password: "password123" }
+    ), as: :json
 
     assert_response :ok
 
@@ -138,12 +137,9 @@ class Auth::SessionsControllerTest < ApplicationControllerTest
     User::GenerateOtpSecret.(admin)
     User::EnableOtp.(admin)
 
-    post user_session_path, params: {
-      user: {
-        email: "admin@example.com",
-        password: "password123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "admin@example.com", password: "password123" }
+    ), as: :json
 
     assert_response :ok
 
@@ -162,12 +158,9 @@ class Auth::SessionsControllerTest < ApplicationControllerTest
     User::EnableOtp.(admin)
 
     # Login - should return 2fa_required
-    post user_session_path, params: {
-      user: {
-        email: "admin@example.com",
-        password: "password123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "admin@example.com", password: "password123" }
+    ), as: :json
 
     assert_response :ok
     assert_equal "2fa_required", response.parsed_body["status"]
@@ -178,12 +171,9 @@ class Auth::SessionsControllerTest < ApplicationControllerTest
   end
 
   test "POST login for non-admin signs in normally" do
-    post user_session_path, params: {
-      user: {
-        email: "test@example.com",
-        password: "password123"
-      }
-    }, as: :json
+    post user_session_path, params: with_turnstile(
+      user: { email: "test@example.com", password: "password123" }
+    ), as: :json
 
     assert_response :ok
     assert_json_response({

--- a/test/controllers/auth/two_factor_controller_test.rb
+++ b/test/controllers/auth/two_factor_controller_test.rb
@@ -135,12 +135,12 @@ class Auth::TwoFactorControllerTest < ApplicationControllerTest
   def setup_otp_session(user, timestamp: Time.current)
     # Simulate the session state that would be set by the login controller
     # In integration tests, we need to set this via a login request
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: {
         email: user.email,
         password: "password123"
       }
-    }, as: :json
+    ), as: :json
 
     # If we need to test expired sessions, we manipulate the session directly
     return unless timestamp != Time.current
@@ -149,12 +149,12 @@ class Auth::TwoFactorControllerTest < ApplicationControllerTest
     # since we can't easily manipulate sessions in controller tests
     # Instead, we'll travel in time
     travel_to(timestamp) do
-      post user_session_path, params: {
+      post user_session_path, params: with_turnstile(
         user: {
           email: user.email,
           password: "password123"
         }
-      }, as: :json
+      ), as: :json
     end
   end
 

--- a/test/controllers/internal/assistant_conversations_controller_test.rb
+++ b/test/controllers/internal/assistant_conversations_controller_test.rb
@@ -16,7 +16,7 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
     @current_user.data.update!(membership_type: "premium")
 
     post internal_assistant_conversations_path,
-      params: { lesson_slug: "basic-movement" },
+      params: with_turnstile(lesson_slug: "basic-movement"),
       as: :json
 
     assert_response :success
@@ -37,7 +37,7 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
     @current_user.data.update!(membership_type: "standard")
 
     post internal_assistant_conversations_path,
-      params: { lesson_slug: "basic-movement" },
+      params: with_turnstile(lesson_slug: "basic-movement"),
       as: :json
 
     assert_response :success
@@ -50,7 +50,7 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
     create(:assistant_conversation, user: @current_user, context: other_lesson)
 
     post internal_assistant_conversations_path,
-      params: { lesson_slug: "basic-movement" },
+      params: with_turnstile(lesson_slug: "basic-movement"),
       as: :json
 
     assert_json_error(:forbidden, error_type: :access_denied)
@@ -58,7 +58,7 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
 
   test "POST create returns 404 for non-existent lesson" do
     post internal_assistant_conversations_path,
-      params: { lesson_slug: "non-existent" },
+      params: with_turnstile(lesson_slug: "non-existent"),
       as: :json
 
     assert_json_error(:not_found, error_type: :lesson_not_found)
@@ -69,7 +69,7 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
     project = create(:project, slug: "calculator", exercise_slug: "jiki/calculator")
 
     post internal_assistant_conversations_path,
-      params: { project_slug: "calculator" },
+      params: with_turnstile(project_slug: "calculator"),
       as: :json
 
     assert_response :success
@@ -88,7 +88,7 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
 
   test "POST create returns 404 for non-existent project" do
     post internal_assistant_conversations_path,
-      params: { project_slug: "non-existent" },
+      params: with_turnstile(project_slug: "non-existent"),
       as: :json
 
     assert_json_error(:not_found, error_type: :project_not_found)
@@ -99,7 +99,7 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
 
     assert_difference 'AssistantConversation.count', 1 do
       post internal_assistant_conversations_path,
-        params: { lesson_slug: "basic-movement" },
+        params: with_turnstile(lesson_slug: "basic-movement"),
         as: :json
     end
 
@@ -108,15 +108,51 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
     assert_equal @lesson, conversation.context
   end
 
+  # Turnstile coverage for POST create
+  test "POST create returns 403 invalid_captcha when token missing" do
+    post internal_assistant_conversations_path,
+      params: { lesson_slug: "basic-movement" },
+      as: :json
+
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
+  end
+
+  test "POST create returns 403 invalid_captcha when siteverify rejects token" do
+    WebMock.stub_request(:post, Captcha::VerifyTurnstileToken::SITEVERIFY_URL).
+      to_return(status: 200, body: { success: false }.to_json)
+
+    post internal_assistant_conversations_path,
+      params: with_turnstile(lesson_slug: "basic-movement"),
+      as: :json
+
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
+  end
+
+  # Turnstile runs BEFORE the access-denied check. Without this ordering, a
+  # bot-blocked free user past their fair-use cap would surface as
+  # access_denied (which the FE uses to open the premium-upgrade modal and
+  # fire an analytics event) instead of invalid_captcha.
+  test "POST create returns invalid_captcha, not access_denied, when both would apply" do
+    @current_user.data.update!(membership_type: "standard")
+    other_lesson = create(:lesson, :exercise, slug: "other-lesson")
+    create(:assistant_conversation, user: @current_user, context: other_lesson)
+
+    post internal_assistant_conversations_path,
+      params: { lesson_slug: "basic-movement" },
+      as: :json
+
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
+  end
+
   # POST user_messages
   test "POST user_messages successfully adds user message" do
     post user_messages_internal_assistant_conversations_path,
-      params: {
+      params: with_turnstile(
         context_type: "lesson",
         context_identifier: "basic-movement",
         content: "How do I solve this?",
         timestamp: "2025-10-31T08:15:30.000Z"
-      },
+      ),
       as: :json
 
     assert_response :success
@@ -132,6 +168,19 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
     ).returns(build_stubbed(:assistant_conversation))
 
     post user_messages_internal_assistant_conversations_path,
+      params: with_turnstile(
+        context_type: "lesson",
+        context_identifier: "basic-movement",
+        content: "How do I solve this?",
+        timestamp: "2025-10-31T08:15:30.000Z"
+      ),
+      as: :json
+
+    assert_response :success
+  end
+
+  test "POST user_messages returns 403 invalid_captcha when token missing" do
+    post user_messages_internal_assistant_conversations_path,
       params: {
         context_type: "lesson",
         context_identifier: "basic-movement",
@@ -140,7 +189,7 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
       },
       as: :json
 
-    assert_response :success
+    assert_json_error(:forbidden, error_type: :invalid_captcha)
   end
 
   # POST assistant_messages

--- a/test/controllers/user_id_cookie_test.rb
+++ b/test/controllers/user_id_cookie_test.rb
@@ -6,9 +6,9 @@ class UserIdCookieTest < ApplicationControllerTest
   end
 
   test "cookie is set when user logs in" do
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: "test@example.com", password: "password123" }
-    }, as: :json
+    ), as: :json
 
     assert_response :ok
     assert_cookie_set
@@ -16,9 +16,9 @@ class UserIdCookieTest < ApplicationControllerTest
 
   test "cookie is cleared when user logs out" do
     # Login first
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: "test@example.com", password: "password123" }
-    }, as: :json
+    ), as: :json
     assert_response :ok
     assert_cookie_set
 
@@ -52,9 +52,9 @@ class UserIdCookieTest < ApplicationControllerTest
     # hitting logout must still send a deletion cookie so the client clears it.
     # Get a real signed cookie with the right domain by logging in, then
     # discard the session so we're in the "stale cookie, no session" state.
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: "test@example.com", password: "password123" }
-    }, as: :json
+    ), as: :json
     assert_response :ok
     set_cookie = jiki_user_id_cookie
     set_domain = set_cookie[/domain=([^;]+)/, 1]
@@ -77,9 +77,9 @@ class UserIdCookieTest < ApplicationControllerTest
 
   test "cookie is cleared on 401 from authenticated endpoint" do
     # First, log in to get a real signed cookie with the right domain set.
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: "test@example.com", password: "password123" }
-    }, as: :json
+    ), as: :json
     assert_response :ok
     set_cookie = jiki_user_id_cookie
     set_domain = set_cookie[/domain=([^;]+)/, 1]
@@ -114,18 +114,18 @@ class UserIdCookieTest < ApplicationControllerTest
   end
 
   test "cookie is not set when login fails with wrong password" do
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: "test@example.com", password: "wrongpassword" }
-    }, as: :json
+    ), as: :json
 
     assert_response :unauthorized
     assert_cookie_cleared
   end
 
   test "cookie is not set when login fails with non-existent email" do
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: "nonexistent@example.com", password: "password123" }
-    }, as: :json
+    ), as: :json
 
     assert_response :unauthorized
     assert_cookie_cleared
@@ -134,9 +134,9 @@ class UserIdCookieTest < ApplicationControllerTest
   test "cookie is not set for unconfirmed user login attempt" do
     create(:user, :unconfirmed, email: "unconfirmed@example.com", password: "password123")
 
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: "unconfirmed@example.com", password: "password123" }
-    }, as: :json
+    ), as: :json
 
     assert_response :unauthorized
     assert_cookie_cleared
@@ -150,9 +150,9 @@ class UserIdCookieTest < ApplicationControllerTest
   end
 
   test "cookie has httponly attribute" do
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: "test@example.com", password: "password123" }
-    }, as: :json
+    ), as: :json
 
     assert_response :ok
     cookie = jiki_user_id_cookie
@@ -161,9 +161,9 @@ class UserIdCookieTest < ApplicationControllerTest
 
   test "cookie persists across authenticated requests" do
     # Login
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: "test@example.com", password: "password123" }
-    }, as: :json
+    ), as: :json
     assert_response :ok
     assert_cookie_set
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -101,13 +101,22 @@ module AuthenticationHelper
     sign_in_user(@current_user)
   end
 
+  # Merge a fake Turnstile token into a params hash. Use in tests that POST to
+  # endpoints protected by TurnstileVerifiable (signup, login, password reset,
+  # assistant_conversations create/create_user_message).
+  #
+  #   post user_session_path, params: with_turnstile(user: { ... }), as: :json
+  def with_turnstile(params = {})
+    params.merge(cf_turnstile_response: "test-turnstile-token")
+  end
+
   # Sign in a user by posting to the session endpoint
   # This sets up the session cookie for subsequent requests
   # For admin users, completes the 2FA flow automatically
   def sign_in_user(user)
-    post user_session_path, params: {
+    post user_session_path, params: with_turnstile(
       user: { email: user.email, password: "password123" }
-    }, as: :json
+    ), as: :json
 
     if user.admin?
       # Admin users require 2FA - complete the flow
@@ -208,6 +217,20 @@ module JsonAssertions
           "Expected '#{key}' to be #{expected_type}, got #{data[key.to_s].class}"
       end
     end
+  end
+end
+
+# Default Turnstile siteverify to success for every integration test that hits
+# a protected endpoint with a token. Tests that want to exercise the failure
+# path can re-stub this URL with success: false.
+class ActionDispatch::IntegrationTest
+  setup do
+    WebMock.stub_request(:post, Captcha::VerifyTurnstileToken::SITEVERIFY_URL).
+      to_return(
+        status: 200,
+        body: { success: true }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
   end
 end
 


### PR DESCRIPTION
## Summary
- Adds invisible Cloudflare Turnstile bot protection on `POST /auth` (signup), `POST /auth/sign_in` (login), `POST /auth/password` (reset), and `POST /internal/assistant_conversations` `#create` + `#create_user_message`.
- Frontend sends the token as `cf_turnstile_response` at the top level of the request body. Failure returns `403 invalid_captcha`.
- On the assistant-chat endpoints, captcha verification runs **before** the access-denied check so bot-blocked free users don't surface as `access_denied` (which the FE branches on to open the premium-upgrade modal).
- **Fails open** on Cloudflare siteverify outage (non-2xx response or network error), logged to Sentry — a CF incident won't lock all users out.

## Architecture
- `Captcha::VerifyTurnstileToken` — Mandate command, HTTParty to siteverify, JSON body, 5s timeout.
- `TurnstileVerifiable` concern — `verify_turnstile!` before_action, passes `CF-Connecting-IP` as `remoteip` to siteverify.
- Wired via `before_action :verify_turnstile!, only: ...` in the four controllers.

## Dependencies
- Requires [config#18](https://github.com/jiki-education/config/pull/new/add-turnstile-keys) (paired PR) for `Jiki.secrets.turnstile_secret_key` and `Jiki.config.turnstile_site_key`.
- Production rollout: populate `turnstile_secret_key` in the AWS Secrets Manager `config` blob before deploying this PR.
- Coordinate with FE rollout — the FE must land/deploy first so users have a token to send.

## Test plan
- [x] `bin/rails test` — 1736 runs, 10025 assertions, 0 failures, 0 errors
- [x] `bin/rubocop` clean
- [x] `bin/brakeman` clean
- [ ] Manual smoke after deploy: signup/login/password-reset and start-conversation succeed end-to-end with FE
- [ ] Manual smoke: `curl` to each endpoint without a token returns 403 `invalid_captcha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)