### PR TITLE
Retry jobs 10 times by default

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,13 @@
 class ApplicationJob < ActiveJob::Base
+  # Blanket retry for any unhandled error — Solid Queue has no built-in
+  # auto-retry, so without this, a single transient failure (network blip,
+  # third-party API hiccup, brief DB unavailability) leaves the job in
+  # `solid_queue_failed_executions` permanently. Declared first so it acts
+  # as the fallback; later `retry_on` / `discard_on` declarations on this
+  # class or subclasses take precedence (ActiveJob walks declarations in
+  # reverse order).
+  retry_on StandardError, wait: :polynomially_longer, attempts: 10
+
   # Automatically retry jobs that encountered a deadlock
   retry_on ActiveRecord::Deadlocked
 

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -72,16 +72,21 @@ class ApplicationJobTest < ActiveJob::TestCase
   test "gives up after 10 attempts on a persistently-failing job" do
     AlwaysFailingJob.calls = 0
 
-    # The 10th attempt re-raises after retries are exhausted; that's the
-    # signal Solid Queue uses to move the job to failed_executions.
+    # Minitest wraps unexpected exceptions in Minitest::UnexpectedError to
+    # distinguish them from assertion failures, which bypasses our StandardError
+    # rescue. Catch the wrapper and assert on the underlying exception.
+    captured = nil
     begin
       perform_enqueued_jobs do
         AlwaysFailingJob.perform_later
       end
-    rescue Exception # rubocop:disable Lint/RescueException
-      # expected — the final retry re-raises
+    rescue Minitest::UnexpectedError => e
+      captured = e.error
     end
 
+    refute_nil captured, "expected the final retry to re-raise"
+    assert_instance_of RuntimeError, captured
+    assert_equal "always fails", captured.message
     assert_equal 10, AlwaysFailingJob.calls
   end
 

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -41,6 +41,50 @@ class ApplicationJobTest < ActiveJob::TestCase
     assert_respond_to ApplicationJob, :retry_on
   end
 
+  class FlakyJob < ApplicationJob
+    cattr_accessor :calls, default: 0
+
+    def perform
+      self.class.calls += 1
+      raise "flaky" if self.class.calls < 3
+    end
+  end
+
+  test "retries any unhandled StandardError" do
+    FlakyJob.calls = 0
+
+    perform_enqueued_jobs do
+      FlakyJob.perform_later
+    end
+
+    assert_equal 3, FlakyJob.calls
+  end
+
+  class AlwaysFailingJob < ApplicationJob
+    cattr_accessor :calls, default: 0
+
+    def perform
+      self.class.calls += 1
+      raise "always fails"
+    end
+  end
+
+  test "gives up after 10 attempts on a persistently-failing job" do
+    AlwaysFailingJob.calls = 0
+
+    # The 10th attempt re-raises after retries are exhausted; that's the
+    # signal Solid Queue uses to move the job to failed_executions.
+    begin
+      perform_enqueued_jobs do
+        AlwaysFailingJob.perform_later
+      end
+    rescue Exception # rubocop:disable Lint/RescueException
+      # expected — the final retry re-raises
+    end
+
+    assert_equal 10, AlwaysFailingJob.calls
+  end
+
   test "guard_against_deserialization_errors? defaults to true" do
     job = TestJobWithGuard.new
     assert job.guard_against_deserialization_errors?

--- a/test/jobs/mandate_job_test.rb
+++ b/test/jobs/mandate_job_test.rb
@@ -180,12 +180,20 @@ class MandateJobTest < ActiveJob::TestCase
     assert job.guard_against_deserialization_errors?
   end
 
-  test "job fails when Mandate command raises unhandled exception" do
-    error = assert_raises StandardError do
-      MandateJob.perform_now("MandateJobTest::TestErrorCommand")
+  test "job re-raises after retries when Mandate command raises unhandled exception" do
+    # ApplicationJob has a blanket retry_on StandardError; the first attempt
+    # schedules a retry rather than propagating. After retries are exhausted
+    # the underlying exception is re-raised.
+    error = nil
+    begin
+      perform_enqueued_jobs do
+        MandateJob.perform_later("MandateJobTest::TestErrorCommand")
+      end
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      error = e
     end
 
-    assert_equal "Test error", error.message
+    assert_includes error&.message.to_s, "Test error"
   end
 
   test "requeue preserves all arguments" do

--- a/test/jobs/mandate_job_test.rb
+++ b/test/jobs/mandate_job_test.rb
@@ -183,17 +183,19 @@ class MandateJobTest < ActiveJob::TestCase
   test "job re-raises after retries when Mandate command raises unhandled exception" do
     # ApplicationJob has a blanket retry_on StandardError; the first attempt
     # schedules a retry rather than propagating. After retries are exhausted
-    # the underlying exception is re-raised.
+    # the underlying exception is re-raised — but Minitest wraps it in
+    # Minitest::UnexpectedError, so we catch and unwrap.
     error = nil
     begin
       perform_enqueued_jobs do
         MandateJob.perform_later("MandateJobTest::TestErrorCommand")
       end
-    rescue Exception => e # rubocop:disable Lint/RescueException
-      error = e
+    rescue Minitest::UnexpectedError => e
+      error = e.error
     end
 
-    assert_includes error&.message.to_s, "Test error"
+    refute_nil error, "expected the final retry to re-raise"
+    assert_equal "Test error", error.message
   end
 
   test "requeue preserves all arguments" do


### PR DESCRIPTION
## Summary
- Solid Queue 1.4.0 has no built-in auto-retry. Without `retry_on`, an unhandled exception moves the job to `solid_queue_failed_executions` permanently — even for transient failures.
- Adds a blanket `retry_on StandardError, attempts: 10, wait: :polynomially_longer` to `ApplicationJob`. Behaviour aligns roughly with Sidekiq's habit.
- Subclasses' `retry_on` / `discard_on` declarations take precedence (ActiveJob walks declarations in reverse order).

## Trade-off
- Catches real transient failures and self-heals (good).
- Also wraps permanent bugs in 10 attempts before giving up (noisy but bounded, ~30 min total with polynomial backoff). Use `discard_on SpecificError` per class when retries are clearly wasteful.

## Test plan
- [x] `bin/rails test` — full suite green
- [x] `bin/rubocop` — no offenses
- [x] New tests in `application_job_test.rb`: transient failure self-heals after a couple of attempts; persistent failure gives up after 10
- [x] Updated `mandate_job_test.rb` to reflect retry-then-raise instead of immediate raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)