### PR TITLE
Add not_started lesson to user_levels serializer

### DIFF
--- a/app/serializers/serialize_user_levels.rb
+++ b/app/serializers/serialize_user_levels.rb
@@ -28,8 +28,9 @@ class SerializeUserLevels
       rows.each do |row|
         if row[:user_lesson_id].present?
           lessons << serialize_lesson(row, row[:completed_at].present? ? "completed" : "started")
-        elsif !in_progress
+        elsif !in_progress && row[:user_level_completed_at].blank?
           # First lesson with no UserLesson record: this is the next lesson up.
+          # A completed level never advertises a next lesson.
           lessons << serialize_lesson(row, "not_started")
           break
         else

--- a/app/serializers/serialize_user_levels.rb
+++ b/app/serializers/serialize_user_levels.rb
@@ -4,55 +4,73 @@ class SerializeUserLevels
   initialize_with :user_levels
 
   def call
-    # Group data from single optimized query by level
+    # Group the single optimized query by level, preserving level position order
     grouped = results.group_by { |row| row[:level_slug] }
 
-    # Serialize each level with its lessons
     grouped.map do |level_slug, rows|
       {
         level_slug: level_slug,
-        status: user_level_status(level_slug),
-        user_lessons: rows.map do |row|
-          {
-            lesson_slug: row[:lesson_slug],
-            status: row[:completed_at].present? ? "completed" : "started",
-            walkthrough_video_watched_percentage: row[:walkthrough_video_watched_percentage]
-          }
-        end
+        status: rows.first[:user_level_completed_at] ? "completed" : "started",
+        user_lessons: serialize_lessons(rows)
       }
     end
   end
 
   private
-  def user_level_status(level_slug)
-    @user_level_statuses ||= {}
-    @user_level_statuses[level_slug] ||= results.find do |r|
-      r[:level_slug] == level_slug
-    end[:user_level_completed_at] ? "completed" : "started"
+  # Each level's rows are ordered by lesson position. We emit every lesson the
+  # user has a record for (completed/started), and - provided nothing in the
+  # level is currently in progress - the single next lesson as not_started.
+  # Lessons beyond that next one are not included.
+  def serialize_lessons(rows)
+    in_progress = rows.any? { |row| row[:user_lesson_id].present? && row[:completed_at].blank? }
+
+    [].tap do |lessons|
+      rows.each do |row|
+        if row[:user_lesson_id].present?
+          lessons << serialize_lesson(row, row[:completed_at].present? ? "completed" : "started")
+        elsif !in_progress
+          # First lesson with no UserLesson record: this is the next lesson up.
+          lessons << serialize_lesson(row, "not_started")
+          break
+        else
+          break
+        end
+      end
+    end
+  end
+
+  def serialize_lesson(row, status)
+    {
+      lesson_slug: row[:lesson_slug],
+      status:,
+      walkthrough_video_watched_percentage: row[:walkthrough_video_watched_percentage]
+    }
   end
 
   memoize
   def results
     results = user_levels.
       joins(:level).
-      joins(level: { lessons: :user_lessons }).
-      where("user_lessons.user_id = user_levels.user_id").
+      joins("INNER JOIN lessons ON lessons.level_id = levels.id").
+      joins("LEFT JOIN user_lessons ON user_lessons.lesson_id = lessons.id AND user_lessons.user_id = user_levels.user_id").
       order("levels.position, lessons.position").
       pluck(
         "levels.slug",
         "lessons.slug",
+        "user_lessons.id",
         "user_lessons.completed_at",
         "user_lessons.walkthrough_video_watched_percentage",
         "user_levels.completed_at"
       )
 
     # Map pluck results (arrays) to hashes for easier access
-    results.map do |level_slug, lesson_slug, lesson_completed_at, walkthrough_video_watched_percentage, user_level_completed_at|
+    results.map do |level_slug, lesson_slug, user_lesson_id, lesson_completed_at, watched_percentage, user_level_completed_at|
       {
         level_slug: level_slug,
         lesson_slug: lesson_slug,
+        user_lesson_id: user_lesson_id,
         completed_at: lesson_completed_at,
-        walkthrough_video_watched_percentage: walkthrough_video_watched_percentage,
+        walkthrough_video_watched_percentage: watched_percentage,
         user_level_completed_at: user_level_completed_at
       }
     end

--- a/test/serializers/serialize_user_levels_test.rb
+++ b/test/serializers/serialize_user_levels_test.rb
@@ -44,13 +44,95 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
     assert_empty SerializeUserLevels.(user.user_levels)
   end
 
-  test "excludes levels with no user_lessons" do
+  test "no not_started lesson is appended while a lesson is in progress" do
     user = create(:user)
-    level = create(:level, slug: "empty-level")
-    create(:user_level, user: user, level: level)
-    create(:lesson, :exercise, level: level, slug: "lesson-1")
+    level = create(:level, slug: "basics")
 
-    assert_empty SerializeUserLevels.(user.user_levels)
+    lesson1 = create(:lesson, :exercise, level: level, slug: "lesson-1", position: 1)
+    lesson2 = create(:lesson, :exercise, level: level, slug: "lesson-2", position: 2)
+    create(:lesson, :exercise, level: level, slug: "lesson-3", position: 3)
+
+    create(:user_level, user: user, level: level)
+    create(:user_lesson, user: user, lesson: lesson1, completed_at: Time.current)
+    create(:user_lesson, user: user, lesson: lesson2, completed_at: nil)
+
+    # lesson-2 is in progress, so lesson-3 is NOT appended as not_started
+    expected = [
+      {
+        level_slug: "basics",
+        status: "started",
+        user_lessons: [
+          { lesson_slug: "lesson-1", status: "completed", walkthrough_video_watched_percentage: nil },
+          { lesson_slug: "lesson-2", status: "started", walkthrough_video_watched_percentage: nil }
+        ]
+      }
+    ]
+
+    assert_equal(expected, SerializeUserLevels.(user.user_levels))
+  end
+
+  test "appends the next lesson as not_started mid-level when all started lessons are complete" do
+    user = create(:user)
+    level = create(:level, slug: "basics")
+
+    lesson1 = create(:lesson, :exercise, level: level, slug: "lesson-1", position: 1)
+    lesson2 = create(:lesson, :exercise, level: level, slug: "lesson-2", position: 2)
+    create(:lesson, :exercise, level: level, slug: "lesson-3", position: 3)
+
+    create(:user_level, user: user, level: level)
+    create(:user_lesson, user: user, lesson: lesson1, completed_at: Time.current)
+    create(:user_lesson, user: user, lesson: lesson2, completed_at: Time.current)
+
+    # All started lessons complete, so the next lesson (lesson-3) is appended as not_started.
+    # lesson-3 is the only not_started lesson - later lessons are not included.
+    expected = [
+      {
+        level_slug: "basics",
+        status: "started",
+        user_lessons: [
+          { lesson_slug: "lesson-1", status: "completed", walkthrough_video_watched_percentage: nil },
+          { lesson_slug: "lesson-2", status: "completed", walkthrough_video_watched_percentage: nil },
+          { lesson_slug: "lesson-3", status: "not_started", walkthrough_video_watched_percentage: nil }
+        ]
+      }
+    ]
+
+    assert_equal(expected, SerializeUserLevels.(user.user_levels))
+  end
+
+  test "appends the first lesson of the next level as not_started when the current level is complete" do
+    user = create(:user)
+    level1 = create(:level, slug: "basics", position: 1)
+    level2 = create(:level, slug: "advanced", position: 2)
+
+    lesson1 = create(:lesson, :exercise, level: level1, slug: "lesson-1", position: 1)
+    create(:lesson, :exercise, level: level2, slug: "lesson-2", position: 1)
+    create(:lesson, :exercise, level: level2, slug: "lesson-3", position: 2)
+
+    create(:user_level, user: user, level: level1, completed_at: Time.current)
+    create(:user_level, user: user, level: level2)
+    create(:user_lesson, user: user, lesson: lesson1, completed_at: Time.current)
+
+    # level2 has a UserLevel but no UserLessons yet (freshly unlocked).
+    # Its first lesson (lesson-2) is appended as not_started; lesson-3 is not included.
+    expected = [
+      {
+        level_slug: "basics",
+        status: "completed",
+        user_lessons: [
+          { lesson_slug: "lesson-1", status: "completed", walkthrough_video_watched_percentage: nil }
+        ]
+      },
+      {
+        level_slug: "advanced",
+        status: "started",
+        user_lessons: [
+          { lesson_slug: "lesson-2", status: "not_started", walkthrough_video_watched_percentage: nil }
+        ]
+      }
+    ]
+
+    assert_equal(expected, SerializeUserLevels.(user.user_levels))
   end
 
   test "maintains level position order" do

--- a/test/serializers/serialize_user_levels_test.rb
+++ b/test/serializers/serialize_user_levels_test.rb
@@ -135,6 +135,35 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
     assert_equal(expected, SerializeUserLevels.(user.user_levels))
   end
 
+  test "does not append a not_started lesson to a completed level" do
+    user = create(:user)
+    level = create(:level, slug: "basics")
+
+    lesson1 = create(:lesson, :exercise, level: level, slug: "lesson-1", position: 1)
+    lesson2 = create(:lesson, :exercise, level: level, slug: "lesson-2", position: 2)
+    # lesson-3 has no UserLesson record. Normal progression can't complete a level
+    # with an unstarted lesson, but a completed level must never advertise a next
+    # lesson even if content drifts.
+    create(:lesson, :exercise, level: level, slug: "lesson-3", position: 3)
+
+    create(:user_level, user: user, level: level, completed_at: Time.current)
+    create(:user_lesson, user: user, lesson: lesson1, completed_at: Time.current)
+    create(:user_lesson, user: user, lesson: lesson2, completed_at: Time.current)
+
+    expected = [
+      {
+        level_slug: "basics",
+        status: "completed",
+        user_lessons: [
+          { lesson_slug: "lesson-1", status: "completed", walkthrough_video_watched_percentage: nil },
+          { lesson_slug: "lesson-2", status: "completed", walkthrough_video_watched_percentage: nil }
+        ]
+      }
+    ]
+
+    assert_equal(expected, SerializeUserLevels.(user.user_levels))
+  end
+
   test "maintains level position order" do
     user = create(:user)
     level1 = create(:level, slug: "level-c", position: 3)

--- a/test/serializers/serialize_user_levels_test.rb
+++ b/test/serializers/serialize_user_levels_test.rb
@@ -100,7 +100,7 @@ class SerializeUserLevelsTest < ActiveSupport::TestCase
     assert_equal(expected, SerializeUserLevels.(user.user_levels))
   end
 
-  test "appends the first lesson of the next level as not_started when the current level is complete" do
+  test "appends the first lesson of a freshly-unlocked level (UserLevel, no UserLessons) as not_started" do
     user = create(:user)
     level1 = create(:level, slug: "basics", position: 1)
     level2 = create(:level, slug: "advanced", position: 2)


### PR DESCRIPTION
## What

`GET /internal/user_levels?course_slug=…` previously only returned lessons the user already had a `UserLesson` record for. It now also surfaces the single **next** lesson as `not_started`, so the front-end knows what's up next without inferring it from a separate full-structure fetch.

## How

- The `lessons → user_lessons` join goes from **INNER → LEFT**, so record-less lessons are visible. The `user_levels → levels` join stays INNER, so **only levels the user has reached are returned — level behaviour is unchanged**.
- Per level, walking lessons in position order: emit lessons that have a record (`completed`/`started`), then — **provided nothing in that level is in progress** — append the first record-less lesson as `not_started`. Lessons beyond that one are not included (this is deliberately *not* a `locked` model).

This covers two cases:
- **Mid-level**: all started lessons complete → next lesson in the current level appears as `not_started`.
- **Freshly-unlocked level**: a `UserLevel` with zero `UserLesson`s (the common state right after completing a level — unlocking never creates a `UserLesson`) now shows its first lesson as `not_started`. This reverses the old `excludes levels with no user_lessons` behaviour.

## Behaviour change to note

A reached-but-unstarted level changes from *absent* to *present with one `not_started` lesson*. That's the intended "here's your next lesson" pointer, but it is a deliberate contract change from the previous endpoint.

## Performance

The next-lesson join uses the existing unique composite index on `user_lessons (user_id, lesson_id)` — confirmed via `EXPLAIN ANALYZE` against dev data (single `Index Scan`, ~1.8ms). **No new index required.**

## Tests

`test/serializers/serialize_user_levels_test.rb` updated to cover the three scenarios: no append while a lesson is in progress, append mid-level, and append the first lesson of a freshly-unlocked next level. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)