### PR TITLE
Send $useragent and referrer attribution properties to PostHog

### DIFF
--- a/app/commands/analytics/track_event.rb
+++ b/app/commands/analytics/track_event.rb
@@ -3,14 +3,15 @@ class Analytics::TrackEvent
 
   queue_as :analytics
 
-  initialize_with :user, :event, properties: {}, user_ip: nil
+  initialize_with :user, :event, properties: {}, user_ip: nil, user_agent: nil
 
   # Current is request-scoped and unavailable in the background job,
-  # so materialise the user's IP into the job arguments at defer time.
-  # The guard preserves an already-materialised IP when a job re-defers
-  # itself (e.g. via requeue_job!).
+  # so materialise the user's IP and user agent into the job arguments at
+  # defer time. The guards preserve already-materialised values when a job
+  # re-defers itself (e.g. via requeue_job!).
   def self.defer(*args, **kwargs)
     kwargs[:user_ip] = Current.user_ip unless kwargs.key?(:user_ip)
+    kwargs[:user_agent] = Current.user_agent unless kwargs.key?(:user_agent)
     super(*args, **kwargs)
   end
 
@@ -20,7 +21,7 @@ class Analytics::TrackEvent
     PostHog.capture(
       distinct_id: user.id.to_s,
       event: event,
-      properties: properties.merge(default_properties).merge(geoip_properties)
+      properties: properties.merge(default_properties).merge(derived_properties)
     )
   end
 
@@ -32,6 +33,10 @@ class Analytics::TrackEvent
     }
   end
 
+  def derived_properties
+    geoip_properties.merge(user_agent_properties)
+  end
+
   # With a real user IP, PostHog's GeoIP transformation resolves it into
   # location data. Without one, disable GeoIP for this event so PostHog
   # doesn't resolve the location of our servers instead.
@@ -39,5 +44,14 @@ class Analytics::TrackEvent
     return { "$geoip_disable": true } unless user_ip.present?
 
     { "$ip": user_ip }
+  end
+
+  # PostHog's "User Agent Populator" transformation parses $useragent into
+  # $browser, $browser_version, $os, $device and $device_type. It must be
+  # enabled in the PostHog project (Data pipeline → Transformations).
+  def user_agent_properties
+    return {} if user_agent.blank?
+
+    { "$useragent": user_agent }
   end
 end

--- a/app/commands/user/bootstrap.rb
+++ b/app/commands/user/bootstrap.rb
@@ -35,8 +35,53 @@ class User::Bootstrap
     Analytics::TrackEvent.defer(
       user,
       "user_signed_up",
-      properties: { provider: }.merge(attribution || {})
+      properties: { provider: }.merge(attribution || {}).merge(attribution_properties)
     )
+  end
+
+  # Map our signup attribution onto PostHog's reserved property names so its
+  # built-in attribution features work: $referrer/$referring_domain/$current_url
+  # drive Channel Type classification on the event, and $set_once writes the
+  # $initial_* person properties used for first-touch attribution breakdowns.
+  memoize
+  def attribution_properties
+    return {} if attribution.blank?
+
+    {
+      "$referrer": referrer,
+      "$referring_domain": referring_domain,
+      "$current_url": landing_url,
+      "$set_once": {
+        "$initial_referrer": referrer,
+        "$initial_referring_domain": referring_domain,
+        "$initial_current_url": landing_url,
+        "$initial_utm_source": attribution["utm_source"],
+        "$initial_utm_medium": attribution["utm_medium"],
+        "$initial_utm_campaign": attribution["utm_campaign"]
+      }.compact
+    }.compact
+  end
+
+  # PostHog uses the literal value "$direct" to mean "no referrer".
+  memoize
+  def referrer = attribution["referrer"].presence || "$direct"
+
+  memoize
+  def referring_domain
+    return "$direct" if attribution["referrer"].blank?
+
+    URI.parse(attribution["referrer"]).host || "$direct"
+  rescue URI::InvalidURIError
+    "$direct"
+  end
+
+  memoize
+  def landing_url
+    return nil if attribution["landing_path"].blank?
+
+    URI.join(Jiki.config.frontend_base_url, attribution["landing_path"]).to_s
+  rescue URI::InvalidURIError
+    nil
   end
 
   memoize

--- a/test/commands/analytics/track_event_test.rb
+++ b/test/commands/analytics/track_event_test.rb
@@ -120,6 +120,83 @@ class Analytics::TrackEventTest < ActiveSupport::TestCase
     end
   end
 
+  test "includes $useragent when user_agent is present" do
+    user = create(:user, locale: "en")
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with(
+      distinct_id: user.id.to_s,
+      event: "user_signed_up",
+      properties: {
+        membership_type: "standard",
+        locale: "en",
+        "$geoip_disable": true,
+        "$useragent": "Mozilla/5.0 (Macintosh)"
+      }
+    )
+
+    Analytics::TrackEvent.(user, "user_signed_up", user_agent: "Mozilla/5.0 (Macintosh)")
+  end
+
+  test "defer materialises Current.user_agent into the job" do
+    user = create(:user, locale: "en")
+    Current.user_agent = "Mozilla/5.0 (Macintosh)"
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with(
+      distinct_id: user.id.to_s,
+      event: "user_signed_up",
+      properties: {
+        membership_type: "standard",
+        locale: "en",
+        "$geoip_disable": true,
+        "$useragent": "Mozilla/5.0 (Macintosh)"
+      }
+    )
+
+    perform_enqueued_jobs do
+      Analytics::TrackEvent.defer(user, "user_signed_up")
+    end
+  end
+
+  test "defer does not override an explicitly passed user_agent" do
+    user = create(:user, locale: "en")
+    Current.user_agent = "Mozilla/5.0 (Other)"
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with(
+      distinct_id: user.id.to_s,
+      event: "user_signed_up",
+      properties: {
+        membership_type: "standard",
+        locale: "en",
+        "$geoip_disable": true,
+        "$useragent": "Mozilla/5.0 (Macintosh)"
+      }
+    )
+
+    perform_enqueued_jobs do
+      Analytics::TrackEvent.defer(user, "user_signed_up", user_agent: "Mozilla/5.0 (Macintosh)")
+    end
+  end
+
+  test "omits $useragent when user_agent is blank" do
+    user = create(:user, locale: "en")
+
+    PostHog.stubs(:initialized?).returns(true)
+    PostHog.expects(:capture).with(
+      distinct_id: user.id.to_s,
+      event: "user_signed_up",
+      properties: {
+        membership_type: "standard",
+        locale: "en",
+        "$geoip_disable": true
+      }
+    )
+
+    Analytics::TrackEvent.(user, "user_signed_up", user_agent: "")
+  end
+
   test "no-ops when PostHog is not initialized" do
     PostHog.stubs(:initialized?).returns(false)
     PostHog.expects(:capture).never

--- a/test/commands/user/bootstrap_test.rb
+++ b/test/commands/user/bootstrap_test.rb
@@ -59,18 +59,91 @@ class User::BootstrapTest < ActiveSupport::TestCase
   test "merges attribution into event properties and persists to user.data" do
     create(:course, slug: "coding-fundamentals")
     user = create(:user)
-    attribution = { "utm_source" => "twitter", "referrer" => "https://t.co/foo" }
+    attribution = {
+      "utm_source" => "twitter",
+      "utm_medium" => "social",
+      "utm_campaign" => "launch",
+      "referrer" => "https://t.co/foo",
+      "landing_path" => "/blog/welcome"
+    }
 
     User::Identify.expects(:defer).with(user)
     Analytics::TrackEvent.expects(:defer).with(
       user,
       "user_signed_up",
-      properties: { provider: "google", "utm_source" => "twitter", "referrer" => "https://t.co/foo" }
+      properties: {
+        provider: "google",
+        "utm_source" => "twitter",
+        "utm_medium" => "social",
+        "utm_campaign" => "launch",
+        "referrer" => "https://t.co/foo",
+        "landing_path" => "/blog/welcome",
+        "$referrer": "https://t.co/foo",
+        "$referring_domain": "t.co",
+        "$current_url": "#{Jiki.config.frontend_base_url}/blog/welcome",
+        "$set_once": {
+          "$initial_referrer": "https://t.co/foo",
+          "$initial_referring_domain": "t.co",
+          "$initial_current_url": "#{Jiki.config.frontend_base_url}/blog/welcome",
+          "$initial_utm_source": "twitter",
+          "$initial_utm_medium": "social",
+          "$initial_utm_campaign": "launch"
+        }
+      }
     )
 
     User::Bootstrap.(user, "google", attribution: attribution)
 
     assert_equal attribution, user.data.reload.signup_attribution
+  end
+
+  test "uses $direct as referrer when attribution has no referrer" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+    attribution = { "utm_source" => "newsletter" }
+
+    User::Identify.stubs(:defer)
+    Analytics::TrackEvent.expects(:defer).with(
+      user,
+      "user_signed_up",
+      properties: {
+        provider: "email",
+        "utm_source" => "newsletter",
+        "$referrer": "$direct",
+        "$referring_domain": "$direct",
+        "$set_once": {
+          "$initial_referrer": "$direct",
+          "$initial_referring_domain": "$direct",
+          "$initial_utm_source": "newsletter"
+        }
+      }
+    )
+
+    User::Bootstrap.(user, "email", attribution: attribution)
+  end
+
+  test "uses $direct as referring domain when referrer is not a valid URL" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+    attribution = { "referrer" => "not a valid url" }
+
+    User::Identify.stubs(:defer)
+    Analytics::TrackEvent.expects(:defer).with(
+      user,
+      "user_signed_up",
+      properties: {
+        provider: "email",
+        "referrer" => "not a valid url",
+        "$referrer": "not a valid url",
+        "$referring_domain": "$direct",
+        "$set_once": {
+          "$initial_referrer": "not a valid url",
+          "$initial_referring_domain": "$direct"
+        }
+      }
+    )
+
+    User::Bootstrap.(user, "email", attribution: attribution)
   end
 
   test "does not touch user.data when attribution is nil" do


### PR DESCRIPTION
## Summary

- **$useragent on every event**: Threads the request's User-Agent through `Analytics::TrackEvent` (same materialise-at-defer pattern as `user_ip`). PostHog's **User Agent Populator** transformation parses this into `$browser`, `$browser_version`, `$os`, `$device` and `$device_type`.
- **Referrer attribution on signup**: `User::Bootstrap` now maps signup attribution onto PostHog's reserved property names on the `user_signed_up` event:
  - `$referrer`, `$referring_domain`, `$current_url` — enables PostHog's built-in Channel Type classification (Organic Search / Organic Social / Direct / Paid).
  - `$set_once` with `$initial_referrer`, `$initial_referring_domain`, `$initial_current_url`, `$initial_utm_source/medium/campaign` — writes the person properties PostHog's first-touch attribution breakdowns read.
  - Follows the posthog-js convention of `$direct` when there's no referrer.

## Post-merge action required

The User Agent Populator transformation is **not enabled by default**. Enable it once in PostHog: **Data pipeline → Transformations → New → "User Agent Populator"**. Until then the `$useragent` property is stored but not parsed.

## Test plan

- [x] New tests for `$useragent` threading (explicit, via `Current`, blank, no-override)
- [x] New tests for attribution mapping (full attribution, no referrer → `$direct`, invalid referrer URL)
- [x] Full suite, rubocop and brakeman pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)