### PR TITLE
Send a once-per-day site_visited event to PostHog

### DIFF
--- a/app/commands/analytics/track_last_active_on.rb
+++ b/app/commands/analytics/track_last_active_on.rb
@@ -1,0 +1,24 @@
+class Analytics::TrackLastActiveOn
+  include Mandate
+
+  initialize_with :user
+
+  def call
+    # Cheap in-memory guard - this runs on every authenticated request.
+    return if user.last_active_on == Date.current
+    return unless claim_today!
+
+    Analytics::TrackEvent.defer(user, "site_visited")
+  end
+
+  private
+  # Concurrent requests can both pass the in-memory check above, so claim
+  # today atomically in SQL. Only the request that actually flips the column
+  # sends the event.
+  def claim_today!
+    User::Data.where(user_id: user.id).
+      where("last_active_on IS NULL OR last_active_on < ?", Date.current).
+      update_all(last_active_on: Date.current, updated_at: Time.current).
+      positive?
+  end
+end

--- a/app/commands/analytics/track_last_active_on.rb
+++ b/app/commands/analytics/track_last_active_on.rb
@@ -5,7 +5,7 @@ class Analytics::TrackLastActiveOn
 
   def call
     # Cheap in-memory guard - this runs on every authenticated request.
-    return if user.last_active_on == Date.current
+    return if user.last_active_on == today
     return unless claim_today!
 
     Analytics::TrackEvent.defer(user, "site_visited")
@@ -17,8 +17,14 @@ class Analytics::TrackLastActiveOn
   # sends the event.
   def claim_today!
     User::Data.where(user_id: user.id).
-      where("last_active_on IS NULL OR last_active_on < ?", Date.current).
-      update_all(last_active_on: Date.current, updated_at: Time.current).
+      where("last_active_on IS NULL OR last_active_on < ?", today).
+      update_all(last_active_on: today, updated_at: Time.current).
       positive?
   end
+
+  # Use the UTC date, not Date.current, so the once-per-day boundary matches
+  # PostHog's bucketing and stays stable even if the app ever sets Time.zone
+  # to the user's timezone.
+  memoize
+  def today = Time.current.utc.to_date
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::API
   before_action :extend_session_cookie!
   before_action :set_sentry_user
   after_action :set_user_id_cookie
+  after_action :track_last_active_on
 
   private
   # Sets a signed cookie to indicate the user is authenticated.
@@ -45,6 +46,14 @@ class ApplicationController < ActionController::API
     return unless Rails.env.production? && user_signed_in?
 
     Sentry.set_user(id: current_user.id)
+  end
+
+  # Records that the user visited the site today and sends a once-per-day
+  # "site_visited" analytics event (used for DAU tracking in PostHog).
+  def track_last_active_on
+    return unless user_signed_in?
+
+    Analytics::TrackLastActiveOn.(current_user)
   end
 
   # Implement sliding session expiration by touching the session periodically.

--- a/db/migrate/20260602100000_add_last_active_on_to_user_data.rb
+++ b/db/migrate/20260602100000_add_last_active_on_to_user_data.rb
@@ -1,0 +1,5 @@
+class AddLastActiveOnToUserData < ActiveRecord::Migration[8.1]
+  def change
+    add_column :user_data, :last_active_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_01_151511) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_02_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -414,6 +414,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_151511) do
     t.datetime "email_complaint_at"
     t.string "email_complaint_type"
     t.string "email_verification_token"
+    t.date "last_active_on"
     t.datetime "last_email_opened_at"
     t.string "membership_type", default: "standard", null: false
     t.boolean "notifications_enabled", default: true, null: false

--- a/test/commands/analytics/track_last_active_on_test.rb
+++ b/test/commands/analytics/track_last_active_on_test.rb
@@ -8,23 +8,38 @@ class Analytics::TrackLastActiveOnTest < ActiveSupport::TestCase
 
     Analytics::TrackLastActiveOn.(user)
 
-    assert_equal Date.current, user.data.reload.last_active_on
+    assert_equal Time.current.utc.to_date, user.data.reload.last_active_on
   end
 
   test "records today and defers site_visited event when last active before today" do
     user = create(:user)
-    user.data.update!(last_active_on: Date.current - 1.day)
+    user.data.update!(last_active_on: Time.current.utc.to_date - 1.day)
 
     Analytics::TrackEvent.expects(:defer).with(user, "site_visited")
 
     Analytics::TrackLastActiveOn.(user)
 
-    assert_equal Date.current, user.data.reload.last_active_on
+    assert_equal Time.current.utc.to_date, user.data.reload.last_active_on
+  end
+
+  test "uses the UTC date even when the app timezone is not UTC" do
+    user = create(:user)
+
+    Analytics::TrackEvent.expects(:defer).with(user, "site_visited")
+
+    # 11pm UTC on June 2nd is already June 3rd in Auckland
+    travel_to Time.utc(2026, 6, 2, 23, 0) do
+      Time.use_zone("Auckland") do
+        Analytics::TrackLastActiveOn.(user)
+      end
+    end
+
+    assert_equal Date.new(2026, 6, 2), user.data.reload.last_active_on
   end
 
   test "no-ops when already active today" do
     user = create(:user)
-    user.data.update!(last_active_on: Date.current)
+    user.data.update!(last_active_on: Time.current.utc.to_date)
 
     Analytics::TrackEvent.expects(:defer).never
 
@@ -38,7 +53,7 @@ class Analytics::TrackLastActiveOnTest < ActiveSupport::TestCase
     # today behind this command's back (so the in-memory check passes but
     # the atomic SQL claim does not).
     user.data
-    User::Data.where(user_id: user.id).update_all(last_active_on: Date.current)
+    User::Data.where(user_id: user.id).update_all(last_active_on: Time.current.utc.to_date)
 
     Analytics::TrackEvent.expects(:defer).never
 

--- a/test/commands/analytics/track_last_active_on_test.rb
+++ b/test/commands/analytics/track_last_active_on_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class Analytics::TrackLastActiveOnTest < ActiveSupport::TestCase
+  test "records today and defers site_visited event on first ever visit" do
+    user = create(:user)
+
+    Analytics::TrackEvent.expects(:defer).with(user, "site_visited")
+
+    Analytics::TrackLastActiveOn.(user)
+
+    assert_equal Date.current, user.data.reload.last_active_on
+  end
+
+  test "records today and defers site_visited event when last active before today" do
+    user = create(:user)
+    user.data.update!(last_active_on: Date.current - 1.day)
+
+    Analytics::TrackEvent.expects(:defer).with(user, "site_visited")
+
+    Analytics::TrackLastActiveOn.(user)
+
+    assert_equal Date.current, user.data.reload.last_active_on
+  end
+
+  test "no-ops when already active today" do
+    user = create(:user)
+    user.data.update!(last_active_on: Date.current)
+
+    Analytics::TrackEvent.expects(:defer).never
+
+    Analytics::TrackLastActiveOn.(user)
+  end
+
+  test "does not send event when a concurrent request claims today first" do
+    user = create(:user)
+
+    # Load user data into memory, then simulate another request claiming
+    # today behind this command's back (so the in-memory check passes but
+    # the atomic SQL claim does not).
+    user.data
+    User::Data.where(user_id: user.id).update_all(last_active_on: Date.current)
+
+    Analytics::TrackEvent.expects(:defer).never
+
+    Analytics::TrackLastActiveOn.(user)
+  end
+end

--- a/test/controllers/track_last_active_on_test.rb
+++ b/test/controllers/track_last_active_on_test.rb
@@ -10,7 +10,7 @@ class TrackLastActiveOnTest < ApplicationControllerTest
     # Signing in is itself an authenticated request, so it claims today.
     setup_user(user)
 
-    assert_equal Date.current, user.data.reload.last_active_on
+    assert_equal Time.current.utc.to_date, user.data.reload.last_active_on
   end
 
   test "calls Analytics::TrackLastActiveOn on authenticated requests" do

--- a/test/controllers/track_last_active_on_test.rb
+++ b/test/controllers/track_last_active_on_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+# Tests the ApplicationController after_action that records a user's daily
+# activity and sends a once-per-day "site_visited" analytics event.
+class TrackLastActiveOnTest < ApplicationControllerTest
+  test "authenticated request records last_active_on" do
+    user = create(:user)
+    assert_nil user.data.last_active_on
+
+    # Signing in is itself an authenticated request, so it claims today.
+    setup_user(user)
+
+    assert_equal Date.current, user.data.reload.last_active_on
+  end
+
+  test "calls Analytics::TrackLastActiveOn on authenticated requests" do
+    setup_user
+
+    Analytics::TrackLastActiveOn.expects(:call).with(@current_user)
+
+    get internal_me_path, as: :json
+
+    assert_response :success
+  end
+
+  test "does not track unauthenticated requests" do
+    Analytics::TrackLastActiveOn.expects(:call).never
+
+    get internal_me_path, as: :json
+
+    assert_json_error(:unauthorized, error_type: :unauthenticated)
+  end
+
+  test "only sends site_visited once per day" do
+    setup_user # the sign-in request claims today
+
+    Analytics::TrackEvent.expects(:defer).never
+
+    get internal_me_path, as: :json
+    get internal_me_path, as: :json
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## Summary

Gives PostHog a reliable server-side DAU signal: the first authenticated request a user makes each day fires a `site_visited` analytics event. This isn't blocked by adblockers (unlike `$pageview` from the JS SDK) and counts users who visit without completing any learning work.

## Changes

- **Migration**: adds `last_active_on` (date) to `user_data` — doubles as last-seen data
- **`Analytics::TrackLastActiveOn`**: new command with a cheap in-memory guard, an atomic SQL claim (so concurrent requests can't double-send), and a deferred `Analytics::TrackEvent` call
- **`ApplicationController`**: `after_action` hook calls the command on every authenticated request

The event rides on the `TrackEvent` IP work from #410 (this PR is stacked on `posthog-real-user-ip`), so it carries the user's real IP for GeoIP.

## Test plan

- [x] Command tests: first visit, repeat visit same day, next day, concurrent-request race
- [x] Controller tests: authenticated requests tracked, unauthenticated not, once-per-day dedup
- [x] Full suite passes (1798 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)