### PR TITLE
Bump jiki-config to fix R2 checksum incompatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/jiki-education/config.git
-  revision: 076dee182e95a386ecb61467435becc839c1b428
+  revision: 67542f5c5915d6e7f1b85193889a29ef9a661717
   branch: main
   specs:
     jiki-config (0.1.0)


### PR DESCRIPTION
Closes #409

## Summary
- Production R2 uploads (`Utils::R2::Upload` via background jobs) fail with `Aws::S3::Errors::InvalidRequest: You can only specify one non-default checksum at a time.`
- Root cause: aws-sdk-s3 ≥ 1.178 sends CRC32 request checksums by default, which Cloudflare R2 rejects.
- Fix lives in the config gem (jiki-education/config#22): `Jiki.r2_client` now sets `request_checksum_calculation` / `response_checksum_validation` to `"when_required"`.
- This PR bumps the locked jiki-config revision in `Gemfile.lock` to pick up that fix (`076dee1` → `67542f5`).

## Test plan
- [x] Config gem test asserts the R2 client options (jiki-education/config#22)
- [x] `bin/rails test test/commands/utils/r2 test/commands/images` — 15 runs, 0 failures
- [x] Full suite via pre-commit hook — 1799 runs, 0 failures
- [ ] After deploy: retry the failing Sentry job and confirm R2 uploads succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)