### PR TITLE
Stop eager-loading annual Stripe price ID

### DIFF
--- a/app/commands/stripe/determine_subscription_details.rb
+++ b/app/commands/stripe/determine_subscription_details.rb
@@ -12,8 +12,8 @@ class Stripe::DetermineSubscriptionDetails
 
   def self.price_map
     {
-      'monthly' => Jiki.config.stripe_premium_monthly_price_id,
-      'annual' => Jiki.config.stripe_premium_annual_price_id
+      'monthly' => Jiki.config.stripe_premium_monthly_price_id
+      # 'annual' => Jiki.config.stripe_premium_annual_price_id
     }
   end
 end

--- a/test/commands/stripe/determine_subscription_details_test.rb
+++ b/test/commands/stripe/determine_subscription_details_test.rb
@@ -7,6 +7,7 @@ class Stripe::DetermineSubscriptionDetailsTest < ActiveSupport::TestCase
   end
 
   test "price_id_for returns annual price ID" do
+    skip "annual checkout disabled until FE wires it up"
     assert_equal Jiki.config.stripe_premium_annual_price_id,
       Stripe::DetermineSubscriptionDetails.price_id_for('annual')
   end
@@ -24,6 +25,7 @@ class Stripe::DetermineSubscriptionDetailsTest < ActiveSupport::TestCase
   end
 
   test "interval_for_price_id returns annual for annual price ID" do
+    skip "annual checkout disabled until FE wires it up"
     assert_equal 'annual',
       Stripe::DetermineSubscriptionDetails.interval_for_price_id(Jiki.config.stripe_premium_annual_price_id)
   end

--- a/test/commands/stripe/update_subscription_test.rb
+++ b/test/commands/stripe/update_subscription_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class Stripe::UpdateSubscriptionTest < ActiveSupport::TestCase
   test "switches from monthly to annual with immediate proration" do
+    skip "annual checkout disabled until FE wires it up"
     user = create(:user)
     period_end = 1.year.from_now
     user.data.update!(

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -29,6 +29,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
   end
 
   test "verifies checkout session for annual subscription" do
+    skip "annual checkout disabled until FE wires it up"
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
     session_id = "cs_test_123"

--- a/test/commands/stripe/webhook/subscription_created_test.rb
+++ b/test/commands/stripe/webhook/subscription_created_test.rb
@@ -27,6 +27,7 @@ class Stripe::Webhook::SubscriptionCreatedTest < ActiveSupport::TestCase
   end
 
   test "creates annual subscription for user" do
+    skip "annual checkout disabled until FE wires it up"
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
 

--- a/test/commands/stripe/webhook/subscription_updated_test.rb
+++ b/test/commands/stripe/webhook/subscription_updated_test.rb
@@ -187,6 +187,7 @@ class Stripe::Webhook::SubscriptionUpdatedTest < ActiveSupport::TestCase
   end
 
   test "handles interval change from monthly to annual" do
+    skip "annual checkout disabled until FE wires it up"
     @user.data.update!(subscription_interval: "monthly")
 
     subscription = mock_subscription_with_price(Jiki.config.stripe_premium_annual_price_id)
@@ -325,6 +326,7 @@ class Stripe::Webhook::SubscriptionUpdatedTest < ActiveSupport::TestCase
   end
 
   test "is idempotent - does not duplicate entry on retry" do
+    skip "annual checkout disabled until FE wires it up"
     @user.data.update!(
       subscription_interval: "annual",
       subscriptions: [

--- a/test/controllers/internal/subscriptions_controller_test.rb
+++ b/test/controllers/internal/subscriptions_controller_test.rb
@@ -58,6 +58,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
   end
 
   test "POST checkout_session omits trigger when not provided" do
+    skip "annual checkout disabled until FE wires it up"
     return_url = "#{Jiki.config.frontend_base_url}/subscribe/complete"
     session = mock
     session.stubs(:client_secret).returns("cs_secret_x")
@@ -81,6 +82,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
   end
 
   test "POST checkout_session creates session for annual interval" do
+    skip "annual checkout disabled until FE wires it up"
     price_id = Jiki.config.stripe_premium_annual_price_id
     return_url = "#{Jiki.config.frontend_base_url}/subscribe/complete"
     session = mock


### PR DESCRIPTION
## Summary
- `price_map` builds a hash that eagerly dereferences `Jiki.config.stripe_premium_annual_price_id`, so even a monthly checkout crashed with `NoMethodError` in production where that key isn't configured (Sentry: jiki-education/api#434).
- Comments out the annual entry until the FE wires up annual checkout. Skips the annual-only tests with the same reason.

## Test plan
- [ ] `bin/rails test` passes (annual tests now skipped).
- [ ] Hit `POST /internal/subscriptions/checkout_session` with `interval=monthly` in prod-like config (annual key absent) and confirm 200 instead of 500.
- [ ] Revisit and re-enable when FE ships annual checkout + prod DynamoDB gets the annual price ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)