### PR TITLE
Distinguish declined/processing checkout payments and surface plan context

### DIFF
--- a/app/commands/stripe/create_checkout_session.rb
+++ b/app/commands/stripe/create_checkout_session.rb
@@ -16,7 +16,8 @@ class Stripe::CreateCheckoutSession
       mode: 'subscription',
       return_url: return_url,
       metadata: {
-        user_id: user.id
+        user_id: user.id,
+        price_id: price_id
       },
       subscription_data: {
         metadata: {

--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -7,9 +7,13 @@ class Stripe::VerifyCheckoutSession
     verify_ownership!
 
     # An incomplete session is an expected outcome (declined/abandoned/expired payment),
-    # not a bug. Surface the decline reason and the attempted price (which encodes
-    # interval + currency) so the UI can offer a precise "retry" CTA.
-    raise StripeCheckoutSessionIncompleteError.new(decline_reason:, price_id: attempted_price_id) unless session.status == "complete"
+    # not a bug. Surface the decline reason and the attempted plan (interval + currency,
+    # which Jiki prices vary by) so the UI can offer a precise "retry" CTA.
+    unless session.status == "complete"
+      raise StripeCheckoutSessionIncompleteError.new(
+        decline_reason:, interval: attempted_interval, currency: session.currency
+      )
+    end
     raise ArgumentError, "Checkout session has no subscription" unless session.subscription.present?
 
     persist_customer_id!
@@ -43,11 +47,17 @@ class Stripe::VerifyCheckoutSession
   memoize
   def subscription = ::Stripe::Subscription.retrieve(session.subscription)
 
-  # The price the customer tried to buy, stamped into the session metadata at
-  # creation. Encodes both interval and currency, so the front-end can retry the
-  # exact plan. Nil for sessions created before this shipped.
-  def attempted_price_id
-    session.metadata&.[](:price_id) || session.metadata&.[]('price_id')
+  # The interval the customer tried to buy, derived from the price stamped into the
+  # session metadata at creation. (Currency is read separately off the session, since
+  # Jiki prices are multi-currency.) Nil for sessions created before this shipped, or
+  # an unrecognised price.
+  def attempted_interval
+    price_id = session.metadata&.[](:price_id) || session.metadata&.[]('price_id')
+    return nil if price_id.blank?
+
+    Stripe::DetermineSubscriptionDetails.interval_for_price_id(price_id)
+  rescue ArgumentError
+    nil
   end
 
   def verify_ownership!

--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -4,18 +4,14 @@ class Stripe::VerifyCheckoutSession
   initialize_with :user, :session_id
 
   def call
-    session = ::Stripe::Checkout::Session.retrieve(session_id)
-
-    verify_ownership!(session)
+    verify_ownership!
 
     # An incomplete session is an expected outcome (declined/abandoned/expired payment),
     # not a bug. Surface the decline reason so the UI can be specific.
     raise StripeCheckoutSessionIncompleteError, decline_reason unless session.status == "complete"
     raise ArgumentError, "Checkout session has no subscription" unless session.subscription.present?
 
-    persist_customer_id!(session)
-
-    subscription = ::Stripe::Subscription.retrieve(session.subscription)
+    persist_customer_id!
 
     subscription_item = subscription.items.data.first
     raise ArgumentError, "Subscription has no items" unless subscription_item
@@ -33,12 +29,20 @@ class Stripe::VerifyCheckoutSession
       success: true,
       interval: interval,
       payment_status: session.payment_status,
+      payment_state: payment_state,
+      decline_reason: payment_state == "failed" ? first_invoice_payment_intent&.last_payment_error&.message : nil,
       subscription_status: status
     }
   end
 
   private
-  def verify_ownership!(session)
+  memoize
+  def session = ::Stripe::Checkout::Session.retrieve(session_id)
+
+  memoize
+  def subscription = ::Stripe::Subscription.retrieve(session.subscription)
+
+  def verify_ownership!
     metadata_user_id = session.metadata&.[](:user_id) || session.metadata&.[]('user_id')
 
     if metadata_user_id.present?
@@ -50,7 +54,7 @@ class Stripe::VerifyCheckoutSession
     raise SecurityError, "Checkout session does not belong to current user"
   end
 
-  def persist_customer_id!(session)
+  def persist_customer_id!
     return if session.customer.blank?
 
     user.data.with_lock do
@@ -60,9 +64,41 @@ class Stripe::VerifyCheckoutSession
     end
   end
 
-  # Best-effort customer-facing decline reason for an incomplete checkout. Returns
-  # nil for abandoned/expired sessions with no payment attempt, and never raises -
-  # a missing reason just degrades to the generic "payment wasn't completed" message.
+  # Disambiguates the "complete but unpaid" Checkout outcome into a three-way
+  # signal the front-end can branch on: a still-clearing async payment (processing)
+  # vs a declined first payment (failed). "paid"/"no_payment_required" short-circuit
+  # so the common case needs no extra Stripe calls.
+  memoize
+  def payment_state
+    return "paid" if session.payment_status.in?(%w[paid no_payment_required])
+
+    case first_invoice_payment_intent&.status
+    when "succeeded" then "paid"
+    when "requires_payment_method", "canceled" then "failed"
+    when "processing", "requires_action", "requires_confirmation" then "processing"
+    else first_invoice_payment_intent&.last_payment_error ? "failed" : "processing"
+    end
+  end
+
+  # The PaymentIntent behind the subscription's first invoice. On Basil+ the invoice
+  # no longer exposes payment_intent directly, so it is reached via invoice.payments.
+  # Best-effort: returns nil (=> "processing") on any Stripe error rather than raising.
+  memoize
+  def first_invoice_payment_intent
+    invoice_id = subscription.latest_invoice
+    return nil if invoice_id.blank?
+
+    invoice = ::Stripe::Invoice.retrieve(id: invoice_id, expand: ["payments"])
+    payment_intent_id = invoice.payments&.data&.first&.payment&.payment_intent
+    payment_intent_id ? ::Stripe::PaymentIntent.retrieve(payment_intent_id) : nil
+  rescue ::Stripe::StripeError => e
+    Rails.logger.warn("Could not determine checkout payment state for #{session_id}: #{e.message}")
+    nil
+  end
+
+  # Best-effort customer-facing decline reason for an incomplete (status != complete)
+  # checkout. Returns nil for abandoned/expired sessions with no payment attempt, and
+  # never raises - a missing reason degrades to the generic "payment wasn't completed".
   def decline_reason
     declined_payment_intent&.last_payment_error&.message
   rescue ::Stripe::StripeError => e

--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -103,6 +103,8 @@ class Stripe::VerifyCheckoutSession
   # Best-effort: returns nil (=> "processing") on any Stripe error rather than raising.
   memoize
   def first_invoice_payment_intent
+    return nil if session.subscription.blank?
+
     invoice_id = subscription.latest_invoice
     return nil if invoice_id.blank?
 

--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -7,8 +7,9 @@ class Stripe::VerifyCheckoutSession
     verify_ownership!
 
     # An incomplete session is an expected outcome (declined/abandoned/expired payment),
-    # not a bug. Surface the decline reason so the UI can be specific.
-    raise StripeCheckoutSessionIncompleteError, decline_reason unless session.status == "complete"
+    # not a bug. Surface the decline reason and the attempted price (which encodes
+    # interval + currency) so the UI can offer a precise "retry" CTA.
+    raise StripeCheckoutSessionIncompleteError.new(decline_reason:, price_id: attempted_price_id) unless session.status == "complete"
     raise ArgumentError, "Checkout session has no subscription" unless session.subscription.present?
 
     persist_customer_id!
@@ -41,6 +42,13 @@ class Stripe::VerifyCheckoutSession
 
   memoize
   def subscription = ::Stripe::Subscription.retrieve(session.subscription)
+
+  # The price the customer tried to buy, stamped into the session metadata at
+  # creation. Encodes both interval and currency, so the front-end can retry the
+  # exact plan. Nil for sessions created before this shipped.
+  def attempted_price_id
+    session.metadata&.[](:price_id) || session.metadata&.[]('price_id')
+  end
 
   def verify_ownership!
     metadata_user_id = session.metadata&.[](:user_id) || session.metadata&.[]('user_id')

--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -8,7 +8,9 @@ class Stripe::VerifyCheckoutSession
 
     verify_ownership!(session)
 
-    raise ArgumentError, "Checkout session is not complete (status: #{session.status})" unless session.status == "complete"
+    # An incomplete session is an expected outcome (declined/abandoned/expired payment),
+    # not a bug. Surface the decline reason so the UI can be specific.
+    raise StripeCheckoutSessionIncompleteError, decline_reason unless session.status == "complete"
     raise ArgumentError, "Checkout session has no subscription" unless session.subscription.present?
 
     persist_customer_id!(session)
@@ -56,5 +58,30 @@ class Stripe::VerifyCheckoutSession
 
       user.data.update!(stripe_customer_id: session.customer)
     end
+  end
+
+  # Best-effort customer-facing decline reason for an incomplete checkout. Returns
+  # nil for abandoned/expired sessions with no payment attempt, and never raises -
+  # a missing reason just degrades to the generic "payment wasn't completed" message.
+  def decline_reason
+    declined_payment_intent&.last_payment_error&.message
+  rescue ::Stripe::StripeError => e
+    Rails.logger.warn("Could not determine checkout decline reason for #{session_id}: #{e.message}")
+    nil
+  end
+
+  def declined_payment_intent
+    detailed = ::Stripe::Checkout::Session.retrieve(
+      id: session_id,
+      expand: ["payment_intent", "subscription.latest_invoice.payments"]
+    )
+
+    # Payment-mode sessions expose the PaymentIntent directly; subscription-mode
+    # first payments run through the subscription's latest invoice instead.
+    return detailed.payment_intent if detailed.payment_intent
+
+    payment_intent_id =
+      detailed.subscription&.latest_invoice&.payments&.data&.first&.payment&.payment_intent
+    payment_intent_id ? ::Stripe::PaymentIntent.retrieve(payment_intent_id) : nil
   end
 end

--- a/app/controllers/internal/subscriptions_controller.rb
+++ b/app/controllers/internal/subscriptions_controller.rb
@@ -146,6 +146,15 @@ class Internal::SubscriptionsController < Internal::BaseController
         message: "Checkout session does not belong to current user"
       }
     }, status: :forbidden
+  rescue StripeCheckoutSessionIncompleteError => e
+    Rails.logger.info("Checkout session incomplete: #{e.decline_reason || 'no reason given'}")
+    render json: {
+      error: {
+        type: "checkout_payment_incomplete",
+        message: "Your payment wasn't completed. Please try again.",
+        decline_reason: e.decline_reason
+      }
+    }, status: :unprocessable_entity
   rescue ArgumentError => e
     Rails.logger.error("Invalid checkout session: #{e.message}")
     render json: {

--- a/app/controllers/internal/subscriptions_controller.rb
+++ b/app/controllers/internal/subscriptions_controller.rb
@@ -154,7 +154,8 @@ class Internal::SubscriptionsController < Internal::BaseController
       error: {
         type: "checkout_payment_incomplete",
         message: "Your payment wasn't completed. Please try again.",
-        decline_reason: e.decline_reason
+        decline_reason: e.decline_reason,
+        price_id: e.price_id
       }
     }, status: :unprocessable_entity
   rescue ArgumentError => e

--- a/app/controllers/internal/subscriptions_controller.rb
+++ b/app/controllers/internal/subscriptions_controller.rb
@@ -136,6 +136,8 @@ class Internal::SubscriptionsController < Internal::BaseController
       success: result[:success],
       interval: result[:interval],
       payment_status: result[:payment_status],
+      payment_state: result[:payment_state],
+      decline_reason: result[:decline_reason],
       subscription_status: result[:subscription_status]
     }
   rescue SecurityError => e

--- a/app/controllers/internal/subscriptions_controller.rb
+++ b/app/controllers/internal/subscriptions_controller.rb
@@ -155,7 +155,8 @@ class Internal::SubscriptionsController < Internal::BaseController
         type: "checkout_payment_incomplete",
         message: "Your payment wasn't completed. Please try again.",
         decline_reason: e.decline_reason,
-        price_id: e.price_id
+        interval: e.interval,
+        currency: e.currency
       }
     }, status: :unprocessable_entity
   rescue ArgumentError => e

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -60,10 +60,11 @@ class AssistantConversationAccessDeniedError < RuntimeError; end
 class StripeSubscriptionCancellationError < RuntimeError; end
 
 class StripeCheckoutSessionIncompleteError < RuntimeError
-  attr_reader :decline_reason
+  attr_reader :decline_reason, :price_id
 
-  def initialize(decline_reason = nil)
+  def initialize(decline_reason: nil, price_id: nil)
     @decline_reason = decline_reason
+    @price_id = price_id
     super(decline_reason || "Checkout session is not complete")
   end
 end

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -58,3 +58,12 @@ class AssistantConversationAccessDeniedError < RuntimeError; end
 
 # Stripe errors
 class StripeSubscriptionCancellationError < RuntimeError; end
+
+class StripeCheckoutSessionIncompleteError < RuntimeError
+  attr_reader :decline_reason
+
+  def initialize(decline_reason = nil)
+    @decline_reason = decline_reason
+    super(decline_reason || "Checkout session is not complete")
+  end
+end

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -60,11 +60,12 @@ class AssistantConversationAccessDeniedError < RuntimeError; end
 class StripeSubscriptionCancellationError < RuntimeError; end
 
 class StripeCheckoutSessionIncompleteError < RuntimeError
-  attr_reader :decline_reason, :price_id
+  attr_reader :decline_reason, :interval, :currency
 
-  def initialize(decline_reason: nil, price_id: nil)
+  def initialize(decline_reason: nil, interval: nil, currency: nil)
     @decline_reason = decline_reason
-    @price_id = price_id
+    @interval = interval
+    @currency = currency
     super(decline_reason || "Checkout session is not complete")
   end
 end

--- a/test/commands/stripe/create_checkout_session_test.rb
+++ b/test/commands/stripe/create_checkout_session_test.rb
@@ -25,7 +25,8 @@ class Stripe::CreateCheckoutSessionTest < ActiveSupport::TestCase
       mode: 'subscription',
       return_url: return_url,
       metadata: {
-        user_id: user.id
+        user_id: user.id,
+        price_id: price_id
       },
       subscription_data: {
         metadata: {
@@ -62,7 +63,8 @@ class Stripe::CreateCheckoutSessionTest < ActiveSupport::TestCase
       mode: 'subscription',
       return_url: return_url,
       metadata: {
-        user_id: user.id
+        user_id: user.id,
+        price_id: price_id
       },
       subscription_data: {
         metadata: {

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -160,6 +160,30 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     assert_nil error.decline_reason
   end
 
+  test "does not adopt the customer id when the checkout is incomplete" do
+    user = create(:user)
+    assert_nil user.data.stripe_customer_id
+
+    stripe_session = mock
+    stripe_session.stubs(:metadata).returns(
+      "user_id" => user.id.to_s, "price_id" => Jiki.config.stripe_premium_monthly_price_id
+    )
+    stripe_session.stubs(:status).returns("open")
+    stripe_session.stubs(:currency).returns("usd")
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+
+    detailed = stub(payment_intent: nil, subscription: nil)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
+      returns(detailed)
+
+    assert_raises(StripeCheckoutSessionIncompleteError) do
+      Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+    end
+
+    assert_nil user.data.reload.stripe_customer_id
+  end
+
   test "raises ArgumentError when session has no subscription" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -17,6 +17,8 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     assert result[:success]
     assert_equal "monthly", result[:interval]
     assert_equal "paid", result[:payment_status]
+    assert_equal "paid", result[:payment_state]
+    assert_nil result[:decline_reason]
     assert_equal "active", result[:subscription_status]
 
     user.data.reload
@@ -205,7 +207,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     end
   end
 
-  test "handles incomplete subscription for async payments" do
+  test "handles incomplete subscription for async payments and reports payment_state processing" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
 
@@ -214,20 +216,55 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
       status: "incomplete",
       price_id: Jiki.config.stripe_premium_monthly_price_id
     )
+    stripe_subscription.stubs(:latest_invoice).returns("in_1")
 
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
     ::Stripe::Subscription.expects(:retrieve).with("sub_123").returns(stripe_subscription)
+
+    invoice = stub(payments: stub(data: [stub(payment: stub(payment_intent: "pi_1"))]))
+    ::Stripe::Invoice.expects(:retrieve).with(id: "in_1", expand: ["payments"]).returns(invoice)
+    ::Stripe::PaymentIntent.expects(:retrieve).with("pi_1").returns(stub(status: "processing"))
 
     result = Stripe::VerifyCheckoutSession.(user, "cs_test_123")
 
     assert result[:success]
     assert_equal "monthly", result[:interval]
     assert_equal "unpaid", result[:payment_status]
+    assert_equal "processing", result[:payment_state]
+    assert_nil result[:decline_reason]
     assert_equal "incomplete", result[:subscription_status]
 
     user.data.reload
     refute user.premium?
     assert_equal "incomplete", user.data.subscription_status
+  end
+
+  test "reports payment_state failed with the decline reason when the first payment is declined" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock_stripe_session(payment_status: "unpaid")
+    stripe_subscription = mock_stripe_subscription(
+      status: "incomplete",
+      price_id: Jiki.config.stripe_premium_monthly_price_id
+    )
+    stripe_subscription.stubs(:latest_invoice).returns("in_1")
+
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+    ::Stripe::Subscription.expects(:retrieve).with("sub_123").returns(stripe_subscription)
+
+    invoice = stub(payments: stub(data: [stub(payment: stub(payment_intent: "pi_1"))]))
+    ::Stripe::Invoice.expects(:retrieve).with(id: "in_1", expand: ["payments"]).returns(invoice)
+    payment_intent = stub(
+      status: "requires_payment_method",
+      last_payment_error: stub(message: "Your card has insufficient funds.")
+    )
+    ::Stripe::PaymentIntent.expects(:retrieve).with("pi_1").returns(payment_intent)
+
+    result = Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+
+    assert_equal "failed", result[:payment_state]
+    assert_equal "Your card has insufficient funds.", result[:decline_reason]
   end
 
   private

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -88,6 +88,32 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     assert_equal "Your card has insufficient funds.", error.decline_reason
   end
 
+  test "derives the decline reason from the subscription invoice in subscription mode" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
+    stripe_session.stubs(:customer).returns("cus_123")
+    stripe_session.stubs(:status).returns("open")
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+
+    # Subscription-mode: the session has no PaymentIntent; it lives on the invoice.
+    subscription = stub(latest_invoice: stub(payments: stub(data: [stub(payment: stub(payment_intent: "pi_1"))])))
+    detailed = stub(payment_intent: nil, subscription:)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
+      returns(detailed)
+
+    payment_intent = stub(last_payment_error: stub(message: "Your card was declined."))
+    ::Stripe::PaymentIntent.expects(:retrieve).with("pi_1").returns(payment_intent)
+
+    error = assert_raises(StripeCheckoutSessionIncompleteError) do
+      Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+    end
+    assert_equal "Your card was declined.", error.decline_reason
+  end
+
   test "raises StripeCheckoutSessionIncompleteError with nil reason when no payment was attempted" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -77,7 +77,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     payment_intent = stub(last_payment_error: stub(message: "Your card has insufficient funds."))
     detailed = stub(payment_intent:)
     ::Stripe::Checkout::Session.expects(:retrieve).
-      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
       returns(detailed)
 
     error = assert_raises(StripeCheckoutSessionIncompleteError) do
@@ -98,7 +98,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
 
     detailed = stub(payment_intent: nil, subscription: nil)
     ::Stripe::Checkout::Session.expects(:retrieve).
-      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
       returns(detailed)
 
     error = assert_raises(StripeCheckoutSessionIncompleteError) do
@@ -117,7 +117,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     stripe_session.stubs(:status).returns("open")
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
     ::Stripe::Checkout::Session.expects(:retrieve).
-      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
       raises(::Stripe::InvalidRequestError.new("bad expand", "expand"))
 
     error = assert_raises(StripeCheckoutSessionIncompleteError) do

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -295,6 +295,27 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     assert_equal "incomplete", user.data.subscription_status
   end
 
+  test "degrades payment_state to processing when the payment intent lookup fails" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock_stripe_session(payment_status: "unpaid")
+    stripe_subscription = mock_stripe_subscription(
+      status: "incomplete",
+      price_id: Jiki.config.stripe_premium_monthly_price_id
+    )
+    stripe_subscription.stubs(:latest_invoice).returns("in_1")
+
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+    ::Stripe::Subscription.expects(:retrieve).with("sub_123").returns(stripe_subscription)
+    ::Stripe::Invoice.expects(:retrieve).with(id: "in_1", expand: ["payments"]).raises(::Stripe::APIError.new("boom"))
+
+    result = Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+
+    assert_equal "processing", result[:payment_state]
+    assert_nil result[:decline_reason]
+  end
+
   test "reports payment_state failed with the decline reason when the first payment is declined" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -66,12 +66,12 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     end
   end
 
-  test "raises StripeCheckoutSessionIncompleteError with the decline reason when not complete" do
+  test "raises StripeCheckoutSessionIncompleteError with the decline reason and attempted price when not complete" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
 
     stripe_session = mock
-    stripe_session.stubs(:metadata).returns(nil)
+    stripe_session.stubs(:metadata).returns("price_id" => "price_abc")
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("open")
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
@@ -86,6 +86,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
       Stripe::VerifyCheckoutSession.(user, "cs_test_123")
     end
     assert_equal "Your card has insufficient funds.", error.decline_reason
+    assert_equal "price_abc", error.price_id
   end
 
   test "derives the decline reason from the subscription invoice in subscription mode" do

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -64,7 +64,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     end
   end
 
-  test "raises ArgumentError when session is not complete" do
+  test "raises StripeCheckoutSessionIncompleteError with the decline reason when not complete" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
 
@@ -72,13 +72,58 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     stripe_session.stubs(:metadata).returns(nil)
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("open")
-
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
 
-    error = assert_raises(ArgumentError) do
+    payment_intent = stub(last_payment_error: stub(message: "Your card has insufficient funds."))
+    detailed = stub(payment_intent:)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      returns(detailed)
+
+    error = assert_raises(StripeCheckoutSessionIncompleteError) do
       Stripe::VerifyCheckoutSession.(user, "cs_test_123")
     end
-    assert_match(/not complete/, error.message)
+    assert_equal "Your card has insufficient funds.", error.decline_reason
+  end
+
+  test "raises StripeCheckoutSessionIncompleteError with nil reason when no payment was attempted" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
+    stripe_session.stubs(:customer).returns("cus_123")
+    stripe_session.stubs(:status).returns("expired")
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+
+    detailed = stub(payment_intent: nil, subscription: nil)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      returns(detailed)
+
+    error = assert_raises(StripeCheckoutSessionIncompleteError) do
+      Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+    end
+    assert_nil error.decline_reason
+  end
+
+  test "swallows Stripe errors while fetching the decline reason" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock
+    stripe_session.stubs(:metadata).returns(nil)
+    stripe_session.stubs(:customer).returns("cus_123")
+    stripe_session.stubs(:status).returns("open")
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: [ "payment_intent", "subscription.latest_invoice.payments" ]).
+      raises(::Stripe::InvalidRequestError.new("bad expand", "expand"))
+
+    error = assert_raises(StripeCheckoutSessionIncompleteError) do
+      Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+    end
+    assert_nil error.decline_reason
   end
 
   test "raises ArgumentError when session has no subscription" do

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -66,14 +66,15 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     end
   end
 
-  test "raises StripeCheckoutSessionIncompleteError with the decline reason and attempted price when not complete" do
+  test "raises StripeCheckoutSessionIncompleteError with the decline reason and attempted plan when not complete" do
     user = create(:user)
     user.data.update!(stripe_customer_id: "cus_123")
 
     stripe_session = mock
-    stripe_session.stubs(:metadata).returns("price_id" => "price_abc")
+    stripe_session.stubs(:metadata).returns("price_id" => Jiki.config.stripe_premium_monthly_price_id)
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("open")
+    stripe_session.stubs(:currency).returns("gbp")
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
 
     payment_intent = stub(last_payment_error: stub(message: "Your card has insufficient funds."))
@@ -86,7 +87,8 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
       Stripe::VerifyCheckoutSession.(user, "cs_test_123")
     end
     assert_equal "Your card has insufficient funds.", error.decline_reason
-    assert_equal "price_abc", error.price_id
+    assert_equal "monthly", error.interval
+    assert_equal "gbp", error.currency
   end
 
   test "derives the decline reason from the subscription invoice in subscription mode" do
@@ -97,6 +99,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     stripe_session.stubs(:metadata).returns(nil)
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("open")
+    stripe_session.stubs(:currency).returns("usd")
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
 
     # Subscription-mode: the session has no PaymentIntent; it lives on the invoice.
@@ -123,6 +126,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     stripe_session.stubs(:metadata).returns(nil)
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("expired")
+    stripe_session.stubs(:currency).returns("usd")
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
 
     detailed = stub(payment_intent: nil, subscription: nil)
@@ -144,6 +148,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     stripe_session.stubs(:metadata).returns(nil)
     stripe_session.stubs(:customer).returns("cus_123")
     stripe_session.stubs(:status).returns("open")
+    stripe_session.stubs(:currency).returns("usd")
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
     ::Stripe::Checkout::Session.expects(:retrieve).
       with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).

--- a/test/controllers/internal/subscriptions_controller_test.rb
+++ b/test/controllers/internal/subscriptions_controller_test.rb
@@ -252,6 +252,8 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
       success: true,
       interval: "monthly",
       payment_status: "paid",
+      payment_state: "paid",
+      decline_reason: nil,
       subscription_status: "active"
     })
 
@@ -264,7 +266,31 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert json["success"]
     assert_equal "monthly", json["interval"]
     assert_equal "paid", json["payment_status"]
+    assert_equal "paid", json["payment_state"]
+    assert_nil json["decline_reason"]
     assert_equal "active", json["subscription_status"]
+  end
+
+  test "POST verify_checkout passes through payment_state and decline_reason for a failed async payment" do
+    session_id = "cs_test_123"
+
+    Stripe::VerifyCheckoutSession.expects(:call).with(@user, session_id).returns({
+      success: true,
+      interval: "monthly",
+      payment_status: "unpaid",
+      payment_state: "failed",
+      decline_reason: "Your card has insufficient funds.",
+      subscription_status: "incomplete"
+    })
+
+    post internal_subscriptions_verify_checkout_path,
+      params: { session_id: },
+      as: :json
+
+    assert_response :success
+    json = response.parsed_body
+    assert_equal "failed", json["payment_state"]
+    assert_equal "Your card has insufficient funds.", json["decline_reason"]
   end
 
   test "POST verify_checkout returns incomplete status for async payments" do
@@ -274,6 +300,8 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
       success: true,
       interval: "monthly",
       payment_status: "unpaid",
+      payment_state: "processing",
+      decline_reason: nil,
       subscription_status: "incomplete"
     })
 
@@ -286,6 +314,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert json["success"]
     assert_equal "monthly", json["interval"]
     assert_equal "unpaid", json["payment_status"]
+    assert_equal "processing", json["payment_state"]
     assert_equal "incomplete", json["subscription_status"]
   end
 

--- a/test/controllers/internal/subscriptions_controller_test.rb
+++ b/test/controllers/internal/subscriptions_controller_test.rb
@@ -361,12 +361,14 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert_equal "invalid_session", json["error"]["type"]
   end
 
-  test "POST verify_checkout returns checkout_payment_incomplete with decline reason and price" do
+  test "POST verify_checkout returns checkout_payment_incomplete with decline reason and attempted plan" do
     session_id = "cs_test_123"
 
     Stripe::VerifyCheckoutSession.expects(:call).
       with(@user, session_id).
-      raises(StripeCheckoutSessionIncompleteError.new(decline_reason: "Your card has insufficient funds.", price_id: "price_abc"))
+      raises(StripeCheckoutSessionIncompleteError.new(
+        decline_reason: "Your card has insufficient funds.", interval: "monthly", currency: "gbp"
+      ))
 
     post internal_subscriptions_verify_checkout_path,
       params: { session_id: },
@@ -376,7 +378,8 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     json = response.parsed_body
     assert_equal "checkout_payment_incomplete", json["error"]["type"]
     assert_equal "Your card has insufficient funds.", json["error"]["decline_reason"]
-    assert_equal "price_abc", json["error"]["price_id"]
+    assert_equal "monthly", json["error"]["interval"]
+    assert_equal "gbp", json["error"]["currency"]
   end
 
   test "POST verify_checkout handles general errors gracefully" do

--- a/test/controllers/internal/subscriptions_controller_test.rb
+++ b/test/controllers/internal/subscriptions_controller_test.rb
@@ -321,7 +321,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
 
     Stripe::VerifyCheckoutSession.expects(:call).
       with(@user, session_id).
-      raises(ArgumentError.new("Checkout session is not complete"))
+      raises(ArgumentError.new("Subscription has no items"))
 
     post internal_subscriptions_verify_checkout_path,
       params: { session_id: },
@@ -330,6 +330,23 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert_response :unprocessable_entity
     json = response.parsed_body
     assert_equal "invalid_session", json["error"]["type"]
+  end
+
+  test "POST verify_checkout returns checkout_payment_incomplete with decline reason" do
+    session_id = "cs_test_123"
+
+    Stripe::VerifyCheckoutSession.expects(:call).
+      with(@user, session_id).
+      raises(StripeCheckoutSessionIncompleteError.new("Your card has insufficient funds."))
+
+    post internal_subscriptions_verify_checkout_path,
+      params: { session_id: },
+      as: :json
+
+    assert_response :unprocessable_entity
+    json = response.parsed_body
+    assert_equal "checkout_payment_incomplete", json["error"]["type"]
+    assert_equal "Your card has insufficient funds.", json["error"]["decline_reason"]
   end
 
   test "POST verify_checkout handles general errors gracefully" do

--- a/test/controllers/internal/subscriptions_controller_test.rb
+++ b/test/controllers/internal/subscriptions_controller_test.rb
@@ -361,12 +361,12 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert_equal "invalid_session", json["error"]["type"]
   end
 
-  test "POST verify_checkout returns checkout_payment_incomplete with decline reason" do
+  test "POST verify_checkout returns checkout_payment_incomplete with decline reason and price" do
     session_id = "cs_test_123"
 
     Stripe::VerifyCheckoutSession.expects(:call).
       with(@user, session_id).
-      raises(StripeCheckoutSessionIncompleteError.new("Your card has insufficient funds."))
+      raises(StripeCheckoutSessionIncompleteError.new(decline_reason: "Your card has insufficient funds.", price_id: "price_abc"))
 
     post internal_subscriptions_verify_checkout_path,
       params: { session_id: },
@@ -376,6 +376,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     json = response.parsed_body
     assert_equal "checkout_payment_incomplete", json["error"]["type"]
     assert_equal "Your card has insufficient funds.", json["error"]["decline_reason"]
+    assert_equal "price_abc", json["error"]["price_id"]
   end
 
   test "POST verify_checkout handles general errors gracefully" do


### PR DESCRIPTION
Rebased onto current `main` (post-#475). Supersedes #476.

## Summary
Fixes the API half of the checkout-return UX: when a user comes back from Stripe with a payment that didn't cleanly succeed, the endpoint now gives the front-end enough to branch honestly instead of a single generic error.

**1. Incomplete sessions (declined / abandoned / expired)** → `422 checkout_payment_incomplete` (was a generic `invalid_session`), carrying:
- `decline_reason` — customer-safe Stripe message when available, else null.
- `interval` — the plan interval the user tried to buy, derived from the price stamped into the session metadata at creation.
- `currency` — read from the session. Jiki prices are per-currency, so `interval` + `currency` together let the FE retry the exact plan.

**2. Completed-but-unpaid sessions** → 200 with a new `payment_state`: `"paid" | "processing" | "failed"`, derived from the subscription's first-invoice PaymentIntent (`processing` = async still clearing; `failed` = declined first payment, with `decline_reason`). This disambiguates the previously-conflated `payment_status: "unpaid"`. The controller now passes `payment_state`/`decline_reason` through (they were being dropped).

`interval`/`currency`/`decline_reason`/`payment_state` are all best-effort and never raise; the friendly outcome is always delivered. `interval` is populated for sessions created after this ships (null for older ones); `currency` is present even for older sessions.

## Notes
- The webhook-controller 500-on-error change is **not** in this PR — it shipped in #475 (already merged).

## Test plan
- [x] `bin/rails test test/commands/stripe/ test/controllers/internal/subscriptions_controller_test.rb` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)