### PR TITLE
Pass R2 checksum options to ActiveStorage S3 client

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -25,6 +25,12 @@ r2:
   bucket: <%= Jiki.config.r2_bucket_uploads %>
   public: true
   force_path_style: true
+  # R2 rejects the AWS SDK's default CRC32 request checksum with
+  # "You can only specify one non-default checksum at a time", so only
+  # send/validate checksums when strictly required. Mirrors the patch
+  # applied to Jiki.r2_client in the jiki-config gem.
+  request_checksum_calculation: when_required
+  response_checksum_validation: when_required
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
## Summary

- The R2 checksum fix in #413 only patched `Jiki.r2_client`. ActiveStorage builds its own `Aws::S3::Client` from `config/storage.yml` and never received the same options, so every `.attach` against R2 (exercise submission files, user avatars) still fails in production with `Aws::S3::Errors::InvalidRequest: You can only specify one non-default checksum at a time` — surfaced by Sentry on `Internal::ExerciseSubmissionsController#create`.
- Forward `request_checksum_calculation: when_required` and `response_checksum_validation: when_required` through the `r2:` block in `storage.yml` so ActiveStorage's R2 client matches `Jiki.r2_client`.

Closes #429.

## Test plan

- [ ] Confirm exercise submission upload succeeds against production R2 (no more `InvalidRequest` in Sentry)
- [ ] Confirm user avatar upload still works
- [ ] Existing test suite passes (Disk service in test, so this is a config-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)