### PR TITLE
Store exercise submission files on S3 instead of R2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/jiki-education/config.git
-  revision: e60f1d985483a9d86100cb79380810af81a0ed4b
+  revision: 41c4ca9c03821ec4ef0cb6e009f796789a7fa717
   branch: main
   specs:
     jiki-config (0.1.0)

--- a/app/models/exercise_submission/file.rb
+++ b/app/models/exercise_submission/file.rb
@@ -1,6 +1,6 @@
 class ExerciseSubmission::File < ApplicationRecord
   belongs_to :exercise_submission
-  has_one_attached :content
+  has_one_attached :content, service: Rails.configuration.x.exercise_submission_storage_service
 
   validates :exercise_submission, presence: true
   validates :filename, presence: true

--- a/bin/init-localstack
+++ b/bin/init-localstack
@@ -28,7 +28,8 @@ end
 # Create S3 buckets
 buckets = [
   { name: Jiki.config.r2_bucket_assets, description: 'Assets (R2)' },
-  { name: Jiki.config.r2_bucket_uploads, description: 'Uploads (R2)' }
+  { name: Jiki.config.r2_bucket_uploads, description: 'Uploads (R2)' },
+  { name: Jiki.config.s3_active_storage_bucket, description: 'Active Storage (S3)' }
 ]
 
 buckets.each do |bucket_info|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,9 @@ Rails.application.configure do
   # Store uploaded files on R2 (see config/storage.yml for options).
   config.active_storage.service = :r2
 
+  # Exercise submission files go to S3 (LocalStack in dev), mirroring production.
+  config.x.exercise_submission_storage_service = :amazon
+
   # Use letter_opener to preview emails in browser instead of sending
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,6 +24,10 @@ Rails.application.configure do
   # Store uploaded files on R2 (see config/storage.yml for options).
   config.active_storage.service = :r2
 
+  # Exercise submission files go to S3 instead of R2 (lower-latency writes/reads
+  # from ECS). Existing blobs keep their stored service_name and stay readable.
+  config.x.exercise_submission_storage_service = :amazon
+
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
+  # Exercise submission files use the same on-disk test service.
+  config.x.exercise_submission_storage_service = :test
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -14,13 +14,12 @@ amazon:
   region: <%= Jiki.config.s3_active_storage_region %>
   bucket: <%= Jiki.config.s3_active_storage_bucket %>
 <% unless Jiki.env.production? %>
+  # LocalStack needs path-style addressing; the default checksum handling
+  # (unlike Cloudflare R2) works fine, so no checksum overrides here.
   endpoint: <%= Jiki.config.r2_endpoint %>
   access_key_id: FAKE
   secret_access_key: FAKE
   force_path_style: true
-  # Mirror the R2/LocalStack checksum handling (see the r2 service below).
-  request_checksum_calculation: when_required
-  response_checksum_validation: when_required
 <% end %>
 
 # Cloudflare R2 for user uploads (avatars, etc.)

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,11 +7,21 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Amazon S3 for Active Storage (exercise submission files)
-# Uses IAM role authentication in production (ECS task role)
+# Production uses IAM role authentication (ECS task role); dev/test use the
+# same LocalStack instance as R2.
 amazon:
   service: S3
-  region: eu-west-1
-  bucket: jiki-active-storage
+  region: <%= Jiki.config.s3_active_storage_region %>
+  bucket: <%= Jiki.config.s3_active_storage_bucket %>
+<% unless Jiki.env.production? %>
+  endpoint: <%= Jiki.config.r2_endpoint %>
+  access_key_id: FAKE
+  secret_access_key: FAKE
+  force_path_style: true
+  # Mirror the R2/LocalStack checksum handling (see the r2 service below).
+  request_checksum_calculation: when_required
+  response_checksum_validation: when_required
+<% end %>
 
 # Cloudflare R2 for user uploads (avatars, etc.)
 # Uses S3-compatible API with public access via uploads.jiki.io


### PR DESCRIPTION
## Why

Exercise submission files were stored on Cloudflare R2 (a private bucket proxied through Rails). Because the app runs on AWS ECS, every R2 PUT/GET is a cross-cloud round-trip. Skylight shows the single upload taking **~250ms — ~83% of the create request**:

```
[#53 app] ActiveStorage Upload ········· 265ms (83% of request)
  [#54 --] PUT ...r2.cloudflarestorage.com ··· 250ms
```

Same-region S3 avoids the hop. R2's latency also hit reads (submission files are downloaded and embedded in JSON, not served as URLs), so this speeds up both writes and reads.

Avatars **stay on R2** — they're served as public CDN URLs straight from Cloudflare's edge, so R2 is the right fit there.

## What

- Default Active Storage service stays `:r2` (avatars, etc.)
- Submission files use a per-environment service via `config.x.exercise_submission_storage_service`: `:amazon` (S3) in production, `:amazon` (LocalStack) in development, `:test` on disk in test
- `storage.yml`'s `amazon` service reads bucket/region from `Jiki.config.s3_active_storage_*`; production authenticates via the ECS task IAM role, dev/test use LocalStack
- `init-localstack` creates the `active-storage` bucket

Existing submission blobs keep their stored `service_name` (`"r2"`) and stay readable — **no data migration needed** (the `r2` service remains defined).

## Depends on

- config: jiki-education/config#24 (merged) — adds `s3_active_storage_bucket` / `s3_active_storage_region`
- Terraform (already applied): S3 bucket, ECS task IAM policy, and the two DynamoDB config items

🤖 Generated with [Claude Code](https://claude.com/claude-code)