### PR TITLE
Set email From display name to "Jiki"

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -48,7 +48,7 @@ class ApplicationMailer < ActionMailer::Base
     end
 
     # Set from address, SES configuration set, and reply-to
-    args[:from] ||= config[:from_email]
+    args[:from] ||= "Jiki <#{config[:from_email]}>"
     args[:reply_to] ||= Jiki.config.support_email
     headers['X-SES-CONFIGURATION-SET'] = config[:configuration_set]
 


### PR DESCRIPTION
## Summary
- Wrap the From address in all mailers with a "Jiki" display name so recipients see "Jiki" rather than "hello" as the sender.

## Test plan
- [x] `bin/rails test test/mailers/` passes
- [ ] Send a test email locally and verify the From shows as "Jiki <hello@...>"

🤖 Generated with [Claude Code](https://claude.com/claude-code)