### PR TITLE
Stop requiring Turnstile on chat message saves

### DIFF
--- a/app/controllers/internal/assistant_conversations_controller.rb
+++ b/app/controllers/internal/assistant_conversations_controller.rb
@@ -1,7 +1,7 @@
 class Internal::AssistantConversationsController < Internal::BaseController
   include TurnstileVerifiable
 
-  before_action :verify_turnstile!, only: %i[create create_user_message]
+  before_action :verify_turnstile!, only: %i[create]
 
   def create
     context = find_context

--- a/test/controllers/internal/assistant_conversations_controller_test.rb
+++ b/test/controllers/internal/assistant_conversations_controller_test.rb
@@ -147,12 +147,12 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
   # POST user_messages
   test "POST user_messages successfully adds user message" do
     post user_messages_internal_assistant_conversations_path,
-      params: with_turnstile(
+      params: {
         context_type: "lesson",
         context_identifier: "basic-movement",
         content: "How do I solve this?",
         timestamp: "2025-10-31T08:15:30.000Z"
-      ),
+      },
       as: :json
 
     assert_response :success
@@ -168,19 +168,6 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
     ).returns(build_stubbed(:assistant_conversation))
 
     post user_messages_internal_assistant_conversations_path,
-      params: with_turnstile(
-        context_type: "lesson",
-        context_identifier: "basic-movement",
-        content: "How do I solve this?",
-        timestamp: "2025-10-31T08:15:30.000Z"
-      ),
-      as: :json
-
-    assert_response :success
-  end
-
-  test "POST user_messages returns 403 invalid_captcha when token missing" do
-    post user_messages_internal_assistant_conversations_path,
       params: {
         context_type: "lesson",
         context_identifier: "basic-movement",
@@ -189,7 +176,7 @@ class Internal::AssistantConversationsControllerTest < ApplicationControllerTest
       },
       as: :json
 
-    assert_json_error(:forbidden, error_type: :invalid_captcha)
+    assert_response :success
   end
 
   # POST assistant_messages


### PR DESCRIPTION
## Summary
- The frontend only collects a Turnstile token at the JWT exchange (`POST /internal/assistant_conversations`) and reuses the resulting chat token for the session. Per-message saves never send `cf_turnstile_response`.
- The `before_action :verify_turnstile!` was also gating `create_user_message`, so every save 403'd. `saveConversation` on the FE swallows the error, so the user saw their chat in-session but nothing persisted — on revisit the conversation came back empty.
- Limited `verify_turnstile!` to `:create` only. `create_assistant_message` is unaffected (it was already excluded; it's gated by HMAC instead).

## Test plan
- [x] `bin/rails test test/controllers/internal/assistant_conversations_controller_test.rb` (18 runs, 0 failures)
- [x] Full suite via pre-commit hook (1822 runs, 0 failures)
- [ ] Manual: free user has a chat, completes the exercise, revisits — conversation is still there

🤖 Generated with [Claude Code](https://claude.com/claude-code)