### PR TITLE
Wire up first_lesson, early_bird, beta_user, and townsfolk badges

### DIFF
--- a/app/commands/user/bootstrap.rb
+++ b/app/commands/user/bootstrap.rb
@@ -8,6 +8,7 @@ class User::Bootstrap
     send_welcome_email!
     enroll_in_course!
     award_member_badge!
+    award_beta_user_badge!
     attribute!
     track!
   end
@@ -35,6 +36,10 @@ class User::Bootstrap
 
   def award_member_badge!
     AwardBadgeJob.perform_later(user, 'member')
+  end
+
+  def award_beta_user_badge!
+    AwardBadgeJob.perform_later(user, 'beta_user')
   end
 
   def attribute!

--- a/app/commands/user_lesson/complete.rb
+++ b/app/commands/user_lesson/complete.rb
@@ -41,9 +41,11 @@ class UserLesson::Complete
     emit_project_unlocked_event! if lesson.unlocked_project
 
     # Check for badges that might be awarded (badge's award_to? determines eligibility)
+    AwardBadgeJob.perform_later(user, 'first_lesson')
     AwardBadgeJob.perform_later(user, 'maze_navigator')
     AwardBadgeJob.perform_later(user, 'scenario_handler')
     AwardBadgeJob.perform_later(user, 'night_owl')
+    AwardBadgeJob.perform_later(user, 'early_bird')
 
     # Log activity for streak tracking
     User::ActivityLog::LogActivity.(user, Date.current)

--- a/app/controllers/auth/discourse_controller.rb
+++ b/app/controllers/auth/discourse_controller.rb
@@ -18,6 +18,8 @@ class Auth::DiscourseController < ApplicationController
     sso.external_id = current_user.id
     sso.sso_secret = secret
 
+    AwardBadgeJob.perform_later(current_user, 'townsfolk')
+
     redirect_to sso.to_url("#{FORUM_URL}/session/sso_login"), allow_other_host: true
   end
 end

--- a/app/models/badges/beta_user_badge.rb
+++ b/app/models/badges/beta_user_badge.rb
@@ -3,7 +3,8 @@ module Badges
     CUTOFF = Time.utc(2026, 7, 1).freeze
 
     seed "Beta User", "Joined Jiki during the beta",
-      fun_fact: "Beta users help shape the future of Jiki. Thank you for believing in us early!"
+      fun_fact: "Beta users help shape the future of Jiki. Thank you for believing in us early!",
+      secret: true
 
     def award_to?(user)
       user.created_at < CUTOFF

--- a/app/models/badges/beta_user_badge.rb
+++ b/app/models/badges/beta_user_badge.rb
@@ -1,0 +1,12 @@
+module Badges
+  class BetaUserBadge < Badge
+    CUTOFF = Time.utc(2026, 7, 1).freeze
+
+    seed "Beta User", "Joined Jiki during the beta",
+      fun_fact: "Beta users help shape the future of Jiki. Thank you for believing in us early!"
+
+    def award_to?(user)
+      user.created_at < CUTOFF
+    end
+  end
+end

--- a/app/models/badges/early_bird_badge.rb
+++ b/app/models/badges/early_bird_badge.rb
@@ -1,11 +1,19 @@
 module Badges
   class EarlyBirdBadge < Badge
-    seed "Early Bird", "Joined during early access",
-      fun_fact: "Early adopters help shape the future of products. Thank you for believing in us!",
+    seed "Early Bird", "Completed a lesson in the early-morning hours",
+      fun_fact: "The early bird catches the worm. Coding before the world wakes up is a superpower!",
       secret: true
 
     def award_to?(user)
-      user.created_at < 1.month.ago
+      user.user_lessons.completed.pluck(:completed_at).any? do |completed_at|
+        early_bird_time?(completed_at, user.timezone)
+      end
+    end
+
+    private
+    def early_bird_time?(time, timezone)
+      hour = time.in_time_zone(timezone).hour
+      hour >= 4 && hour < 9
     end
   end
 end

--- a/app/models/badges/townsfolk_badge.rb
+++ b/app/models/badges/townsfolk_badge.rb
@@ -1,0 +1,10 @@
+module Badges
+  class TownsfolkBadge < Badge
+    seed "Townsfolk", "Joined the Jiki community forum",
+      fun_fact: "The best way to learn is to teach. Welcome to the conversation!"
+
+    # Awarded when a user completes Discourse SSO, so eligibility is implied by
+    # the enqueue site (Auth::DiscourseController#sso).
+    def award_to?(_user) = true
+  end
+end

--- a/script/backfill_new_badges.rb
+++ b/script/backfill_new_badges.rb
@@ -1,0 +1,26 @@
+# Backfill first_lesson, early_bird, and beta_user badges for existing users.
+#
+# Run with:
+#   bin/rails r script/backfill_new_badges.rb
+#
+# Safe to re-run: User::AcquiredBadge::Create is idempotent (returns the
+# existing record if the user already has the badge) and raises
+# BadgeCriteriaNotFulfilledError when award_to? is false, which we swallow.
+
+BADGES = %w[first_lesson early_bird beta_user].freeze
+
+stats = BADGES.index_with { { awarded: 0, skipped: 0 } }
+
+User.find_each do |user|
+  BADGES.each do |slug|
+    User::AcquiredBadge::Create.(user, slug)
+    stats[slug][:awarded] += 1
+  rescue BadgeCriteriaNotFulfilledError
+    stats[slug][:skipped] += 1
+  end
+end
+
+puts "Backfill complete:"
+stats.each do |slug, counts|
+  puts "  #{slug.ljust(16)} awarded=#{counts[:awarded]} skipped=#{counts[:skipped]}"
+end

--- a/test/commands/user/bootstrap_test.rb
+++ b/test/commands/user/bootstrap_test.rb
@@ -37,6 +37,15 @@ class User::BootstrapTest < ActiveSupport::TestCase
     end
   end
 
+  test "enqueues beta user badge award job" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+
+    assert_enqueued_with(job: AwardBadgeJob, args: [user, 'beta_user']) do
+      User::Bootstrap.(user, "email")
+    end
+  end
+
   test "awards member badge to new user" do
     create(:course, slug: "coding-fundamentals")
     user = create(:user)

--- a/test/commands/user_lesson/complete_test.rb
+++ b/test/commands/user_lesson/complete_test.rb
@@ -224,6 +224,30 @@ class UserLesson::CompleteTest < ActiveSupport::TestCase
   end
 
   # Badge tests
+  test "enqueues first lesson badge job on lesson completion" do
+    user = create(:user)
+    level = create(:level)
+    lesson = create(:lesson, :exercise, level:)
+    create(:user_level, user:, level:)
+    create(:user_lesson, user:, lesson:)
+
+    assert_enqueued_with(job: AwardBadgeJob, args: [user, 'first_lesson']) do
+      UserLesson::Complete.(user, lesson)
+    end
+  end
+
+  test "enqueues early bird badge job on lesson completion" do
+    user = create(:user)
+    level = create(:level)
+    lesson = create(:lesson, :exercise, level:)
+    create(:user_level, user:, level:)
+    create(:user_lesson, user:, lesson:)
+
+    assert_enqueued_with(job: AwardBadgeJob, args: [user, 'early_bird']) do
+      UserLesson::Complete.(user, lesson)
+    end
+  end
+
   test "enqueues maze navigator badge job on lesson completion" do
     user = create(:user)
     level = create(:level)

--- a/test/controllers/auth/discourse_controller_test.rb
+++ b/test/controllers/auth/discourse_controller_test.rb
@@ -28,6 +28,25 @@ class Auth::DiscourseControllerTest < ApplicationControllerTest
     assert_includes return_to, "sig="
   end
 
+  test "GET sso enqueues townsfolk badge for authenticated user" do
+    Jiki.secrets.stubs(:discourse_sso_secret).returns(@secret)
+    sign_in_user(@user)
+    sso_payload = build_sso_payload(nonce: "badge_nonce")
+
+    assert_enqueued_with(job: AwardBadgeJob, args: [@user, 'townsfolk']) do
+      get auth_discourse_sso_path, params: { sso: sso_payload[:sso], sig: sso_payload[:sig] }
+    end
+  end
+
+  test "GET sso does not enqueue townsfolk badge for unauthenticated user" do
+    Jiki.config.stubs(:frontend_base_url).returns("https://app.jiki.io")
+    sso_payload = build_sso_payload(nonce: "unauth_nonce")
+
+    assert_no_enqueued_jobs(only: AwardBadgeJob) do
+      get auth_discourse_sso_path, params: { sso: sso_payload[:sso], sig: sso_payload[:sig] }
+    end
+  end
+
   test "GET sso redirects authenticated user to Discourse with signed payload" do
     Jiki.secrets.stubs(:discourse_sso_secret).returns(@secret)
 

--- a/test/models/badges/beta_user_badge_test.rb
+++ b/test/models/badges/beta_user_badge_test.rb
@@ -6,7 +6,7 @@ class Badges::BetaUserBadgeTest < ActiveSupport::TestCase
 
     assert_equal 'Beta User', badge.name
     assert_equal 'Joined Jiki during the beta', badge.description
-    refute badge.secret
+    assert badge.secret
   end
 
   test "award_to? returns true when user was created before July 1st 2026" do

--- a/test/models/badges/beta_user_badge_test.rb
+++ b/test/models/badges/beta_user_badge_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class Badges::BetaUserBadgeTest < ActiveSupport::TestCase
+  test "has correct seed data" do
+    badge = Badge.find_by_slug!('beta_user') # rubocop:disable Rails/DynamicFindBy
+
+    assert_equal 'Beta User', badge.name
+    assert_equal 'Joined Jiki during the beta', badge.description
+    refute badge.secret
+  end
+
+  test "award_to? returns true when user was created before July 1st 2026" do
+    badge = Badge.find_by_slug!('beta_user') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.update_column(:created_at, Time.utc(2026, 6, 30, 23, 59, 59))
+
+    assert badge.award_to?(user)
+  end
+
+  test "award_to? returns false when user was created on July 1st 2026" do
+    badge = Badge.find_by_slug!('beta_user') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.update_column(:created_at, Time.utc(2026, 7, 1, 0, 0, 0))
+
+    refute badge.award_to?(user)
+  end
+
+  test "award_to? returns false when user was created after July 1st 2026" do
+    badge = Badge.find_by_slug!('beta_user') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.update_column(:created_at, Time.utc(2026, 8, 1, 0, 0, 0))
+
+    refute badge.award_to?(user)
+  end
+end

--- a/test/models/badges/early_bird_badge_test.rb
+++ b/test/models/badges/early_bird_badge_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class Badges::EarlyBirdBadgeTest < ActiveSupport::TestCase
+  test "has correct seed data" do
+    badge = Badge.find_by_slug!('early_bird') # rubocop:disable Rails/DynamicFindBy
+
+    assert_equal 'Early Bird', badge.name
+    assert_equal 'Completed a lesson in the early-morning hours', badge.description
+    assert badge.secret
+  end
+
+  test "award_to? returns true when lesson completed at 5am in user timezone" do
+    badge = Badge.find_by_slug!('early_bird') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.data.update!(timezone: "UTC")
+    lesson = create(:lesson, :exercise)
+    create(:user_lesson, :completed, user:, lesson:, completed_at: Time.utc(2026, 3, 21, 5, 0, 0))
+
+    assert badge.award_to?(user)
+  end
+
+  test "award_to? returns true at boundary of exactly 4am" do
+    badge = Badge.find_by_slug!('early_bird') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.data.update!(timezone: "UTC")
+    lesson = create(:lesson, :exercise)
+    create(:user_lesson, :completed, user:, lesson:, completed_at: Time.utc(2026, 3, 21, 4, 0, 0))
+
+    assert badge.award_to?(user)
+  end
+
+  test "award_to? returns false at boundary of exactly 9am" do
+    badge = Badge.find_by_slug!('early_bird') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.data.update!(timezone: "UTC")
+    lesson = create(:lesson, :exercise)
+    create(:user_lesson, :completed, user:, lesson:, completed_at: Time.utc(2026, 3, 21, 9, 0, 0))
+
+    refute badge.award_to?(user)
+  end
+
+  test "award_to? returns false at 3:59am" do
+    badge = Badge.find_by_slug!('early_bird') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.data.update!(timezone: "UTC")
+    lesson = create(:lesson, :exercise)
+    create(:user_lesson, :completed, user:, lesson:, completed_at: Time.utc(2026, 3, 21, 3, 59, 0))
+
+    refute badge.award_to?(user)
+  end
+
+  test "award_to? returns false when lesson completed at 3pm" do
+    badge = Badge.find_by_slug!('early_bird') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.data.update!(timezone: "UTC")
+    lesson = create(:lesson, :exercise)
+    create(:user_lesson, :completed, user:, lesson:, completed_at: Time.utc(2026, 3, 21, 15, 0, 0))
+
+    refute badge.award_to?(user)
+  end
+
+  test "award_to? returns false when no completed lessons" do
+    badge = Badge.find_by_slug!('early_bird') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+
+    refute badge.award_to?(user)
+  end
+
+  test "award_to? respects user timezone" do
+    badge = Badge.find_by_slug!('early_bird') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.data.update!(timezone: "Asia/Karachi") # UTC+5
+    lesson = create(:lesson, :exercise)
+    # 5am UTC = 10am in Asia/Karachi - outside window
+    create(:user_lesson, :completed, user:, lesson:, completed_at: Time.utc(2026, 3, 21, 5, 0, 0))
+
+    refute badge.award_to?(user)
+  end
+
+  test "award_to? converts UTC to early morning in user timezone" do
+    badge = Badge.find_by_slug!('early_bird') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    user.data.update!(timezone: "Asia/Karachi") # UTC+5
+    lesson = create(:lesson, :exercise)
+    # midnight UTC = 5am in Asia/Karachi - in window
+    create(:user_lesson, :completed, user:, lesson:, completed_at: Time.utc(2026, 3, 21, 0, 0, 0))
+
+    assert badge.award_to?(user)
+  end
+end

--- a/test/models/badges/first_lesson_badge_test.rb
+++ b/test/models/badges/first_lesson_badge_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class Badges::FirstLessonBadgeTest < ActiveSupport::TestCase
+  test "has correct seed data" do
+    badge = Badge.find_by_slug!('first_lesson') # rubocop:disable Rails/DynamicFindBy
+
+    assert_equal 'First Steps', badge.name
+    assert_equal 'Completed your first lesson', badge.description
+    refute badge.secret
+  end
+
+  test "award_to? returns true when user has a completed lesson" do
+    badge = Badge.find_by_slug!('first_lesson') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    lesson = create(:lesson, :exercise)
+    create(:user_lesson, :completed, user:, lesson:)
+
+    assert badge.award_to?(user)
+  end
+
+  test "award_to? returns false when user has no completed lessons" do
+    badge = Badge.find_by_slug!('first_lesson') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+
+    refute badge.award_to?(user)
+  end
+
+  test "award_to? returns false when user has an in-progress lesson but none completed" do
+    badge = Badge.find_by_slug!('first_lesson') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+    lesson = create(:lesson, :exercise)
+    create(:user_lesson, user:, lesson:)
+
+    refute badge.award_to?(user)
+  end
+end

--- a/test/models/badges/townsfolk_badge_test.rb
+++ b/test/models/badges/townsfolk_badge_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class Badges::TownsfolkBadgeTest < ActiveSupport::TestCase
+  test "has correct seed data" do
+    badge = Badge.find_by_slug!('townsfolk') # rubocop:disable Rails/DynamicFindBy
+
+    assert_equal 'Townsfolk', badge.name
+    assert_equal 'Joined the Jiki community forum', badge.description
+    refute badge.secret
+  end
+
+  test "award_to? returns true for any user" do
+    badge = Badge.find_by_slug!('townsfolk') # rubocop:disable Rails/DynamicFindBy
+    user = create(:user)
+
+    assert badge.award_to?(user)
+  end
+end


### PR DESCRIPTION
## Summary
- **Fixes a latent bug**: `first_lesson` and `early_bird` badges existed but were never enqueued, so no user could earn them. `UserLesson::Complete` now enqueues both alongside the existing trio.
- **Redefines Early Bird** from "joined during early access" to "completed a lesson between 4:00–8:59 in the user's local timezone" — mirrors `NightOwlBadge`.
- **Adds Beta User badge** (secret): awarded to anyone whose account was created before 2026-07-01 UTC. Enqueued from `User::Bootstrap` on signup.
- **Adds Townsfolk badge**: awarded when a user completes Discourse SSO into the community forum. Enqueued from `Auth::DiscourseController#sso`.
- Adds `script/backfill_new_badges.rb` (run via `bin/rails r`) to retroactively award `first_lesson`, `early_bird`, and `beta_user` to existing users. Idempotent; safe to re-run.

## Front-end follow-up
The following SVG icons need adding in `front-end/curriculum/images/badge-icons/`:
- `beta_user.svg`
- `townsfolk.svg`

(`first_lesson.svg` and `early_bird.svg` already exist.)

## Test plan
- [ ] `bin/rails test test/models/badges test/commands/user_lesson/complete_test.rb test/commands/user/bootstrap_test.rb test/controllers/auth/discourse_controller_test.rb` passes
- [ ] Complete a lesson between 4–9am local time → Early Bird awarded
- [ ] Complete first lesson → First Steps awarded
- [ ] New signup before 2026-07-01 → Beta User awarded; signup after → not awarded
- [ ] Visit `/auth/discourse/sso` while signed in → Townsfolk awarded
- [ ] Run `bin/rails r script/backfill_new_badges.rb` in staging and confirm counts look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)