### PR TITLE
Send real user IPs to PostHog instead of geo-locating our servers

### DIFF
--- a/app/commands/analytics/track_event.rb
+++ b/app/commands/analytics/track_event.rb
@@ -3,7 +3,16 @@ class Analytics::TrackEvent
 
   queue_as :analytics
 
-  initialize_with :user, :event, properties: {}
+  initialize_with :user, :event, properties: {}, user_ip: nil
+
+  # Current is request-scoped and unavailable in the background job,
+  # so materialise the user's IP into the job arguments at defer time.
+  # The guard preserves an already-materialised IP when a job re-defers
+  # itself (e.g. via requeue_job!).
+  def self.defer(*args, **kwargs)
+    kwargs[:user_ip] = Current.user_ip unless kwargs.key?(:user_ip)
+    super(*args, **kwargs)
+  end
 
   def call
     return unless PostHog.initialized?
@@ -11,7 +20,7 @@ class Analytics::TrackEvent
     PostHog.capture(
       distinct_id: user.id.to_s,
       event: event,
-      properties: properties.merge(default_properties)
+      properties: properties.merge(default_properties).merge(geoip_properties)
     )
   end
 
@@ -21,5 +30,14 @@ class Analytics::TrackEvent
       membership_type: user.membership_type,
       locale: user.locale
     }
+  end
+
+  # With a real user IP, PostHog's GeoIP transformation resolves it into
+  # location data. Without one, disable GeoIP for this event so PostHog
+  # doesn't resolve the location of our servers instead.
+  def geoip_properties
+    return { "$geoip_disable": true } unless user_ip.present?
+
+    { "$ip": user_ip }
   end
 end

--- a/app/commands/user/identify.rb
+++ b/app/commands/user/identify.rb
@@ -3,7 +3,16 @@ class User::Identify
 
   queue_as :analytics
 
-  initialize_with :user
+  initialize_with :user, user_ip: nil
+
+  # Current is request-scoped and unavailable in the background job,
+  # so materialise the user's IP into the job arguments at defer time.
+  # The guard preserves an already-materialised IP when a job re-defers
+  # itself (e.g. via requeue_job!).
+  def self.defer(*args, **kwargs)
+    kwargs[:user_ip] = Current.user_ip unless kwargs.key?(:user_ip)
+    super(*args, **kwargs)
+  end
 
   def call
     return unless PostHog.initialized?
@@ -11,10 +20,21 @@ class User::Identify
     PostHog.identify(
       distinct_id: user.id.to_s,
       properties: {
+        username: user.handle,
         membership_type: user.membership_type,
         locale: user.locale,
         signup_date: user.created_at.to_date.iso8601
-      }
+      }.merge(geoip_properties)
     )
+  end
+
+  private
+  # With a real user IP, PostHog's GeoIP transformation resolves it into
+  # location data. Without one, disable GeoIP for this event so PostHog
+  # doesn't resolve the location of our servers instead.
+  def geoip_properties
+    return { "$geoip_disable": true } unless user_ip.present?
+
+    { "$ip": user_ip }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::API
   USER_ID_COOKIE_NAME = :"jiki_user_id_#{Rails.env}"
 
   before_action :set_current_user_agent
+  before_action :set_current_user_ip
   before_action :set_locale
   before_action :set_country_code
   before_action :extend_session_cookie!
@@ -32,6 +33,12 @@ class ApplicationController < ActionController::API
 
   def set_current_user_agent
     Current.user_agent = request.headers["User-Agent"]
+  end
+
+  # Behind Cloudflare, request.remote_ip is Cloudflare's edge IP
+  # (CF isn't in trusted_proxies), so prefer the CF-Connecting-IP header.
+  def set_current_user_ip
+    Current.user_ip = request.headers["CF-Connecting-IP"].presence || request.remote_ip
   end
 
   def set_sentry_user

--- a/app/controllers/concerns/turnstile_verifiable.rb
+++ b/app/controllers/concerns/turnstile_verifiable.rb
@@ -4,12 +4,8 @@ module TurnstileVerifiable
   private
   def verify_turnstile!
     return render_403(:invalid_captcha) if params[:cf_turnstile_response].blank?
-    return if Captcha::VerifyTurnstileToken.(params[:cf_turnstile_response], remote_ip: turnstile_remote_ip)
+    return if Captcha::VerifyTurnstileToken.(params[:cf_turnstile_response], remote_ip: Current.user_ip)
 
     render_403(:invalid_captcha)
-  end
-
-  def turnstile_remote_ip
-    request.headers["CF-Connecting-IP"].presence || request.remote_ip
   end
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,7 +1,7 @@
 # Provides request-scoped attributes using ActiveSupport::CurrentAttributes
 # Automatically resets after each request, ensuring thread-safety
 class Current < ActiveSupport::CurrentAttributes
-  attribute :events, :refresh_token_id, :user_agent, :jwt_record_id
+  attribute :events, :refresh_token_id, :user_agent, :jwt_record_id, :user_ip
 
   # Adds an event to the current request's event collection
   #

--- a/test/commands/analytics/track_event_test.rb
+++ b/test/commands/analytics/track_event_test.rb
@@ -1,6 +1,14 @@
 require "test_helper"
 
 class Analytics::TrackEventTest < ActiveSupport::TestCase
+  setup do
+    Current.reset
+  end
+
+  teardown do
+    Current.reset
+  end
+
   test "captures event with default properties merged in" do
     user = create(:user, locale: "en")
 
@@ -11,7 +19,8 @@ class Analytics::TrackEventTest < ActiveSupport::TestCase
       properties: {
         trigger: "upgrade_cta_nav",
         membership_type: "standard",
-        locale: "en"
+        locale: "en",
+        "$geoip_disable": true
       }
     )
 
@@ -27,11 +36,88 @@ class Analytics::TrackEventTest < ActiveSupport::TestCase
       event: "user_signed_up",
       properties: {
         membership_type: user.membership_type,
-        locale: user.locale
+        locale: user.locale,
+        "$geoip_disable": true
       }
     )
 
     Analytics::TrackEvent.(user, "user_signed_up")
+  end
+
+  test "sends $ip instead of disabling geoip when user_ip is present" do
+    user = create(:user, locale: "en")
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with(
+      distinct_id: user.id.to_s,
+      event: "user_signed_up",
+      properties: {
+        membership_type: "standard",
+        locale: "en",
+        "$ip": "86.41.10.20"
+      }
+    )
+
+    Analytics::TrackEvent.(user, "user_signed_up", user_ip: "86.41.10.20")
+  end
+
+  test "defer materialises Current.user_ip into the job" do
+    user = create(:user, locale: "en")
+    Current.user_ip = "86.41.10.20"
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with(
+      distinct_id: user.id.to_s,
+      event: "user_signed_up",
+      properties: {
+        membership_type: "standard",
+        locale: "en",
+        "$ip": "86.41.10.20"
+      }
+    )
+
+    perform_enqueued_jobs do
+      Analytics::TrackEvent.defer(user, "user_signed_up")
+    end
+  end
+
+  test "defer disables geoip when Current.user_ip is not set" do
+    user = create(:user, locale: "en")
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with(
+      distinct_id: user.id.to_s,
+      event: "user_signed_up",
+      properties: {
+        membership_type: "standard",
+        locale: "en",
+        "$geoip_disable": true
+      }
+    )
+
+    perform_enqueued_jobs do
+      Analytics::TrackEvent.defer(user, "user_signed_up")
+    end
+  end
+
+  test "defer does not override an explicitly passed user_ip" do
+    user = create(:user, locale: "en")
+    Current.user_ip = "9.9.9.9"
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with(
+      distinct_id: user.id.to_s,
+      event: "user_signed_up",
+      properties: {
+        membership_type: "standard",
+        locale: "en",
+        "$ip": "86.41.10.20"
+      }
+    )
+
+    perform_enqueued_jobs do
+      Analytics::TrackEvent.defer(user, "user_signed_up", user_ip: "86.41.10.20")
+    end
   end
 
   test "no-ops when PostHog is not initialized" do

--- a/test/commands/user/identify_test.rb
+++ b/test/commands/user/identify_test.rb
@@ -1,6 +1,14 @@
 require "test_helper"
 
 class User::IdentifyTest < ActiveSupport::TestCase
+  setup do
+    Current.reset
+  end
+
+  teardown do
+    Current.reset
+  end
+
   test "calls PostHog.identify with user state snapshot" do
     user = create(:user, created_at: Date.new(2026, 1, 15), locale: "en")
 
@@ -8,13 +16,95 @@ class User::IdentifyTest < ActiveSupport::TestCase
     PostHog.expects(:identify).with(
       distinct_id: user.id.to_s,
       properties: {
+        username: user.handle,
         membership_type: "standard",
         locale: "en",
-        signup_date: "2026-01-15"
+        signup_date: "2026-01-15",
+        "$geoip_disable": true
       }
     )
 
     User::Identify.(user)
+  end
+
+  test "sends $ip instead of disabling geoip when user_ip is present" do
+    user = create(:user, created_at: Date.new(2026, 1, 15), locale: "en")
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:identify).with(
+      distinct_id: user.id.to_s,
+      properties: {
+        username: user.handle,
+        membership_type: "standard",
+        locale: "en",
+        signup_date: "2026-01-15",
+        "$ip": "86.41.10.20"
+      }
+    )
+
+    User::Identify.(user, user_ip: "86.41.10.20")
+  end
+
+  test "defer materialises Current.user_ip into the job" do
+    user = create(:user, created_at: Date.new(2026, 1, 15), locale: "en")
+    Current.user_ip = "86.41.10.20"
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:identify).with(
+      distinct_id: user.id.to_s,
+      properties: {
+        username: user.handle,
+        membership_type: "standard",
+        locale: "en",
+        signup_date: "2026-01-15",
+        "$ip": "86.41.10.20"
+      }
+    )
+
+    perform_enqueued_jobs do
+      User::Identify.defer(user)
+    end
+  end
+
+  test "defer disables geoip when Current.user_ip is not set" do
+    user = create(:user, created_at: Date.new(2026, 1, 15), locale: "en")
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:identify).with(
+      distinct_id: user.id.to_s,
+      properties: {
+        username: user.handle,
+        membership_type: "standard",
+        locale: "en",
+        signup_date: "2026-01-15",
+        "$geoip_disable": true
+      }
+    )
+
+    perform_enqueued_jobs do
+      User::Identify.defer(user)
+    end
+  end
+
+  test "defer does not override an explicitly passed user_ip" do
+    user = create(:user, created_at: Date.new(2026, 1, 15), locale: "en")
+    Current.user_ip = "9.9.9.9"
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:identify).with(
+      distinct_id: user.id.to_s,
+      properties: {
+        username: user.handle,
+        membership_type: "standard",
+        locale: "en",
+        signup_date: "2026-01-15",
+        "$ip": "86.41.10.20"
+      }
+    )
+
+    perform_enqueued_jobs do
+      User::Identify.defer(user, user_ip: "86.41.10.20")
+    end
   end
 
   test "no-ops when PostHog is not initialized" do

--- a/test/controllers/current_user_ip_test.rb
+++ b/test/controllers/current_user_ip_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+# Tests ApplicationController#set_current_user_ip end-to-end: the request's IP
+# is stored in Current.user_ip, materialised into deferred analytics jobs, and
+# sent to PostHog as the $ip property.
+class CurrentUserIpTest < ApplicationControllerTest
+  setup do
+    setup_user
+  end
+
+  test "uses CF-Connecting-IP header when present" do
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with do |args|
+      args[:properties][:"$ip"] == "86.41.10.20"
+    end
+
+    perform_enqueued_jobs do
+      post internal_events_path,
+        params: { event: "premium_modal_shown", properties: { trigger: "upgrade_cta_nav" } },
+        headers: { "CF-Connecting-IP" => "86.41.10.20" },
+        as: :json
+    end
+
+    assert_response :no_content
+  end
+
+  test "falls back to remote_ip without CF-Connecting-IP header" do
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with do |args|
+      # Integration test requests come from 127.0.0.1
+      args[:properties][:"$ip"] == "127.0.0.1"
+    end
+
+    perform_enqueued_jobs do
+      post internal_events_path,
+        params: { event: "premium_modal_shown", properties: { trigger: "upgrade_cta_nav" } },
+        as: :json
+    end
+
+    assert_response :no_content
+  end
+end

--- a/test/models/current_test.rb
+++ b/test/models/current_test.rb
@@ -64,6 +64,24 @@ class CurrentTest < ActiveSupport::TestCase
     assert_equal "value", stored_data[:metadata][:nested][:deep]
   end
 
+  test "user_ip defaults to nil" do
+    assert_nil Current.user_ip
+  end
+
+  test "user_ip can be set and read" do
+    Current.user_ip = "86.41.10.20"
+
+    assert_equal "86.41.10.20", Current.user_ip
+  end
+
+  test "reset clears user_ip" do
+    Current.user_ip = "86.41.10.20"
+
+    Current.reset
+
+    assert_nil Current.user_ip
+  end
+
   test "reset clears events" do
     Current.add_event(:test_event, {})
     assert_equal 1, Current.events.size


### PR DESCRIPTION
## Problem

Every server-side PostHog event was being geo-located to **Dublin, Ireland** — the location of our ECS servers (eu-west-1), not the user. Worse, the GeoIP transformation writes `$set` / `$set_once` person properties, so user profiles were permanently stamped with the wrong location.

## Solution

Pass the real user IP through to PostHog:

- **`Current.user_ip`** — new request-scoped attribute, set in `ApplicationController` from `CF-Connecting-IP` (we're behind Cloudflare, so `remote_ip` alone would give CF's edge IP) with `remote_ip` fallback.
- **`Analytics::TrackEvent` / `User::Identify`** — override `self.defer` to materialise `Current.user_ip` into the job arguments at defer time (`Current` is unavailable in background jobs). At send time:
  - IP present → `$ip` property, so PostHog resolves the user's real location
  - No IP (Stripe webhooks, background jobs) → `$geoip_disable` so PostHog doesn't fall back to our server's location
- **`TurnstileVerifiable`** — now reads `Current.user_ip` instead of doing its own header lookup.
- **`User::Identify`** — also now includes `username` in the identify properties.

## Notes

- Webhook-driven events (`upgraded_to_premium` etc.) intentionally carry no location data — the person profile already has correct location from request-context events.
- Existing person profiles stamped with Dublin via `$set_once` need cleanup in PostHog itself; this PR stops further damage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)