### PR TITLE
Add Skylight APM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,9 @@ gem "stripe"
 gem "sentry-ruby"
 gem "sentry-rails"
 
+# Performance monitoring (APM dashboard; free for OSS)
+gem "skylight"
+
 # Product analytics
 gem "posthog-ruby"
 gem "posthog-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,6 +465,8 @@ GEM
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
+    skylight (7.1.1)
+      activesupport (>= 7.2.0)
     solid_queue (1.4.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
@@ -570,6 +572,7 @@ DEPENDENCIES
   rubocop-rails
   sentry-rails
   sentry-ruby
+  skylight
   solid_queue
   solid_queue_monitor
   stripe

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/jiki-education/config.git
-  revision: 67542f5c5915d6e7f1b85193889a29ef9a661717
+  revision: e60f1d985483a9d86100cb79380810af81a0ed4b
   branch: main
   specs:
     jiki-config (0.1.0)
@@ -96,8 +96,8 @@ GEM
       aws-sdk-ses (~> 1, >= 1.50.0)
       aws-sdk-sesv2 (~> 1, >= 1.34.0)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1257.0)
-    aws-sdk-core (3.251.0)
+    aws-partitions (1.1261.0)
+    aws-sdk-core (3.252.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -105,7 +105,7 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-dynamodb (1.168.0)
+    aws-sdk-dynamodb (1.169.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
     aws-sdk-kms (1.129.0)

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,9 @@
+# Skylight APM configuration.
+# Reports only in production by default (controlled by Skylight's report
+# environments). The authentication token is empty in dev/test, so the agent
+# stays inert there.
+authentication: <%= Jiki.secrets.skylight_key %>
+
+# Don't report the ECS/ALB health check - it's high-volume and uninteresting.
+ignored_endpoints:
+  - External::HealthController#check


### PR DESCRIPTION
## What

Adds [Skylight](https://www.skylight.io) for application performance monitoring — per-endpoint latency and **slow-query grouping** via a hosted dashboard. Skylight is **free for OSS**, so no marginal cost.

This is the app-side half of our query-visibility story; it pairs with **Aurora Performance Insights** (already enabled in terraform) which gives the DB-side view. Skylight uniquely adds *caller attribution* (which endpoint/job fired a query), N+1 detection, and full-request latency breakdown (Ruby vs DB vs external) — things Perf Insights can't see.

## How

- `gem "skylight"` + `config/skylight.yml`.
- Reports **only in production** — the agent stays inert in dev/test where the token is empty.
- Ignores the ECS/ALB health check (`External::HealthController#check`).

## Required companion steps

1. Merge **jiki-education/config#23** (adds the `skylight_key` secret), then `bundle update jiki-config` here.
2. Set the production `skylight_key` (the OSS dashboard token) in **AWS Secrets Manager**.

Until those land, production won't report — but nothing breaks (agent inert without a token).

## Notes / follow-ups

- Mirrors Exercism's setup. Skylight auto-instruments Active Job (Solid Queue), so no Sidekiq-style flag needed.
- Optional later: set `SKYLIGHT_DEPLOY_GIT_SHA` for deploy tracking (Exercism does this; skipped here to avoid assumptions about the ECS image's `.git`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)