### PR TITLE
Add Jiki logo image to 2FA provisioning URI

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,9 +48,17 @@ class User < ApplicationRecord
   def total_active_days = aggregate_activity_data[:total_active_days]
 
   # Two-Factor Authentication
+  OTP_PROVISIONING_IMAGE_URL = "https://jiki.io/static/images/logo.png".freeze
+
   def otp_enabled? = otp_secret.present? && otp_enabled_at.present?
   def requires_otp? = admin?
-  def otp_provisioning_uri = otp_secret ? ROTP::TOTP.new(otp_secret, issuer: "Jiki").provisioning_uri(email) : nil
+
+  def otp_provisioning_uri
+    return nil unless otp_secret
+
+    uri = ROTP::TOTP.new(otp_secret, issuer: "Jiki").provisioning_uri(email)
+    "#{uri}&image=#{CGI.escape(OTP_PROVISIONING_IMAGE_URL)}"
+  end
 
   memoize
   def aggregate_activity_data = User::ActivityLog::SyncAndRetrieveAggregates.(self)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -199,4 +199,20 @@ class UserTest < ActiveSupport::TestCase
 
     assert_equal :usd, user.currency
   end
+
+  test "otp_provisioning_uri returns nil without otp_secret" do
+    user = create(:user)
+
+    assert_nil user.otp_provisioning_uri
+  end
+
+  test "otp_provisioning_uri includes issuer, email and image" do
+    user = create(:user, :with_2fa)
+
+    uri = user.otp_provisioning_uri
+    assert uri.start_with?("otpauth://totp/Jiki:")
+    assert_includes uri, CGI.escape(user.email)
+    assert_includes uri, "issuer=Jiki"
+    assert uri.end_with?("&image=#{CGI.escape(User::OTP_PROVISIONING_IMAGE_URL)}")
+  end
 end


### PR DESCRIPTION
Appends `image=https://jiki.io/static/images/logo.png` to the OTP provisioning URI so authenticator apps that support the `image` param (e.g. FreeOTP) show the Jiki logo during 2FA setup.

- Adds `User::OTP_PROVISIONING_IMAGE_URL` constant
- Adds model tests for `otp_provisioning_uri` (nil without secret, full URI structure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)