### PR TITLE
Remove stub deep dive from Maze Solve Repeat

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     bigdecimal (4.1.2)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     childprocess (5.1.0)

--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -217,13 +217,7 @@
           "type": "exercise",
           "data": {
             "slug": "maze-solve-repeat"
-          },
-          "walkthrough_video_data": [
-            {
-              "provider": "mux",
-              "id": "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU"
-            }
-          ]
+          }
         },
         {
           "uuid": "057f7bf7-b033-4174-ab04-f8aa4a58e6b6",


### PR DESCRIPTION
## Summary
- Drop the `walkthrough_video_data` stub from the Maze Solve Repeat lesson seed so the Deep Dive panel no longer renders for it.
- Bump Brakeman 8.0.4 → 8.0.5 so the pre-commit `--ensure-latest` check passes.

## Test plan
- [ ] `bin/rails db:seed` and confirm the Maze Solve Repeat lesson no longer exposes walkthrough video data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)