### PR TITLE
Distinguish declined checkout payments from invalid sessions

### DIFF
--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -4,18 +4,14 @@ class Stripe::VerifyCheckoutSession
   initialize_with :user, :session_id
 
   def call
-    session = ::Stripe::Checkout::Session.retrieve(session_id)
-
-    verify_ownership!(session)
+    verify_ownership!
 
     # An incomplete session is an expected outcome (declined/abandoned/expired payment),
     # not a bug. Surface the decline reason so the UI can be specific.
     raise StripeCheckoutSessionIncompleteError, decline_reason unless session.status == "complete"
     raise ArgumentError, "Checkout session has no subscription" unless session.subscription.present?
 
-    persist_customer_id!(session)
-
-    subscription = ::Stripe::Subscription.retrieve(session.subscription)
+    persist_customer_id!
 
     subscription_item = subscription.items.data.first
     raise ArgumentError, "Subscription has no items" unless subscription_item
@@ -33,12 +29,20 @@ class Stripe::VerifyCheckoutSession
       success: true,
       interval: interval,
       payment_status: session.payment_status,
+      payment_state: payment_state,
+      decline_reason: payment_state == "failed" ? first_invoice_payment_intent&.last_payment_error&.message : nil,
       subscription_status: status
     }
   end
 
   private
-  def verify_ownership!(session)
+  memoize
+  def session = ::Stripe::Checkout::Session.retrieve(session_id)
+
+  memoize
+  def subscription = ::Stripe::Subscription.retrieve(session.subscription)
+
+  def verify_ownership!
     metadata_user_id = session.metadata&.[](:user_id) || session.metadata&.[]('user_id')
 
     if metadata_user_id.present?
@@ -50,7 +54,7 @@ class Stripe::VerifyCheckoutSession
     raise SecurityError, "Checkout session does not belong to current user"
   end
 
-  def persist_customer_id!(session)
+  def persist_customer_id!
     return if session.customer.blank?
 
     user.data.with_lock do
@@ -60,9 +64,41 @@ class Stripe::VerifyCheckoutSession
     end
   end
 
-  # Best-effort customer-facing decline reason for an incomplete checkout. Returns
-  # nil for abandoned/expired sessions with no payment attempt, and never raises -
-  # a missing reason just degrades to the generic "payment wasn't completed" message.
+  # Disambiguates the "complete but unpaid" Checkout outcome into a three-way
+  # signal the front-end can branch on: a still-clearing async payment (processing)
+  # vs a declined first payment (failed). "paid"/"no_payment_required" short-circuit
+  # so the common case needs no extra Stripe calls.
+  memoize
+  def payment_state
+    return "paid" if session.payment_status.in?(%w[paid no_payment_required])
+
+    case first_invoice_payment_intent&.status
+    when "succeeded" then "paid"
+    when "requires_payment_method", "canceled" then "failed"
+    when "processing", "requires_action", "requires_confirmation" then "processing"
+    else first_invoice_payment_intent&.last_payment_error ? "failed" : "processing"
+    end
+  end
+
+  # The PaymentIntent behind the subscription's first invoice. On Basil+ the invoice
+  # no longer exposes payment_intent directly, so it is reached via invoice.payments.
+  # Best-effort: returns nil (=> "processing") on any Stripe error rather than raising.
+  memoize
+  def first_invoice_payment_intent
+    invoice_id = subscription.latest_invoice
+    return nil if invoice_id.blank?
+
+    invoice = ::Stripe::Invoice.retrieve(id: invoice_id, expand: ["payments"])
+    payment_intent_id = invoice.payments&.data&.first&.payment&.payment_intent
+    payment_intent_id ? ::Stripe::PaymentIntent.retrieve(payment_intent_id) : nil
+  rescue ::Stripe::StripeError => e
+    Rails.logger.warn("Could not determine checkout payment state for #{session_id}: #{e.message}")
+    nil
+  end
+
+  # Best-effort customer-facing decline reason for an incomplete (status != complete)
+  # checkout. Returns nil for abandoned/expired sessions with no payment attempt, and
+  # never raises - a missing reason degrades to the generic "payment wasn't completed".
   def decline_reason
     declined_payment_intent&.last_payment_error&.message
   rescue ::Stripe::StripeError => e

--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -8,7 +8,9 @@ class Stripe::VerifyCheckoutSession
 
     verify_ownership!(session)
 
-    raise ArgumentError, "Checkout session is not complete (status: #{session.status})" unless session.status == "complete"
+    # An incomplete session is an expected outcome (declined/abandoned/expired payment),
+    # not a bug. Surface the decline reason so the UI can be specific.
+    raise StripeCheckoutSessionIncompleteError, decline_reason unless session.status == "complete"
     raise ArgumentError, "Checkout session has no subscription" unless session.subscription.present?
 
     persist_customer_id!(session)
@@ -56,5 +58,30 @@ class Stripe::VerifyCheckoutSession
 
       user.data.update!(stripe_customer_id: session.customer)
     end
+  end
+
+  # Best-effort customer-facing decline reason for an incomplete checkout. Returns
+  # nil for abandoned/expired sessions with no payment attempt, and never raises -
+  # a missing reason just degrades to the generic "payment wasn't completed" message.
+  def decline_reason
+    declined_payment_intent&.last_payment_error&.message
+  rescue ::Stripe::StripeError => e
+    Rails.logger.warn("Could not determine checkout decline reason for #{session_id}: #{e.message}")
+    nil
+  end
+
+  def declined_payment_intent
+    detailed = ::Stripe::Checkout::Session.retrieve(
+      id: session_id,
+      expand: ["payment_intent", "subscription.latest_invoice.payments"]
+    )
+
+    # Payment-mode sessions expose the PaymentIntent directly; subscription-mode
+    # first payments run through the subscription's latest invoice instead.
+    return detailed.payment_intent if detailed.payment_intent
+
+    payment_intent_id =
+      detailed.subscription&.latest_invoice&.payments&.data&.first&.payment&.payment_intent
+    payment_intent_id ? ::Stripe::PaymentIntent.retrieve(payment_intent_id) : nil
   end
 end

--- a/app/controllers/internal/subscriptions_controller.rb
+++ b/app/controllers/internal/subscriptions_controller.rb
@@ -146,6 +146,15 @@ class Internal::SubscriptionsController < Internal::BaseController
         message: "Checkout session does not belong to current user"
       }
     }, status: :forbidden
+  rescue StripeCheckoutSessionIncompleteError => e
+    Rails.logger.info("Checkout session incomplete: #{e.decline_reason || 'no reason given'}")
+    render json: {
+      error: {
+        type: "checkout_payment_incomplete",
+        message: "Your payment wasn't completed. Please try again.",
+        decline_reason: e.decline_reason
+      }
+    }, status: :unprocessable_entity
   rescue ArgumentError => e
     Rails.logger.error("Invalid checkout session: #{e.message}")
     render json: {

--- a/app/controllers/internal/subscriptions_controller.rb
+++ b/app/controllers/internal/subscriptions_controller.rb
@@ -136,6 +136,8 @@ class Internal::SubscriptionsController < Internal::BaseController
       success: result[:success],
       interval: result[:interval],
       payment_status: result[:payment_status],
+      payment_state: result[:payment_state],
+      decline_reason: result[:decline_reason],
       subscription_status: result[:subscription_status]
     }
   rescue SecurityError => e

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -58,3 +58,12 @@ class AssistantConversationAccessDeniedError < RuntimeError; end
 
 # Stripe errors
 class StripeSubscriptionCancellationError < RuntimeError; end
+
+class StripeCheckoutSessionIncompleteError < RuntimeError
+  attr_reader :decline_reason
+
+  def initialize(decline_reason = nil)
+    @decline_reason = decline_reason
+    super(decline_reason || "Checkout session is not complete")
+  end
+end

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -17,6 +17,8 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     assert result[:success]
     assert_equal "monthly", result[:interval]
     assert_equal "paid", result[:payment_status]
+    assert_equal "paid", result[:payment_state]
+    assert_nil result[:decline_reason]
     assert_equal "active", result[:subscription_status]
 
     user.data.reload
@@ -205,7 +207,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     end
   end
 
-  test "handles incomplete subscription for async payments" do
+  test "handles incomplete subscription for async payments and reports payment_state processing" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
 
@@ -214,20 +216,55 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
       status: "incomplete",
       price_id: Jiki.config.stripe_premium_monthly_price_id
     )
+    stripe_subscription.stubs(:latest_invoice).returns("in_1")
 
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
     ::Stripe::Subscription.expects(:retrieve).with("sub_123").returns(stripe_subscription)
+
+    invoice = stub(payments: stub(data: [stub(payment: stub(payment_intent: "pi_1"))]))
+    ::Stripe::Invoice.expects(:retrieve).with(id: "in_1", expand: ["payments"]).returns(invoice)
+    ::Stripe::PaymentIntent.expects(:retrieve).with("pi_1").returns(stub(status: "processing"))
 
     result = Stripe::VerifyCheckoutSession.(user, "cs_test_123")
 
     assert result[:success]
     assert_equal "monthly", result[:interval]
     assert_equal "unpaid", result[:payment_status]
+    assert_equal "processing", result[:payment_state]
+    assert_nil result[:decline_reason]
     assert_equal "incomplete", result[:subscription_status]
 
     user.data.reload
     refute user.premium?
     assert_equal "incomplete", user.data.subscription_status
+  end
+
+  test "reports payment_state failed with the decline reason when the first payment is declined" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock_stripe_session(payment_status: "unpaid")
+    stripe_subscription = mock_stripe_subscription(
+      status: "incomplete",
+      price_id: Jiki.config.stripe_premium_monthly_price_id
+    )
+    stripe_subscription.stubs(:latest_invoice).returns("in_1")
+
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+    ::Stripe::Subscription.expects(:retrieve).with("sub_123").returns(stripe_subscription)
+
+    invoice = stub(payments: stub(data: [stub(payment: stub(payment_intent: "pi_1"))]))
+    ::Stripe::Invoice.expects(:retrieve).with(id: "in_1", expand: ["payments"]).returns(invoice)
+    payment_intent = stub(
+      status: "requires_payment_method",
+      last_payment_error: stub(message: "Your card has insufficient funds.")
+    )
+    ::Stripe::PaymentIntent.expects(:retrieve).with("pi_1").returns(payment_intent)
+
+    result = Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+
+    assert_equal "failed", result[:payment_state]
+    assert_equal "Your card has insufficient funds.", result[:decline_reason]
   end
 
   private

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -88,6 +88,32 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     assert_equal "Your card has insufficient funds.", error.decline_reason
   end
 
+  test "derives the decline reason from the subscription invoice in subscription mode" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
+    stripe_session.stubs(:customer).returns("cus_123")
+    stripe_session.stubs(:status).returns("open")
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+
+    # Subscription-mode: the session has no PaymentIntent; it lives on the invoice.
+    subscription = stub(latest_invoice: stub(payments: stub(data: [stub(payment: stub(payment_intent: "pi_1"))])))
+    detailed = stub(payment_intent: nil, subscription:)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
+      returns(detailed)
+
+    payment_intent = stub(last_payment_error: stub(message: "Your card was declined."))
+    ::Stripe::PaymentIntent.expects(:retrieve).with("pi_1").returns(payment_intent)
+
+    error = assert_raises(StripeCheckoutSessionIncompleteError) do
+      Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+    end
+    assert_equal "Your card was declined.", error.decline_reason
+  end
+
   test "raises StripeCheckoutSessionIncompleteError with nil reason when no payment was attempted" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -77,7 +77,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     payment_intent = stub(last_payment_error: stub(message: "Your card has insufficient funds."))
     detailed = stub(payment_intent:)
     ::Stripe::Checkout::Session.expects(:retrieve).
-      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
       returns(detailed)
 
     error = assert_raises(StripeCheckoutSessionIncompleteError) do
@@ -98,7 +98,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
 
     detailed = stub(payment_intent: nil, subscription: nil)
     ::Stripe::Checkout::Session.expects(:retrieve).
-      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
       returns(detailed)
 
     error = assert_raises(StripeCheckoutSessionIncompleteError) do
@@ -117,7 +117,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     stripe_session.stubs(:status).returns("open")
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
     ::Stripe::Checkout::Session.expects(:retrieve).
-      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
       raises(::Stripe::InvalidRequestError.new("bad expand", "expand"))
 
     error = assert_raises(StripeCheckoutSessionIncompleteError) do

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -64,7 +64,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     end
   end
 
-  test "raises ArgumentError when session is not complete" do
+  test "raises StripeCheckoutSessionIncompleteError with the decline reason when not complete" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
 
@@ -72,13 +72,58 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     stripe_session.stubs(:metadata).returns(nil)
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("open")
-
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
 
-    error = assert_raises(ArgumentError) do
+    payment_intent = stub(last_payment_error: stub(message: "Your card has insufficient funds."))
+    detailed = stub(payment_intent:)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      returns(detailed)
+
+    error = assert_raises(StripeCheckoutSessionIncompleteError) do
       Stripe::VerifyCheckoutSession.(user, "cs_test_123")
     end
-    assert_match(/not complete/, error.message)
+    assert_equal "Your card has insufficient funds.", error.decline_reason
+  end
+
+  test "raises StripeCheckoutSessionIncompleteError with nil reason when no payment was attempted" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
+    stripe_session.stubs(:customer).returns("cus_123")
+    stripe_session.stubs(:status).returns("expired")
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+
+    detailed = stub(payment_intent: nil, subscription: nil)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      returns(detailed)
+
+    error = assert_raises(StripeCheckoutSessionIncompleteError) do
+      Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+    end
+    assert_nil error.decline_reason
+  end
+
+  test "swallows Stripe errors while fetching the decline reason" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
+    stripe_session.stubs(:customer).returns("cus_123")
+    stripe_session.stubs(:status).returns("open")
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      raises(::Stripe::InvalidRequestError.new("bad expand", "expand"))
+
+    error = assert_raises(StripeCheckoutSessionIncompleteError) do
+      Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+    end
+    assert_nil error.decline_reason
   end
 
   test "raises ArgumentError when session has no subscription" do

--- a/test/controllers/internal/subscriptions_controller_test.rb
+++ b/test/controllers/internal/subscriptions_controller_test.rb
@@ -252,6 +252,8 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
       success: true,
       interval: "monthly",
       payment_status: "paid",
+      payment_state: "paid",
+      decline_reason: nil,
       subscription_status: "active"
     })
 
@@ -264,7 +266,31 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert json["success"]
     assert_equal "monthly", json["interval"]
     assert_equal "paid", json["payment_status"]
+    assert_equal "paid", json["payment_state"]
+    assert_nil json["decline_reason"]
     assert_equal "active", json["subscription_status"]
+  end
+
+  test "POST verify_checkout passes through payment_state and decline_reason for a failed async payment" do
+    session_id = "cs_test_123"
+
+    Stripe::VerifyCheckoutSession.expects(:call).with(@user, session_id).returns({
+      success: true,
+      interval: "monthly",
+      payment_status: "unpaid",
+      payment_state: "failed",
+      decline_reason: "Your card has insufficient funds.",
+      subscription_status: "incomplete"
+    })
+
+    post internal_subscriptions_verify_checkout_path,
+      params: { session_id: },
+      as: :json
+
+    assert_response :success
+    json = response.parsed_body
+    assert_equal "failed", json["payment_state"]
+    assert_equal "Your card has insufficient funds.", json["decline_reason"]
   end
 
   test "POST verify_checkout returns incomplete status for async payments" do
@@ -274,6 +300,8 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
       success: true,
       interval: "monthly",
       payment_status: "unpaid",
+      payment_state: "processing",
+      decline_reason: nil,
       subscription_status: "incomplete"
     })
 
@@ -286,6 +314,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert json["success"]
     assert_equal "monthly", json["interval"]
     assert_equal "unpaid", json["payment_status"]
+    assert_equal "processing", json["payment_state"]
     assert_equal "incomplete", json["subscription_status"]
   end
 

--- a/test/controllers/internal/subscriptions_controller_test.rb
+++ b/test/controllers/internal/subscriptions_controller_test.rb
@@ -321,7 +321,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
 
     Stripe::VerifyCheckoutSession.expects(:call).
       with(@user, session_id).
-      raises(ArgumentError.new("Checkout session is not complete"))
+      raises(ArgumentError.new("Subscription has no items"))
 
     post internal_subscriptions_verify_checkout_path,
       params: { session_id: },
@@ -330,6 +330,23 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert_response :unprocessable_entity
     json = response.parsed_body
     assert_equal "invalid_session", json["error"]["type"]
+  end
+
+  test "POST verify_checkout returns checkout_payment_incomplete with decline reason" do
+    session_id = "cs_test_123"
+
+    Stripe::VerifyCheckoutSession.expects(:call).
+      with(@user, session_id).
+      raises(StripeCheckoutSessionIncompleteError.new("Your card has insufficient funds."))
+
+    post internal_subscriptions_verify_checkout_path,
+      params: { session_id: },
+      as: :json
+
+    assert_response :unprocessable_entity
+    json = response.parsed_body
+    assert_equal "checkout_payment_incomplete", json["error"]["type"]
+    assert_equal "Your card has insufficient funds.", json["error"]["decline_reason"]
   end
 
   test "POST verify_checkout handles general errors gracefully" do


### PR DESCRIPTION
Mirrors the Giki change (gikiUK/api#304) for Jiki; fixes the API half of the same checkout-decline UX problem.

## Summary
When a user returns from Stripe checkout with a payment that didn't complete (declined / abandoned / expired), `verify_checkout` raised a generic `ArgumentError` → `422 invalid_session`. The front-end can't distinguish a normal decline from a real bug, so it reports to Sentry and shows a generic error.

- New `StripeCheckoutSessionIncompleteError` (in `exceptions.rb`) carries a best-effort, customer-facing `decline_reason`.
- `VerifyCheckoutSession` raises it whenever `session.status != "complete"` (declined/abandoned/expired). The no-subscription / no-items cases **keep** raising `ArgumentError` — genuine bugs.
- The controller rescues it before `ArgumentError`, logs at **info**, and renders `422 checkout_payment_incomplete` with the reason.

### Response contract
```json
{ "error": {
    "type": "checkout_payment_incomplete",
    "message": "Your payment wasn't completed. Please try again.",
    "decline_reason": "Your card has insufficient funds."   // or null
} }
```
`invalid_session` now means only genuine-bug cases.

## On the decline-reason source
I couldn't drive Stripe test mode from here, so `decline_reason` is **best-effort and can never raise**: it re-reads the session with `expand: ["payment_intent", "subscription.latest_invoice.payments"]`, uses the session's `payment_intent.last_payment_error` (payment mode) else the subscription's latest-invoice payment → PaymentIntent → `last_payment_error` (subscription mode, dahlia shape). Any `Stripe::StripeError` is caught → `nil`. So the friendly message is always delivered; the specific reason is populated when extractable. Worth confirming against a real declined subscription session (cards `4000008260003178` / `4000008400001629`) and tightening if needed.

This is an outbound API call, so it always uses the gem's pinned API version regardless of webhook config.

## Test plan
- [x] `bin/rails test test/commands/stripe/verify_checkout_session_test.rb test/controllers/internal/subscriptions_controller_test.rb` — 62 runs, 0 failures
- Covers incomplete-with-reason, incomplete-without-reason (expired), Stripe-error-while-fetching-reason → nil, and the genuine-invalid path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)