### PR TITLE
Set country_code on signup from CF-IPCountry header

### DIFF
--- a/app/commands/user/bootstrap.rb
+++ b/app/commands/user/bootstrap.rb
@@ -1,9 +1,10 @@
 class User::Bootstrap
   include Mandate
 
-  initialize_with :user, :provider, attribution: nil
+  initialize_with :user, :provider, attribution: nil, country_code: nil
 
   def call
+    set_country_code!
     send_welcome_email!
     enroll_in_course!
     award_member_badge!
@@ -12,6 +13,13 @@ class User::Bootstrap
   end
 
   private
+  def set_country_code!
+    code = country_code.to_s.upcase[0, 2]
+    return if code.blank? || code == "XX"
+
+    user.data.update_column(:country_code, code)
+  end
+
   def send_welcome_email!
     AccountMailer.welcome(user).deliver_later
   end

--- a/app/controllers/auth/exercism_oauth_controller.rb
+++ b/app/controllers/auth/exercism_oauth_controller.rb
@@ -3,7 +3,11 @@ module Auth
     def create
       user = Auth::AuthenticateWithOauth.(:exercism, params[:code], code_verifier: params[:code_verifier])
 
-      User::Bootstrap.(user, "exercism", attribution: signup_attribution_params) if user.previously_new_record?
+      if user.previously_new_record?
+        User::Bootstrap.(user, "exercism",
+          attribution: signup_attribution_params,
+          country_code: request.headers["CF-IPCountry"])
+      end
 
       sign_in_with_2fa_guard!(user)
     rescue InvalidExercismTokenError, InvalidOauthPayloadError => e

--- a/app/controllers/auth/google_oauth_controller.rb
+++ b/app/controllers/auth/google_oauth_controller.rb
@@ -3,7 +3,11 @@ module Auth
     def create
       user = Auth::AuthenticateWithOauth.(:google, params[:code])
 
-      User::Bootstrap.(user, "google", attribution: signup_attribution_params) if user.previously_new_record?
+      if user.previously_new_record?
+        User::Bootstrap.(user, "google",
+          attribution: signup_attribution_params,
+          country_code: request.headers["CF-IPCountry"])
+      end
 
       sign_in_with_2fa_guard!(user)
     rescue InvalidGoogleTokenError, InvalidOauthPayloadError => e

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -7,7 +7,11 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
   def create
     super do |resource|
-      User::Bootstrap.(resource, "email", attribution: signup_attribution_params) if resource.persisted?
+      if resource.persisted?
+        User::Bootstrap.(resource, "email",
+          attribution: signup_attribution_params,
+          country_code: request.headers["CF-IPCountry"])
+      end
     end
   end
 

--- a/test/commands/user/bootstrap_test.rb
+++ b/test/commands/user/bootstrap_test.rb
@@ -167,4 +167,49 @@ class User::BootstrapTest < ActiveSupport::TestCase
 
     assert_nil user.data.reload.signup_attribution
   end
+
+  test "sets country_code on user.data" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+
+    User::Bootstrap.(user, "email", country_code: "JP")
+
+    assert_equal "JP", user.data.reload.country_code
+  end
+
+  test "upcases and truncates country_code to two characters" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+
+    User::Bootstrap.(user, "email", country_code: "jpn")
+
+    assert_equal "JP", user.data.reload.country_code
+  end
+
+  test "does not set country_code when blank" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+
+    User::Bootstrap.(user, "email", country_code: "")
+
+    assert_nil user.data.reload.country_code
+  end
+
+  test "does not set country_code when nil" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+
+    User::Bootstrap.(user, "email")
+
+    assert_nil user.data.reload.country_code
+  end
+
+  test "does not set country_code when XX" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+
+    User::Bootstrap.(user, "email", country_code: "XX")
+
+    assert_nil user.data.reload.country_code
+  end
 end

--- a/test/controllers/auth/exercism_oauth_controller_test.rb
+++ b/test/controllers/auth/exercism_oauth_controller_test.rb
@@ -40,6 +40,31 @@ class Auth::ExercismOauthControllerTest < ApplicationControllerTest
     })
   end
 
+  test "POST exercism forwards CF-IPCountry header to User::Bootstrap" do
+    exercism_payload = {
+      'id' => '9999',
+      'email' => 'country@exercism.org',
+      'name' => 'Country User',
+      'handle' => 'countryuser',
+      'avatar_url' => nil
+    }
+
+    Auth::VerifyExercismToken.stubs(:call).returns(exercism_payload)
+
+    User::Bootstrap.expects(:call).with(
+      instance_of(User),
+      "exercism",
+      has_entries(country_code: "JP")
+    )
+
+    post auth_exercism_path,
+      params: { code: 'valid-exercism-auth-code', code_verifier: 'code-verifier' },
+      headers: { "CF-IPCountry" => "JP" },
+      as: :json
+
+    assert_response :ok
+  end
+
   test "POST exercism with valid code for existing exercism user signs them in" do
     existing_user = create(:user,
       email: 'existing@exercism.org',

--- a/test/controllers/auth/google_oauth_controller_test.rb
+++ b/test/controllers/auth/google_oauth_controller_test.rb
@@ -39,6 +39,30 @@ class Auth::GoogleOauthControllerTest < ApplicationControllerTest
     })
   end
 
+  test "POST google forwards CF-IPCountry header to User::Bootstrap" do
+    google_payload = {
+      'id' => 'google-country-id',
+      'email' => 'country@gmail.com',
+      'name' => 'Country User',
+      'exp' => 1.hour.from_now.to_i
+    }
+
+    Auth::VerifyGoogleToken.stubs(:call).returns(google_payload)
+
+    User::Bootstrap.expects(:call).with(
+      instance_of(User),
+      "google",
+      has_entries(country_code: "JP")
+    )
+
+    post auth_google_path,
+      params: { code: 'valid-google-auth-code' },
+      headers: { "CF-IPCountry" => "JP" },
+      as: :json
+
+    assert_response :ok
+  end
+
   test "POST google with valid code for existing google user signs them in" do
     existing_user = create(:user,
       email: 'existing@gmail.com',

--- a/test/controllers/auth/registrations_controller_test.rb
+++ b/test/controllers/auth/registrations_controller_test.rb
@@ -81,6 +81,47 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
     assert_response :created
   end
 
+  test "POST signup forwards CF-IPCountry header to User::Bootstrap" do
+    User::Bootstrap.expects(:call).with(
+      instance_of(User),
+      "email",
+      has_entries(country_code: "JP")
+    )
+
+    post user_registration_path,
+      params: with_turnstile(
+        user: {
+          email: "jp@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          name: "JP User",
+          handle: "jpuser"
+        }
+      ),
+      headers: { "CF-IPCountry" => "JP" },
+      as: :json
+
+    assert_response :created
+  end
+
+  test "POST signup persists country_code from CF-IPCountry header" do
+    post user_registration_path,
+      params: with_turnstile(
+        user: {
+          email: "jp2@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          name: "JP User",
+          handle: "jpuser2"
+        }
+      ),
+      headers: { "CF-IPCountry" => "JP" },
+      as: :json
+
+    assert_response :created
+    assert_equal "JP", User.find_by(email: "jp2@example.com").data.country_code
+  end
+
   test "POST signup does not call User::Bootstrap on failed registration" do
     assert_no_enqueued_jobs do
       post user_registration_path, params: with_turnstile(


### PR DESCRIPTION
## Summary

- Forward the `CF-IPCountry` header into `User::Bootstrap` from all three signup entry points (email, Google OAuth, Exercism OAuth)
- `User::Bootstrap` now writes `country_code` on `user.data` when the header is present and not `XX`

## Context

Previously `country_code` was only populated by the `set_country_code` before_action on `ApplicationController`, which doesn't fire during signup itself (user isn't signed in yet when the before_action evaluates). Any user whose first authenticated API request after signup arrived without a usable `CF-IPCountry` (e.g. a Cloudflare Worker SSR subrequest, where the visitor's country isn't forwarded) stayed `nil` — and `user.currency` falls back to `:usd`, so Stripe checkout fired in USD even for users on JPY/etc.

The signup request itself comes through Cloudflare from the user's browser, so the header is reliably present at that moment. Reading it during signup means the user record carries the correct currency from the very first response.

The existing `set_country_code` before_action stays in place as a backfill for pre-existing users whose `country_code` is still `nil`.

## Test plan

- [x] `bin/rails test test/commands/user/bootstrap_test.rb test/controllers/auth/`
- [x] Full suite: 1831 runs, 0 failures
- [ ] Sanity-check on staging: sign up with `CF-IPCountry: JP` injected, verify `user_data.country_code = "JP"` and `/internal/me` returns JPY prices

🤖 Generated with [Claude Code](https://claude.com/claude-code)