### PR TITLE
Backfill avatar_url with https:// scheme

### DIFF
--- a/db/migrate/20260608120000_backfill_avatar_url_scheme.rb
+++ b/db/migrate/20260608120000_backfill_avatar_url_scheme.rb
@@ -1,0 +1,10 @@
+class BackfillAvatarUrlScheme < ActiveRecord::Migration[8.0]
+  def up
+    User.where("avatar_url IS NOT NULL AND avatar_url <> '' AND avatar_url NOT LIKE 'http%'").
+      update_all("avatar_url = 'https://' || avatar_url")
+  end
+
+  def down
+    # No-op: cannot reliably reverse without knowing which rows were backfilled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_07_120100) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
## Summary
- Production `avatar_url` values were saved as bare `uploads.<domain>/...` because the terraform `uploads_host` local has no scheme (locals.tf:28 comments that hosts are stored without protocol), while `app/commands/user/avatar/upload.rb:22` just concatenates `"#{uploads_host}/#{key}"`.
- This migration prefixes any existing rows whose `avatar_url` doesn't already start with `http` with `https://` so they resolve correctly.
- Does not fix the underlying source of new bad rows — a follow-up will change `uploads_host` (or upload.rb) to include the scheme.

## Test plan
- [ ] Verify migration runs cleanly on a staging snapshot
- [ ] Spot-check a backfilled `avatar_url` resolves in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)