### PR TITLE
Re-enable annual Stripe checkout

### DIFF
--- a/app/commands/stripe/determine_subscription_details.rb
+++ b/app/commands/stripe/determine_subscription_details.rb
@@ -12,8 +12,8 @@ class Stripe::DetermineSubscriptionDetails
 
   def self.price_map
     {
-      'monthly' => Jiki.config.stripe_premium_monthly_price_id
-      # 'annual' => Jiki.config.stripe_premium_annual_price_id
+      'monthly' => Jiki.config.stripe_premium_monthly_price_id,
+      'annual' => Jiki.config.stripe_premium_annual_price_id
     }
   end
 end

--- a/test/commands/stripe/determine_subscription_details_test.rb
+++ b/test/commands/stripe/determine_subscription_details_test.rb
@@ -7,7 +7,6 @@ class Stripe::DetermineSubscriptionDetailsTest < ActiveSupport::TestCase
   end
 
   test "price_id_for returns annual price ID" do
-    skip "annual checkout disabled until FE wires it up"
     assert_equal Jiki.config.stripe_premium_annual_price_id,
       Stripe::DetermineSubscriptionDetails.price_id_for('annual')
   end
@@ -25,7 +24,6 @@ class Stripe::DetermineSubscriptionDetailsTest < ActiveSupport::TestCase
   end
 
   test "interval_for_price_id returns annual for annual price ID" do
-    skip "annual checkout disabled until FE wires it up"
     assert_equal 'annual',
       Stripe::DetermineSubscriptionDetails.interval_for_price_id(Jiki.config.stripe_premium_annual_price_id)
   end

--- a/test/commands/stripe/update_subscription_test.rb
+++ b/test/commands/stripe/update_subscription_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class Stripe::UpdateSubscriptionTest < ActiveSupport::TestCase
   test "switches from monthly to annual with immediate proration" do
-    skip "annual checkout disabled until FE wires it up"
     user = create(:user)
     period_end = 1.year.from_now
     user.data.update!(

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -29,7 +29,6 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
   end
 
   test "verifies checkout session for annual subscription" do
-    skip "annual checkout disabled until FE wires it up"
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
     session_id = "cs_test_123"

--- a/test/commands/stripe/webhook/subscription_created_test.rb
+++ b/test/commands/stripe/webhook/subscription_created_test.rb
@@ -27,7 +27,6 @@ class Stripe::Webhook::SubscriptionCreatedTest < ActiveSupport::TestCase
   end
 
   test "creates annual subscription for user" do
-    skip "annual checkout disabled until FE wires it up"
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
 

--- a/test/commands/stripe/webhook/subscription_updated_test.rb
+++ b/test/commands/stripe/webhook/subscription_updated_test.rb
@@ -187,7 +187,6 @@ class Stripe::Webhook::SubscriptionUpdatedTest < ActiveSupport::TestCase
   end
 
   test "handles interval change from monthly to annual" do
-    skip "annual checkout disabled until FE wires it up"
     @user.data.update!(subscription_interval: "monthly")
 
     subscription = mock_subscription_with_price(Jiki.config.stripe_premium_annual_price_id)
@@ -326,7 +325,6 @@ class Stripe::Webhook::SubscriptionUpdatedTest < ActiveSupport::TestCase
   end
 
   test "is idempotent - does not duplicate entry on retry" do
-    skip "annual checkout disabled until FE wires it up"
     @user.data.update!(
       subscription_interval: "annual",
       subscriptions: [

--- a/test/controllers/internal/subscriptions_controller_test.rb
+++ b/test/controllers/internal/subscriptions_controller_test.rb
@@ -81,7 +81,6 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
   end
 
   test "POST checkout_session creates session for annual interval" do
-    skip "annual checkout disabled until FE wires it up"
     price_id = Jiki.config.stripe_premium_annual_price_id
     return_url = "#{Jiki.config.frontend_base_url}/subscribe/complete"
     session = mock


### PR DESCRIPTION
## Summary
- Restore the `'annual'` entry in `Stripe::DetermineSubscriptionDetails.price_map` now that `stripe_premium_annual_price_id` is configured.
- Un-skip the annual-checkout tests across commands, webhooks, and the subscriptions controller that were parked in #436.

## Test plan
- [x] `bin/rails test` (passes locally via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)