### PR TITLE
Speed up signup: defer Devise emails and skip wasteful OAuth bcrypt

### DIFF
--- a/app/commands/auth/find_or_create_from_oauth.rb
+++ b/app/commands/auth/find_or_create_from_oauth.rb
@@ -51,7 +51,11 @@ module Auth
           email:,
           name:,
           confirmed_at: Time.current, # The provider verified the email
-          password: SecureRandom.hex(32), # Random password (won't be used)
+          # OAuth users authenticate via the provider and never use this password.
+          # Store a cheap (min-cost) bcrypt hash rather than paying the full
+          # cost-12 hash (~480ms on prod) for a credential that's never checked.
+          # It's still a valid hash, so password-auth paths won't raise.
+          encrypted_password: BCrypt::Password.create(SecureRandom.uuid, cost: BCrypt::Engine::MIN_COST),
           handle:
         ).tap do |user|
           User::Avatar::CopyFromUrl.defer(user, avatar_url) if avatar_url.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,4 +97,20 @@ class User < ApplicationRecord
   def to_ary
     nil
   end
+
+  private
+  # Send Devise emails (confirmation, password reset) asynchronously via
+  # Solid Queue instead of blocking the request thread with MJML rendering
+  # and the SES API call. Devise defaults to deliver_now.
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
+
+  # OAuth users authenticate via the provider, so Devise must not require a
+  # password on them. Lets FindOrCreateFromOauth store a cheap placeholder hash.
+  def password_required?
+    return false if uses_oauth?
+
+    super
+  end
 end

--- a/test/controllers/auth/confirmations_controller_test.rb
+++ b/test/controllers/auth/confirmations_controller_test.rb
@@ -72,9 +72,11 @@ class Auth::ConfirmationsControllerTest < ApplicationControllerTest
     create(:user, :unconfirmed, email: "unconfirmed@example.com")
 
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post user_confirmation_path, params: {
-        user: { email: "unconfirmed@example.com" }
-      }, as: :json
+      perform_enqueued_jobs do
+        post user_confirmation_path, params: {
+          user: { email: "unconfirmed@example.com" }
+        }, as: :json
+      end
     end
 
     assert_response :ok

--- a/test/controllers/auth/passwords_controller_test.rb
+++ b/test/controllers/auth/passwords_controller_test.rb
@@ -39,9 +39,11 @@ class Auth::PasswordsControllerTest < ApplicationControllerTest
   test "POST password reset email respects user locale" do
     create(:user, :hungarian, email: "magyar@example.com", name: "József")
 
-    post user_password_path, params: with_turnstile(
-      user: { email: "magyar@example.com" }
-    ), as: :json
+    perform_enqueued_jobs do
+      post user_password_path, params: with_turnstile(
+        user: { email: "magyar@example.com" }
+      ), as: :json
+    end
 
     mail = ActionMailer::Base.deliveries.last
     assert_equal "Jelszó visszaállítása", mail.subject

--- a/test/controllers/auth/registrations_controller_test.rb
+++ b/test/controllers/auth/registrations_controller_test.rb
@@ -45,14 +45,18 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
   end
 
   test "POST signup sends confirmation email" do
+    # Confirmation mail is delivered asynchronously (deliver_later), so run the
+    # enqueued job to assert it actually goes out.
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post user_registration_path, params: with_turnstile(
-        user: {
-          email: "newuser@example.com",
-          password: "password123",
-          password_confirmation: "password123"
-        }
-      ), as: :json
+      perform_enqueued_jobs do
+        post user_registration_path, params: with_turnstile(
+          user: {
+            email: "newuser@example.com",
+            password: "password123",
+            password_confirmation: "password123"
+          }
+        ), as: :json
+      end
     end
 
     assert_response :created


### PR DESCRIPTION
## Why

Skylight showed signup endpoints taking ~1.4s (`Auth::RegistrationsController#create`) and ~0.9s (`Auth::ExercismOauthController#create`). Two avoidable costs dominated:

- **Synchronous confirmation email** (~280ms): MJML render + SES delivery blocking the request thread.
- **Wasteful bcrypt on OAuth signup** (~480ms on prod): OAuth users authenticate via their provider and never use the password Devise stores, yet it was hashed at the default cost (12).

## Changes

- **Defer all Devise emails** — override `send_devise_notification` to use `deliver_later`, moving confirmation + password-reset mail off the request into Solid Queue.
- **Skip the expensive OAuth hash** — store a minimum-cost (`BCrypt::Engine::MIN_COST`) bcrypt hash for OAuth users instead of a cost-12 hash. It's still a *valid* bcrypt hash, so password-auth paths can't raise `InvalidHash`. Adds a `password_required?` override so Devise validation doesn't demand a password for OAuth users.
- Tests that asserted synchronous mail delivery now wrap the request in `perform_enqueued_jobs`.

Welcome email was already `deliver_later`, so no change there.

## Impact

Expected to drop signup from ~1.4s → ~350ms and OAuth signup from ~0.9s → ~250ms. (A separate infra bump — 0.5→1 vCPU per Fargate task — would halve the remaining cost-12 bcrypt on the real password-signup path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)