### PR TITLE
Fix project list hiding projects started by other users

### DIFF
--- a/app/commands/project/search.rb
+++ b/app/commands/project/search.rb
@@ -35,18 +35,18 @@ class Project::Search
   end
 
   def apply_ordering!
-    if user
-      # Scope the join to the current user so other users' user_projects don't filter projects out.
-      @projects = @projects.
-        joins(sanitize_sql_array([
-                                   "LEFT JOIN user_projects ON user_projects.project_id = projects.id AND user_projects.user_id = ?",
-                                   user.id
-                                 ])).
-        select("projects.*, CASE WHEN user_projects.user_id IS NOT NULL THEN 0 ELSE 1 END as lock_order").
-        order("lock_order ASC, projects.title ASC")
-    else
-      @projects = @projects.order(:title)
-    end
+    return @projects = @projects.order(:title) unless user
+
+    # Scope the join to the current user so other users' user_projects don't filter projects out.
+    @projects = @projects.
+      joins(sanitize_sql_array(
+        [
+          "LEFT JOIN user_projects ON user_projects.project_id = projects.id AND user_projects.user_id = ?",
+          user.id
+        ]
+      )).
+      select("projects.*, CASE WHEN user_projects.user_id IS NOT NULL THEN 0 ELSE 1 END as lock_order").
+      order("lock_order ASC, projects.title ASC")
   end
 
   def sanitize_sql_array(array)

--- a/app/commands/project/search.rb
+++ b/app/commands/project/search.rb
@@ -36,15 +36,15 @@ class Project::Search
 
   def apply_ordering!
     if user
-      # Order by whether user has unlocked the project (unlocked first), then by title
+      # Scope the join to the current user so other users' user_projects don't filter projects out.
       @projects = @projects.
-        left_joins(:user_projects).
-        where("user_projects.user_id IS NULL OR user_projects.user_id = ?", user.id).
-        select(sanitize_sql_array(["projects.*, CASE WHEN user_projects.user_id = ? THEN 0 ELSE 1 END as lock_order", user.id])).
-        order("lock_order ASC, projects.title ASC").
-        distinct
+        joins(sanitize_sql_array([
+                                   "LEFT JOIN user_projects ON user_projects.project_id = projects.id AND user_projects.user_id = ?",
+                                   user.id
+                                 ])).
+        select("projects.*, CASE WHEN user_projects.user_id IS NOT NULL THEN 0 ELSE 1 END as lock_order").
+        order("lock_order ASC, projects.title ASC")
     else
-      # Default ordering by title
       @projects = @projects.order(:title)
     end
   end

--- a/test/commands/project/search_test.rb
+++ b/test/commands/project/search_test.rb
@@ -109,6 +109,19 @@ class Project::SearchTest < ActiveSupport::TestCase
     assert_equal [project_calc2, project_calc3, project_calc1], result
   end
 
+  test "user: returns projects even when other users have user_projects for them" do
+    project = create :project, title: "Shared Project"
+    user = create :user
+    other_user = create :user
+
+    # Another user has started this project, but our user has not
+    create :user_project, user: other_user, project: project
+
+    result = Project::Search.(user:).to_a
+
+    assert_equal [project], result
+  end
+
   test "user: pagination works correctly with user filtering" do
     project_1 = create :project, title: "Apple"
     project_2 = create :project, title: "Banana"


### PR DESCRIPTION
## Summary
- `Project::Search` did `left_joins(:user_projects)` with `WHERE user_projects.user_id IS NULL OR user_projects.user_id = ?`. When another user had a `UserProject` row for a project, the LEFT JOIN returned that row (not NULL), the WHERE filtered it out, and the project disappeared from the current user's list entirely.
- Moved the user filter into the JOIN's `ON` clause so each project joins at most one `UserProject` (its own, or none). Dropped the now-unneeded `WHERE` and `.distinct`.
- Reported by a premium user who unlocked "Sprouting Flower" but couldn't find it on the projects page.

## Test plan
- [x] New regression test in `Project::SearchTest`: project visible to user even when another user has a `UserProject` for it
- [x] Existing `Project::SearchTest` (11 tests), `Internal::ProjectsControllerTest`, `SerializeProjectsTest` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)