### PR TITLE
Disable broken mjml-rails disk cache

### DIFF
--- a/config/initializers/mjml.rb
+++ b/config/initializers/mjml.rb
@@ -20,6 +20,8 @@ Mjml.setup do |config|
   config.beautify = !Rails.env.production?
   config.minify = Rails.env.production?
 
-  # Cache compiled templates in production for performance
-  config.cache_mjml = Rails.env.production?
+  # mjml-rails 5.0.0's disk cache keys on the layout file's SHA only, so every
+  # email using layouts/mailer.mjml shares one cache entry — the first render
+  # poisons subsequent ones. Disable until the upstream cache is fixed.
+  config.cache_mjml = false
 end


### PR DESCRIPTION
## Summary
- mjml-rails 5.0.0's disk cache keys each entry on the SHA of the layout file (`app/views/layouts/mailer.mjml`) rather than on the rendered MJML input. Every email using layout `mailer` shares one cache entry — the first render after boot poisons all subsequent ones.
- Only the HTML part is affected (text/erb doesn't touch the cache). Symptom seen in the wild: invite email with correct subject + text part but welcome HTML body.
- Disable `cache_mjml` until upstream is fixed. Mirrors the fix in giki/api@0d5d9b8.

## Test plan
- [ ] Trigger two different mailers back-to-back in production and confirm each renders the correct HTML body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)