### PR TITLE
Add mailshots (bulk email) with per-user dedup

### DIFF
--- a/app/commands/mailshot/render_preview.rb
+++ b/app/commands/mailshot/render_preview.rb
@@ -5,9 +5,8 @@ class Mailshot::RenderPreview
 
   # Renders the mailshot's markdown inside the full MJML email layout
   # (header/footer/unsubscribe), exactly as it would be sent, without
-  # delivering or persisting anything. force: true bypasses opt-out guards
-  # so previews always render regardless of the admin's own preferences.
+  # delivering or persisting anything.
   def call
-    MailshotMailer.send_mailshot(user, mailshot, force: true).html_part.body.decoded
+    MailshotMailer.send_mailshot(user, mailshot).html_part.body.decoded
   end
 end

--- a/app/commands/mailshot/render_preview.rb
+++ b/app/commands/mailshot/render_preview.rb
@@ -1,0 +1,13 @@
+class Mailshot::RenderPreview
+  include Mandate
+
+  initialize_with :mailshot, :user
+
+  # Renders the mailshot's markdown inside the full MJML email layout
+  # (header/footer/unsubscribe), exactly as it would be sent, without
+  # delivering or persisting anything. force: true bypasses opt-out guards
+  # so previews always render regardless of the admin's own preferences.
+  def call
+    MailshotMailer.send_mailshot(user, mailshot, force: true).html_part.body.decoded
+  end
+end

--- a/app/commands/mailshot/send.rb
+++ b/app/commands/mailshot/send.rb
@@ -1,0 +1,16 @@
+class Mailshot::Send
+  include Mandate
+
+  initialize_with :mailshot, :segment_key
+
+  def call
+    raise Mailshot::UnknownSegmentError, segment_key unless Mailshot::SEGMENTS.key?(segment_key)
+
+    # Sending the same segment twice is a no-op — the per-user unique index
+    # would skip everyone anyway, but this avoids enqueuing pointless work.
+    return if mailshot.sent_to_audience?(segment_key)
+
+    mailshot.update!(sent_to_audiences: mailshot.sent_to_audiences + [segment_key])
+    Mailshot::SendToSegment.defer(mailshot, segment_key)
+  end
+end

--- a/app/commands/mailshot/send.rb
+++ b/app/commands/mailshot/send.rb
@@ -4,8 +4,8 @@ class Mailshot::Send
   initialize_with :mailshot, :segment_key
 
   def call
-    raise Mailshot::UnknownSegmentError, segment_key unless Mailshot::SEGMENTS.key?(segment_key)
-    raise Mailshot::BlankBodyError unless mailshot.ready_to_send?
+    raise MailshotUnknownSegmentError, segment_key unless Mailshot::SEGMENTS.key?(segment_key)
+    raise MailshotBlankBodyError unless mailshot.ready_to_send?
 
     # Sending the same segment twice is a no-op — the per-user unique index
     # would skip everyone anyway, but this avoids enqueuing pointless work.

--- a/app/commands/mailshot/send.rb
+++ b/app/commands/mailshot/send.rb
@@ -5,6 +5,7 @@ class Mailshot::Send
 
   def call
     raise Mailshot::UnknownSegmentError, segment_key unless Mailshot::SEGMENTS.key?(segment_key)
+    raise Mailshot::BlankBodyError unless mailshot.ready_to_send?
 
     # Sending the same segment twice is a no-op — the per-user unique index
     # would skip everyone anyway, but this avoids enqueuing pointless work.

--- a/app/commands/mailshot/send_test_email.rb
+++ b/app/commands/mailshot/send_test_email.rb
@@ -3,11 +3,13 @@ class Mailshot::SendTestEmail
 
   initialize_with :mailshot, :user
 
-  # Sends the mailshot to a single user (an admin) without creating a
-  # User::Mailshot record, so test sends never count as a real send and
-  # never affect dedup. force: true bypasses the recipient's opt-out so
-  # the test always arrives.
+  # Sends the mailshot to a single admin through the normal send pipeline.
+  # Any existing send record for this user is deleted first so the test can
+  # be repeated (the unique index would otherwise dedup it away).
   def call
-    MailshotMailer.send_mailshot(user, mailshot, force: true).deliver_later
+    raise ArgumentError, "Test sends can only be sent to admins" unless user.admin?
+
+    mailshot.user_mailshots.where(user:).destroy_all
+    User::Mailshot::Send.(user, mailshot)
   end
 end

--- a/app/commands/mailshot/send_test_email.rb
+++ b/app/commands/mailshot/send_test_email.rb
@@ -1,0 +1,13 @@
+class Mailshot::SendTestEmail
+  include Mandate
+
+  initialize_with :mailshot, :user
+
+  # Sends the mailshot to a single user (an admin) without creating a
+  # User::Mailshot record, so test sends never count as a real send and
+  # never affect dedup. force: true bypasses the recipient's opt-out so
+  # the test always arrives.
+  def call
+    MailshotMailer.send_mailshot(user, mailshot, force: true).deliver_later
+  end
+end

--- a/app/commands/mailshot/send_to_segment.rb
+++ b/app/commands/mailshot/send_to_segment.rb
@@ -5,16 +5,23 @@ class Mailshot::SendToSegment
 
   BATCH_SIZE = 100
 
-  initialize_with :mailshot, :segment_key, limit: BATCH_SIZE, offset: 0
+  # Keyset (cursor) pagination on users.id rather than offset: rows shifting
+  # around mid-send (deletions, segment-exits) can't cause a recipient to be
+  # skipped or revisited, and it avoids OFFSET's growing scan cost.
+  initialize_with :mailshot, :segment_key, last_id: 0
 
   def call
-    users = mailshot.segment_relation(segment_key).order(:id).offset(offset).limit(limit).to_a
+    users = mailshot.segment_relation(segment_key).
+      where("users.id > ?", last_id).
+      order(:id).
+      limit(BATCH_SIZE).
+      to_a
     return if users.empty?
 
     users.each { |user| User::Mailshot::Send.(user, mailshot) }
 
     # TODO: SES daily-quota throttling can be added here — check how many
     # have been sent today and reschedule for tomorrow if over the limit.
-    self.class.defer(mailshot, segment_key, limit:, offset: offset + limit, wait: 5.seconds)
+    self.class.defer(mailshot, segment_key, last_id: users.last.id, wait: 5.seconds)
   end
 end

--- a/app/commands/mailshot/send_to_segment.rb
+++ b/app/commands/mailshot/send_to_segment.rb
@@ -1,0 +1,20 @@
+class Mailshot::SendToSegment
+  include Mandate
+
+  queue_as :mailers
+
+  BATCH_SIZE = 100
+
+  initialize_with :mailshot, :segment_key, limit: BATCH_SIZE, offset: 0
+
+  def call
+    users = mailshot.segment_relation(segment_key).order(:id).offset(offset).limit(limit).to_a
+    return if users.empty?
+
+    users.each { |user| User::Mailshot::Send.(user, mailshot) }
+
+    # TODO: SES daily-quota throttling can be added here — check how many
+    # have been sent today and reschedule for tomorrow if over the limit.
+    self.class.defer(mailshot, segment_key, limit:, offset: offset + limit, wait: 5.seconds)
+  end
+end

--- a/app/commands/user/mailshot/send.rb
+++ b/app/commands/user/mailshot/send.rb
@@ -1,0 +1,26 @@
+class User::Mailshot::Send
+  include Mandate
+
+  initialize_with :user, :mailshot
+
+  def call
+    user_mailshot = create_record!
+
+    # If the record already existed, this user has already been sent this
+    # mailshot. The unique index on [user_id, mailshot_id] is the guarantee
+    # that no user ever receives a duplicate, even across overlapping
+    # segments, retried jobs or concurrent batches.
+    return unless user_mailshot
+
+    User::SendEmail.(user_mailshot) do
+      MailshotMailer.send_mailshot(user, mailshot).deliver_later
+    end
+  end
+
+  private
+  def create_record!
+    user.user_mailshots.create!(mailshot:)
+  rescue ActiveRecord::RecordNotUnique
+    nil
+  end
+end

--- a/app/commands/user/send_email.rb
+++ b/app/commands/user/send_email.rb
@@ -54,7 +54,8 @@ class User::SendEmail
     conditions = [
       has_affirmative_communication_preference?,
       user.may_receive_emails?,
-      user.email_valid?
+      user.email_valid?,
+      user.confirmed?
     ]
 
     return true if conditions.all?

--- a/app/commands/user/send_email.rb
+++ b/app/commands/user/send_email.rb
@@ -53,7 +53,8 @@ class User::SendEmail
   def guard_user_wants_email!
     conditions = [
       has_affirmative_communication_preference?,
-      user.may_receive_emails?
+      user.may_receive_emails?,
+      user.email_valid?
     ]
 
     return true if conditions.all?

--- a/app/controllers/admin/mailshots_controller.rb
+++ b/app/controllers/admin/mailshots_controller.rb
@@ -55,9 +55,9 @@ class Admin::MailshotsController < Admin::BaseController
       mailshot: SerializeMailshot.(@mailshot.reload),
       audience_count:
     }
-  rescue Mailshot::UnknownSegmentError
+  rescue MailshotUnknownSegmentError
     render_422(:unknown_segment, segment: params[:segment])
-  rescue Mailshot::BlankBodyError
+  rescue MailshotBlankBodyError
     render_422(:mailshot_body_blank)
   end
 

--- a/app/controllers/admin/mailshots_controller.rb
+++ b/app/controllers/admin/mailshots_controller.rb
@@ -1,0 +1,77 @@
+class Admin::MailshotsController < Admin::BaseController
+  before_action :use_mailshot, only: %i[show update destroy preview send_test send_to_segment]
+
+  def index
+    mailshots = Mailshot.order(created_at: :desc).page(params[:page]).per(params[:per])
+
+    render json: SerializePaginatedCollection.(
+      mailshots,
+      serializer: SerializeMailshots
+    )
+  end
+
+  def show
+    render json: { mailshot: SerializeMailshot.(@mailshot) }
+  end
+
+  def create
+    mailshot = Mailshot.create!(mailshot_params)
+    render json: { mailshot: SerializeMailshot.(mailshot) }, status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render_422(:validation_error, errors: e.record.errors.as_json)
+  end
+
+  def update
+    @mailshot.update!(mailshot_params)
+    render json: { mailshot: SerializeMailshot.(@mailshot) }
+  rescue ActiveRecord::RecordInvalid => e
+    render_422(:validation_error, errors: e.record.errors.as_json)
+  end
+
+  def destroy
+    return render_422(:mailshot_already_sent) if @mailshot.sent?
+
+    @mailshot.destroy!
+    head :no_content
+  end
+
+  def preview
+    @mailshot.assign_attributes(preview_params)
+    render json: { html: Mailshot::RenderPreview.(@mailshot, current_user) }
+  end
+
+  def send_test
+    Mailshot::SendTestEmail.(@mailshot, current_user)
+    render json: { success: true }
+  end
+
+  def send_to_segment
+    return render_422(:unknown_segment, segment: params[:segment]) unless Mailshot::SEGMENTS.key?(params[:segment])
+    return render_422(:mailshot_body_blank) unless @mailshot.ready_to_send?
+
+    # A re-send of an already-sent segment is a no-op, so report 0 queued.
+    already_sent = @mailshot.sent_to_audience?(params[:segment])
+    Mailshot::Send.(@mailshot, params[:segment])
+    audience_count = already_sent ? 0 : @mailshot.segment_relation(params[:segment]).count
+
+    render json: {
+      mailshot: SerializeMailshot.(@mailshot.reload),
+      audience_count:
+    }
+  end
+
+  private
+  def use_mailshot
+    @mailshot = Mailshot.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render_404(:mailshot_not_found)
+  end
+
+  def mailshot_params
+    params.require(:mailshot).permit(:slug, :subject, :body_markdown, :email_communication_preferences_key)
+  end
+
+  def preview_params
+    params.require(:mailshot).permit(:subject, :body_markdown)
+  end
+end

--- a/app/controllers/admin/mailshots_controller.rb
+++ b/app/controllers/admin/mailshots_controller.rb
@@ -46,9 +46,6 @@ class Admin::MailshotsController < Admin::BaseController
   end
 
   def send_to_segment
-    return render_422(:unknown_segment, segment: params[:segment]) unless Mailshot::SEGMENTS.key?(params[:segment])
-    return render_422(:mailshot_body_blank) unless @mailshot.ready_to_send?
-
     # A re-send of an already-sent segment is a no-op, so report 0 queued.
     already_sent = @mailshot.sent_to_audience?(params[:segment])
     Mailshot::Send.(@mailshot, params[:segment])
@@ -58,6 +55,10 @@ class Admin::MailshotsController < Admin::BaseController
       mailshot: SerializeMailshot.(@mailshot.reload),
       audience_count:
     }
+  rescue Mailshot::UnknownSegmentError
+    render_422(:unknown_segment, segment: params[:segment])
+  rescue Mailshot::BlankBodyError
+    render_422(:mailshot_body_blank)
   end
 
   private

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -63,13 +63,15 @@ class ApplicationMailer < ActionMailer::Base
   # @param user [User] The recipient user
   # @param unsubscribe_key [Symbol, nil] The preference key (e.g., :newsletters, :milestone_emails)
   #   If nil, only checks global email validity
+  # @param force [Boolean] When true, skip the bounce/complaint and preference guards so the
+  #   email always renders/sends. Used only for admin preview and test sends.
   # @param args [Hash] Options passed to mail() (to:, subject:, etc.)
   # @return [Mail::Message, nil] The mail message, or nil if user shouldn't receive email
-  def mail_to_user(user, unsubscribe_key: nil, **args, &block)
-    return unless user.may_receive_emails?
+  def mail_to_user(user, unsubscribe_key: nil, force: false, **args, &block)
+    return unless force || user.may_receive_emails?
 
     if unsubscribe_key
-      return unless user.public_send("receive_#{unsubscribe_key}?")
+      return unless force || user.public_send("receive_#{unsubscribe_key}?")
 
       add_unsubscribe_headers!(user, unsubscribe_key)
     end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -63,15 +63,13 @@ class ApplicationMailer < ActionMailer::Base
   # @param user [User] The recipient user
   # @param unsubscribe_key [Symbol, nil] The preference key (e.g., :newsletters, :milestone_emails)
   #   If nil, only checks global email validity
-  # @param force [Boolean] When true, skip the bounce/complaint and preference guards so the
-  #   email always renders/sends. Used only for admin preview and test sends.
   # @param args [Hash] Options passed to mail() (to:, subject:, etc.)
   # @return [Mail::Message, nil] The mail message, or nil if user shouldn't receive email
-  def mail_to_user(user, unsubscribe_key: nil, force: false, **args, &block)
-    return unless force || user.may_receive_emails?
+  def mail_to_user(user, unsubscribe_key: nil, **args, &block)
+    return unless user.may_receive_emails?
 
     if unsubscribe_key
-      return unless force || user.public_send("receive_#{unsubscribe_key}?")
+      return unless user.public_send("receive_#{unsubscribe_key}?")
 
       add_unsubscribe_headers!(user, unsubscribe_key)
     end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -67,6 +67,7 @@ class ApplicationMailer < ActionMailer::Base
   # @return [Mail::Message, nil] The mail message, or nil if user shouldn't receive email
   def mail_to_user(user, unsubscribe_key: nil, **args, &block)
     return unless user.may_receive_emails?
+    return unless user.email_valid?
 
     if unsubscribe_key
       return unless user.public_send("receive_#{unsubscribe_key}?")

--- a/app/mailers/mailshot_mailer.rb
+++ b/app/mailers/mailshot_mailer.rb
@@ -1,0 +1,19 @@
+# Bulk/marketing emails (mailshots) sent via hello.jiki.io.
+# Authored as markdown in the admin and rendered into the shared MJML layout.
+# Users unsubscribe via the mailshot's email_communication_preferences_key
+# (defaults to :newsletters).
+class MailshotMailer < ApplicationMailer
+  self.email_category = :marketing
+
+  def send_mailshot(user, mailshot, force: false)
+    @mailshot = mailshot
+    @header_image = "newsletter.jpg"
+
+    mail_to_user(
+      user,
+      unsubscribe_key: mailshot.unsubscribe_key,
+      force:,
+      subject: mailshot.subject
+    )
+  end
+end

--- a/app/mailers/mailshot_mailer.rb
+++ b/app/mailers/mailshot_mailer.rb
@@ -5,14 +5,13 @@
 class MailshotMailer < ApplicationMailer
   self.email_category = :marketing
 
-  def send_mailshot(user, mailshot, force: false)
+  def send_mailshot(user, mailshot)
     @mailshot = mailshot
     @header_image = "newsletter.jpg"
 
     mail_to_user(
       user,
       unsubscribe_key: mailshot.unsubscribe_key,
-      force:,
       subject: mailshot.subject
     )
   end

--- a/app/models/mailshot.rb
+++ b/app/models/mailshot.rb
@@ -3,6 +3,7 @@ class Mailshot < ApplicationRecord
   # namespaced constant can't be opened before Mailshot autoloads. It is
   # available app-wide wherever Mailshot is referenced.
   class UnknownSegmentError < RuntimeError; end
+  class BlankBodyError < RuntimeError; end
 
   has_many :user_mailshots, class_name: "User::Mailshot", dependent: :destroy
 

--- a/app/models/mailshot.rb
+++ b/app/models/mailshot.rb
@@ -1,10 +1,4 @@
 class Mailshot < ApplicationRecord
-  # Defined here (rather than config/initializers/exceptions.rb) because the
-  # namespaced constant can't be opened before Mailshot autoloads. It is
-  # available app-wide wherever Mailshot is referenced.
-  class UnknownSegmentError < RuntimeError; end
-  class BlankBodyError < RuntimeError; end
-
   # Communication-preference keys a mailshot is allowed to use. Only newsletters
   # for now; expand this list (and confirm a matching receive_* preference and
   # NOTIFICATION_SLUGS entry exist) to support other kinds.

--- a/app/models/mailshot.rb
+++ b/app/models/mailshot.rb
@@ -5,10 +5,16 @@ class Mailshot < ApplicationRecord
   class UnknownSegmentError < RuntimeError; end
   class BlankBodyError < RuntimeError; end
 
+  # Communication-preference keys a mailshot is allowed to use. Only newsletters
+  # for now; expand this list (and confirm a matching receive_* preference and
+  # NOTIFICATION_SLUGS entry exist) to support other kinds.
+  ALLOWED_PREFERENCE_KEYS = %w[newsletters].freeze
+
   has_many :user_mailshots, class_name: "User::Mailshot", dependent: :destroy
 
   validates :slug, presence: true, uniqueness: true
   validates :subject, presence: true
+  validates :email_communication_preferences_key, inclusion: { in: ALLOWED_PREFERENCE_KEYS }
   # body_markdown may be blank while drafting; presence is enforced at send time.
 
   # Named audience segments → lambdas returning a User relation.

--- a/app/models/mailshot.rb
+++ b/app/models/mailshot.rb
@@ -1,0 +1,27 @@
+class Mailshot < ApplicationRecord
+  # Defined here (rather than config/initializers/exceptions.rb) because the
+  # namespaced constant can't be opened before Mailshot autoloads. It is
+  # available app-wide wherever Mailshot is referenced.
+  class UnknownSegmentError < RuntimeError; end
+
+  has_many :user_mailshots, class_name: "User::Mailshot", dependent: :destroy
+
+  validates :slug, presence: true, uniqueness: true
+  validates :subject, presence: true
+  # body_markdown may be blank while drafting; presence is enforced at send time.
+
+  # Named audience segments → lambdas returning a User relation.
+  # Use merge(...) to avoid hardcoding the user_data table name.
+  SEGMENTS = {
+    "all_users" => -> { User.all },
+    "premium_users" => -> { User.joins(:data).merge(User::Data.where(membership_type: "premium")) },
+    "free_users" => -> { User.joins(:data).merge(User::Data.where(membership_type: "standard")) },
+    "admin_users" => -> { User.where(admin: true) }
+  }.freeze
+
+  def ready_to_send? = body_markdown.present?
+  def segment_relation(key) = SEGMENTS.fetch(key).()
+  def sent_to_audience?(key) = sent_to_audiences.include?(key)
+  def sent? = sent_to_audiences.any?
+  def unsubscribe_key = email_communication_preferences_key.to_sym
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
   has_many :assistant_conversations, dependent: :destroy
   has_many :payments, dependent: :destroy
   has_many :premium_entitlements, class_name: "::PremiumEntitlement", dependent: :destroy
+  has_many :user_mailshots, class_name: "User::Mailshot", dependent: :destroy
 
   after_initialize do
     build_data if new_record? && !data

--- a/app/models/user/mailshot.rb
+++ b/app/models/user/mailshot.rb
@@ -1,0 +1,16 @@
+class User::Mailshot < ApplicationRecord
+  include Emailable
+  has_email_status # default `email_status` column
+
+  belongs_to :user
+  belongs_to :mailshot
+
+  # mail_to_user performs the real preference check, so SendEmail's pref key stays nil...
+  def email_communication_preferences_key(_kind = nil) = nil
+
+  # ...but email_should_send? mirrors that check so the status is marked `skipped`
+  # accurately when the user has opted out of this mailshot's preference.
+  def email_should_send?(_kind = nil)
+    user.public_send("receive_#{mailshot.email_communication_preferences_key}?")
+  end
+end

--- a/app/serializers/serialize_mailshot.rb
+++ b/app/serializers/serialize_mailshot.rb
@@ -1,0 +1,19 @@
+class SerializeMailshot
+  include Mandate
+
+  initialize_with :mailshot
+
+  def call
+    {
+      id: mailshot.id,
+      slug: mailshot.slug,
+      subject: mailshot.subject,
+      body_markdown: mailshot.body_markdown,
+      email_communication_preferences_key: mailshot.email_communication_preferences_key,
+      sent_to_audiences: mailshot.sent_to_audiences,
+      sent_count: mailshot.user_mailshots.count,
+      created_at: mailshot.created_at.iso8601,
+      updated_at: mailshot.updated_at.iso8601
+    }
+  end
+end

--- a/app/serializers/serialize_mailshots.rb
+++ b/app/serializers/serialize_mailshots.rb
@@ -1,0 +1,26 @@
+class SerializeMailshots
+  include Mandate
+
+  initialize_with :mailshots
+
+  def call
+    mailshots.map do |mailshot|
+      {
+        id: mailshot.id,
+        slug: mailshot.slug,
+        subject: mailshot.subject,
+        sent_to_audiences: mailshot.sent_to_audiences,
+        sent_count: sent_counts.fetch(mailshot.id, 0),
+        created_at: mailshot.created_at.iso8601,
+        updated_at: mailshot.updated_at.iso8601
+      }
+    end
+  end
+
+  private
+  # Single grouped query for all sent counts, avoiding an N+1 across the page.
+  memoize
+  def sent_counts
+    User::Mailshot.where(mailshot_id: mailshots.map(&:id)).group(:mailshot_id).count
+  end
+end

--- a/app/views/mailshot_mailer/send_mailshot.mjml
+++ b/app/views/mailshot_mailer/send_mailshot.mjml
@@ -1,0 +1,7 @@
+- content_for :title, @mailshot.subject
+- content_for :preview, @mailshot.subject
+
+%mj-section{ "background-color": "#ffffff" }
+  %mj-column
+    %mj-text
+      = markdown_to_html(@mailshot.body_markdown)

--- a/app/views/mailshot_mailer/send_mailshot.text.erb
+++ b/app/views/mailshot_mailer/send_mailshot.text.erb
@@ -1,0 +1,1 @@
+<%= markdown_to_text(@mailshot.body_markdown) %>

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -59,6 +59,10 @@ class AssistantConversationAccessDeniedError < RuntimeError; end
 # Stripe errors
 class StripeSubscriptionCancellationError < RuntimeError; end
 
+# Mailshot errors
+class MailshotUnknownSegmentError < RuntimeError; end
+class MailshotBlankBodyError < RuntimeError; end
+
 class StripeCheckoutSessionIncompleteError < RuntimeError
   attr_reader :decline_reason, :interval, :currency
 

--- a/config/locales/api_errors.en.yml
+++ b/config/locales/api_errors.en.yml
@@ -29,6 +29,10 @@ en:
     email_template_not_found: "Email template not found"
     user_project_not_found: "User project not found"
     user_video_not_found: "User video not found"
+    mailshot_not_found: "Mailshot not found"
+    unknown_segment: "Unknown audience segment"
+    mailshot_body_blank: "Add content before sending this mailshot"
+    mailshot_already_sent: "This mailshot has already been sent and can't be deleted"
     validation_error: "Validation failed"
     invalid_event: "Unknown analytics event"
 

--- a/config/locales/api_errors.en.yml
+++ b/config/locales/api_errors.en.yml
@@ -26,7 +26,6 @@ en:
     project_not_found: "Project not found"
     concept_not_found: "Concept not found"
     badge_not_found: "Badge not found"
-    email_template_not_found: "Email template not found"
     user_project_not_found: "User project not found"
     user_video_not_found: "User video not found"
     mailshot_not_found: "Mailshot not found"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,15 @@ Rails.application.routes.draw do
         end
       end
     end
+    resources :mailshots, only: %i[index show create update destroy] do
+      member do
+        post :preview
+        # Named send_test (not :test) so the URL helper isn't `test_*`, which
+        # Minitest would treat as a test method.
+        post "test", action: :send_test, as: :send_test
+        post "send", action: :send_to_segment
+      end
+    end
     resources :images, only: [:create]
     resource :seeds, only: [:create]
   end

--- a/db/migrate/20260622120000_create_mailshots.rb
+++ b/db/migrate/20260622120000_create_mailshots.rb
@@ -1,0 +1,15 @@
+class CreateMailshots < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mailshots do |t|
+      t.string :slug, null: false
+      t.string :subject, null: false
+      t.text :body_markdown, null: false
+      t.string :email_communication_preferences_key, null: false, default: "newsletters"
+      t.jsonb :sent_to_audiences, null: false, default: []
+
+      t.timestamps
+    end
+
+    add_index :mailshots, :slug, unique: true
+  end
+end

--- a/db/migrate/20260622120100_create_user_mailshots.rb
+++ b/db/migrate/20260622120100_create_user_mailshots.rb
@@ -1,0 +1,13 @@
+class CreateUserMailshots < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_mailshots do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :mailshot, null: false, foreign_key: true
+      t.integer :email_status, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :user_mailshots, %i[user_id mailshot_id], unique: true
+  end
+end

--- a/db/migrate/20260622120200_default_mailshot_body_markdown.rb
+++ b/db/migrate/20260622120200_default_mailshot_body_markdown.rb
@@ -1,0 +1,6 @@
+class DefaultMailshotBodyMarkdown < ActiveRecord::Migration[8.1]
+  def change
+    # Allow drafts to be created without a body; presence is enforced at send time.
+    change_column_default :mailshots, :body_markdown, from: nil, to: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_21_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_120200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -211,6 +211,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_120000) do
     t.index ["course_id"], name: "index_levels_on_course_id"
     t.index ["slug"], name: "index_levels_on_slug", unique: true
     t.index ["uuid"], name: "index_levels_on_uuid", unique: true
+  end
+
+  create_table "mailshots", force: :cascade do |t|
+    t.text "body_markdown", default: "", null: false
+    t.datetime "created_at", null: false
+    t.string "email_communication_preferences_key", default: "newsletters", null: false
+    t.jsonb "sent_to_audiences", default: [], null: false
+    t.string "slug", null: false
+    t.string "subject", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_mailshots_on_slug", unique: true
   end
 
   create_table "payments", force: :cascade do |t|
@@ -496,6 +507,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_120000) do
     t.index ["user_id"], name: "index_user_levels_on_user_id"
   end
 
+  create_table "user_mailshots", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "email_status", default: 0, null: false
+    t.bigint "mailshot_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["mailshot_id"], name: "index_user_mailshots_on_mailshot_id"
+    t.index ["user_id", "mailshot_id"], name: "index_user_mailshots_on_user_id_and_mailshot_id", unique: true
+    t.index ["user_id"], name: "index_user_mailshots_on_user_id"
+  end
+
   create_table "user_notifications", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "email_status", default: 0, null: false
@@ -593,6 +615,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_120000) do
   add_foreign_key "user_levels", "levels"
   add_foreign_key "user_levels", "user_lessons", column: "current_user_lesson_id"
   add_foreign_key "user_levels", "users"
+  add_foreign_key "user_mailshots", "mailshots"
+  add_foreign_key "user_mailshots", "users"
   add_foreign_key "user_notifications", "users"
   add_foreign_key "user_projects", "projects"
   add_foreign_key "user_projects", "users"

--- a/test/commands/mailshot/render_preview_test.rb
+++ b/test/commands/mailshot/render_preview_test.rb
@@ -12,14 +12,4 @@ class Mailshot::RenderPreviewTest < ActiveSupport::TestCase
     assert_match(/<table/, html) # MJML compiled to HTML tables
     refute_match(/<mj-/, html)   # no raw MJML left
   end
-
-  test "renders even when the user has opted out" do
-    user = create(:user)
-    user.data.update!(receive_newsletters: false)
-    mailshot = create(:mailshot, body_markdown: "preview body")
-
-    html = Mailshot::RenderPreview.(mailshot, user)
-
-    assert_match "preview body", html
-  end
 end

--- a/test/commands/mailshot/render_preview_test.rb
+++ b/test/commands/mailshot/render_preview_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Mailshot::RenderPreviewTest < ActiveSupport::TestCase
+  test "renders the mailshot markdown into compiled email HTML" do
+    user = create(:user)
+    mailshot = create(:mailshot, subject: "Big news", body_markdown: "## Heading\n\n**bold**")
+
+    html = Mailshot::RenderPreview.(mailshot, user)
+
+    assert_match "bold", html
+    assert_match(%r{<strong>bold</strong>}, html)
+    assert_match(/<table/, html) # MJML compiled to HTML tables
+    refute_match(/<mj-/, html)   # no raw MJML left
+  end
+
+  test "renders even when the user has opted out" do
+    user = create(:user)
+    user.data.update!(receive_newsletters: false)
+    mailshot = create(:mailshot, body_markdown: "preview body")
+
+    html = Mailshot::RenderPreview.(mailshot, user)
+
+    assert_match "preview body", html
+  end
+end

--- a/test/commands/mailshot/send_test.rb
+++ b/test/commands/mailshot/send_test.rb
@@ -34,7 +34,7 @@ class Mailshot::SendTest < ActiveSupport::TestCase
   test "raises for an unknown segment" do
     mailshot = create(:mailshot)
 
-    assert_raises(Mailshot::UnknownSegmentError) do
+    assert_raises(MailshotUnknownSegmentError) do
       Mailshot::Send.(mailshot, "nonsense")
     end
   end
@@ -44,7 +44,7 @@ class Mailshot::SendTest < ActiveSupport::TestCase
 
     Mailshot::SendToSegment.expects(:defer).never
 
-    assert_raises(Mailshot::BlankBodyError) do
+    assert_raises(MailshotBlankBodyError) do
       Mailshot::Send.(mailshot, "all_users")
     end
   end

--- a/test/commands/mailshot/send_test.rb
+++ b/test/commands/mailshot/send_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class Mailshot::SendTest < ActiveSupport::TestCase
+  test "records the audience and defers the fan-out" do
+    mailshot = create(:mailshot)
+
+    Mailshot::SendToSegment.expects(:defer).with(mailshot, "all_users")
+
+    Mailshot::Send.(mailshot, "all_users")
+
+    assert_equal ["all_users"], mailshot.reload.sent_to_audiences
+  end
+
+  test "appends to existing audiences" do
+    mailshot = create(:mailshot, sent_to_audiences: ["premium_users"])
+
+    Mailshot::SendToSegment.expects(:defer).with(mailshot, "all_users")
+
+    Mailshot::Send.(mailshot, "all_users")
+
+    assert_equal %w[premium_users all_users], mailshot.reload.sent_to_audiences
+  end
+
+  test "is a no-op for an already-sent segment" do
+    mailshot = create(:mailshot, :sent) # all_users
+
+    Mailshot::SendToSegment.expects(:defer).never
+
+    Mailshot::Send.(mailshot, "all_users")
+
+    assert_equal ["all_users"], mailshot.reload.sent_to_audiences
+  end
+
+  test "raises for an unknown segment" do
+    mailshot = create(:mailshot)
+
+    assert_raises(Mailshot::UnknownSegmentError) do
+      Mailshot::Send.(mailshot, "nonsense")
+    end
+  end
+end

--- a/test/commands/mailshot/send_test.rb
+++ b/test/commands/mailshot/send_test.rb
@@ -38,4 +38,14 @@ class Mailshot::SendTest < ActiveSupport::TestCase
       Mailshot::Send.(mailshot, "nonsense")
     end
   end
+
+  test "raises when the body is blank" do
+    mailshot = create(:mailshot, body_markdown: "")
+
+    Mailshot::SendToSegment.expects(:defer).never
+
+    assert_raises(Mailshot::BlankBodyError) do
+      Mailshot::Send.(mailshot, "all_users")
+    end
+  end
 end

--- a/test/commands/mailshot/send_test_email_test.rb
+++ b/test/commands/mailshot/send_test_email_test.rb
@@ -1,9 +1,21 @@
 require "test_helper"
 
 class Mailshot::SendTestEmailTest < ActiveSupport::TestCase
-  test "sends to the given user without creating a record" do
+  test "sends to the given admin through the normal pipeline" do
     admin = create(:user, :admin)
     mailshot = create(:mailshot)
+
+    assert_difference "User::Mailshot.count", 1 do
+      assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+        Mailshot::SendTestEmail.(mailshot, admin)
+      end
+    end
+  end
+
+  test "deletes any prior send record so the test can be repeated" do
+    admin = create(:user, :admin)
+    mailshot = create(:mailshot)
+    create(:user_mailshot, user: admin, mailshot:)
 
     assert_no_difference "User::Mailshot.count" do
       assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
@@ -12,13 +24,12 @@ class Mailshot::SendTestEmailTest < ActiveSupport::TestCase
     end
   end
 
-  test "sends even when the recipient has opted out" do
-    admin = create(:user, :admin)
-    admin.data.update!(receive_newsletters: false)
+  test "raises when the user is not an admin" do
+    user = create(:user)
     mailshot = create(:mailshot)
 
-    assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
-      Mailshot::SendTestEmail.(mailshot, admin)
+    assert_raises(ArgumentError) do
+      Mailshot::SendTestEmail.(mailshot, user)
     end
   end
 end

--- a/test/commands/mailshot/send_test_email_test.rb
+++ b/test/commands/mailshot/send_test_email_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Mailshot::SendTestEmailTest < ActiveSupport::TestCase
+  test "sends to the given user without creating a record" do
+    admin = create(:user, :admin)
+    mailshot = create(:mailshot)
+
+    assert_no_difference "User::Mailshot.count" do
+      assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+        Mailshot::SendTestEmail.(mailshot, admin)
+      end
+    end
+  end
+
+  test "sends even when the recipient has opted out" do
+    admin = create(:user, :admin)
+    admin.data.update!(receive_newsletters: false)
+    mailshot = create(:mailshot)
+
+    assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+      Mailshot::SendTestEmail.(mailshot, admin)
+    end
+  end
+end

--- a/test/commands/mailshot/send_to_segment_test.rb
+++ b/test/commands/mailshot/send_to_segment_test.rb
@@ -1,16 +1,27 @@
 require "test_helper"
 
 class Mailshot::SendToSegmentTest < ActiveSupport::TestCase
-  test "sends to each user in the segment and reschedules the next batch" do
+  test "sends to each user in the segment and reschedules from the last id" do
     users = create_list(:user, 2).sort_by(&:id)
     mailshot = create(:mailshot)
 
     users.each { |user| User::Mailshot::Send.expects(:call).with(user, mailshot) }
     Mailshot::SendToSegment.expects(:defer).with(
-      mailshot, "all_users", limit: 100, offset: 100, wait: 5.seconds
+      mailshot, "all_users", last_id: users.last.id, wait: 5.seconds
     )
 
     Mailshot::SendToSegment.(mailshot, "all_users")
+  end
+
+  test "only fetches users after the cursor" do
+    first = create(:user)
+    second = create(:user)
+    mailshot = create(:mailshot)
+
+    User::Mailshot::Send.expects(:call).with(second, mailshot).once
+    Mailshot::SendToSegment.stubs(:defer)
+
+    Mailshot::SendToSegment.(mailshot, "all_users", last_id: first.id)
   end
 
   test "only targets users in the segment" do
@@ -25,11 +36,12 @@ class Mailshot::SendToSegmentTest < ActiveSupport::TestCase
   end
 
   test "stops without rescheduling when the batch is empty" do
+    user = create(:user)
     mailshot = create(:mailshot)
 
     User::Mailshot::Send.expects(:call).never
     Mailshot::SendToSegment.expects(:defer).never
 
-    Mailshot::SendToSegment.(mailshot, "all_users", limit: 100, offset: 100)
+    Mailshot::SendToSegment.(mailshot, "all_users", last_id: user.id)
   end
 end

--- a/test/commands/mailshot/send_to_segment_test.rb
+++ b/test/commands/mailshot/send_to_segment_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class Mailshot::SendToSegmentTest < ActiveSupport::TestCase
+  test "sends to each user in the segment and reschedules the next batch" do
+    users = create_list(:user, 2).sort_by(&:id)
+    mailshot = create(:mailshot)
+
+    users.each { |user| User::Mailshot::Send.expects(:call).with(user, mailshot) }
+    Mailshot::SendToSegment.expects(:defer).with(
+      mailshot, "all_users", limit: 100, offset: 100, wait: 5.seconds
+    )
+
+    Mailshot::SendToSegment.(mailshot, "all_users")
+  end
+
+  test "only targets users in the segment" do
+    premium = make_premium(create(:user))
+    create(:user) # free — must be excluded
+    mailshot = create(:mailshot)
+
+    User::Mailshot::Send.expects(:call).with(premium, mailshot).once
+    Mailshot::SendToSegment.stubs(:defer)
+
+    Mailshot::SendToSegment.(mailshot, "premium_users")
+  end
+
+  test "stops without rescheduling when the batch is empty" do
+    mailshot = create(:mailshot)
+
+    User::Mailshot::Send.expects(:call).never
+    Mailshot::SendToSegment.expects(:defer).never
+
+    Mailshot::SendToSegment.(mailshot, "all_users", limit: 100, offset: 100)
+  end
+end

--- a/test/commands/user/mailshot/send_test.rb
+++ b/test/commands/user/mailshot/send_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class User::Mailshot::SendTest < ActiveSupport::TestCase
+  test "creates a record and sends the email" do
+    user = create(:user)
+    mailshot = create(:mailshot)
+
+    assert_difference "User::Mailshot.count", 1 do
+      assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+        User::Mailshot::Send.(user, mailshot)
+      end
+    end
+
+    record = User::Mailshot.last
+    assert_equal user, record.user
+    assert_equal mailshot, record.mailshot
+    assert record.email_sent?
+  end
+
+  test "is idempotent — never creates a duplicate or resends" do
+    user = create(:user)
+    mailshot = create(:mailshot)
+    User::Mailshot::Send.(user, mailshot)
+
+    User::SendEmail.expects(:call).never
+
+    assert_no_difference "User::Mailshot.count" do
+      assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        User::Mailshot::Send.(user, mailshot)
+      end
+    end
+  end
+
+  test "marks skipped and sends nothing when the user has opted out" do
+    user = create(:user)
+    user.data.update!(receive_newsletters: false)
+    mailshot = create(:mailshot)
+
+    assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      User::Mailshot::Send.(user, mailshot)
+    end
+
+    assert User::Mailshot.last.email_skipped?
+  end
+end

--- a/test/commands/user/send_email_test.rb
+++ b/test/commands/user/send_email_test.rb
@@ -33,6 +33,14 @@ class User::SendEmailTest < ActiveSupport::TestCase
     assert user_level.email_skipped?
   end
 
+  test "does not send if the user is unconfirmed" do
+    user_level = create(:user_level, completed_at: Time.current)
+    user_level.user.expects(confirmed?: false)
+
+    refute_email_sent(user_level)
+    assert user_level.email_skipped?
+  end
+
   test "only sends for email pending status" do
     user = create(:user)
     level = create(:level)

--- a/test/commands/user/send_email_test.rb
+++ b/test/commands/user/send_email_test.rb
@@ -25,6 +25,14 @@ class User::SendEmailTest < ActiveSupport::TestCase
     assert user_level.email_skipped?
   end
 
+  test "does not send if the user's email has bounced" do
+    user_level = create(:user_level, completed_at: Time.current)
+    user_level.user.expects(email_valid?: false)
+
+    refute_email_sent(user_level)
+    assert user_level.email_skipped?
+  end
+
   test "only sends for email pending status" do
     user = create(:user)
     level = create(:level)

--- a/test/controllers/admin/mailshots_controller_test.rb
+++ b/test/controllers/admin/mailshots_controller_test.rb
@@ -1,0 +1,191 @@
+require "test_helper"
+
+class Admin::MailshotsControllerTest < ApplicationControllerTest
+  setup do
+    @admin = create(:user, :admin)
+    sign_in_user(@admin)
+  end
+
+  # Authentication and authorization guards
+  guard_admin! :admin_mailshots_path, method: :get
+  guard_admin! :admin_mailshots_path, method: :post
+  guard_admin! :admin_mailshot_path, args: [1], method: :get
+  guard_admin! :admin_mailshot_path, args: [1], method: :patch
+  guard_admin! :admin_mailshot_path, args: [1], method: :delete
+
+  # INDEX
+
+  test "GET index returns mailshots newest first with pagination" do
+    Prosopite.finish
+    older = create(:mailshot, created_at: 2.days.ago)
+    newer = create(:mailshot, created_at: 1.day.ago)
+
+    Prosopite.scan
+    get admin_mailshots_path, as: :json
+
+    assert_response :success
+    assert_json_response({
+      results: SerializeMailshots.([newer, older]),
+      meta: { current_page: 1, total_pages: 1, total_count: 2 }
+    })
+  end
+
+  # SHOW
+
+  test "GET show returns the mailshot" do
+    mailshot = create(:mailshot)
+
+    get admin_mailshot_path(mailshot), as: :json
+
+    assert_response :success
+    assert_json_response({ mailshot: SerializeMailshot.(mailshot) })
+  end
+
+  test "GET show returns 404 for an unknown mailshot" do
+    get admin_mailshot_path(0), as: :json
+
+    assert_json_error(:not_found, error_type: :mailshot_not_found)
+  end
+
+  # CREATE
+
+  test "POST create makes a mailshot" do
+    assert_difference "Mailshot.count", 1 do
+      post admin_mailshots_path,
+        params: { mailshot: { slug: "launch", subject: "We launched", body_markdown: "Hi" } },
+        as: :json
+    end
+
+    assert_response :created
+    assert_json_response({ mailshot: SerializeMailshot.(Mailshot.last) })
+  end
+
+  test "POST create makes a draft without a body" do
+    assert_difference "Mailshot.count", 1 do
+      post admin_mailshots_path,
+        params: { mailshot: { slug: "draft", subject: "Draft" } },
+        as: :json
+    end
+
+    assert_response :created
+    assert_equal "", Mailshot.last.body_markdown
+  end
+
+  test "POST create returns validation errors" do
+    post admin_mailshots_path,
+      params: { mailshot: { body_markdown: "Hi" } },
+      as: :json
+
+    assert_json_error(
+      :unprocessable_entity,
+      error_type: :validation_error,
+      errors: { slug: ["can't be blank"], subject: ["can't be blank"] }
+    )
+  end
+
+  # UPDATE
+
+  test "PATCH update changes the mailshot" do
+    mailshot = create(:mailshot)
+
+    patch admin_mailshot_path(mailshot),
+      params: { mailshot: { subject: "Edited subject" } },
+      as: :json
+
+    assert_response :success
+    assert_equal "Edited subject", mailshot.reload.subject
+    assert_json_response({ mailshot: SerializeMailshot.(mailshot) })
+  end
+
+  # DESTROY
+
+  test "DELETE destroy removes a draft" do
+    mailshot = create(:mailshot)
+
+    assert_difference "Mailshot.count", -1 do
+      delete admin_mailshot_path(mailshot), as: :json
+    end
+
+    assert_response :no_content
+  end
+
+  test "DELETE destroy refuses an already-sent mailshot" do
+    mailshot = create(:mailshot, :sent)
+
+    assert_no_difference "Mailshot.count" do
+      delete admin_mailshot_path(mailshot), as: :json
+    end
+
+    assert_json_error(:unprocessable_entity, error_type: :mailshot_already_sent)
+  end
+
+  # PREVIEW
+
+  test "POST preview renders HTML from the submitted content without saving" do
+    mailshot = create(:mailshot, body_markdown: "saved body")
+
+    post preview_admin_mailshot_path(mailshot),
+      params: { mailshot: { subject: "Live subject", body_markdown: "live body" } },
+      as: :json
+
+    assert_response :success
+    assert_match "live body", response.parsed_body["html"]
+    assert_equal "saved body", mailshot.reload.body_markdown
+  end
+
+  # TEST SEND
+
+  test "POST test sends to the current admin without recording a send" do
+    mailshot = create(:mailshot)
+
+    assert_no_difference "User::Mailshot.count" do
+      assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+        post send_test_admin_mailshot_path(mailshot), as: :json
+      end
+    end
+
+    assert_response :success
+    assert_json_response({ success: true })
+  end
+
+  # SEND
+
+  test "POST send records the audience and returns the count" do
+    create_list(:user, 2)
+    mailshot = create(:mailshot)
+
+    post send_admin_mailshot_path(mailshot), params: { segment: "all_users" }, as: :json
+
+    assert_response :success
+    assert_equal ["all_users"], mailshot.reload.sent_to_audiences
+    assert_equal User.count, response.parsed_body["audience_count"]
+    assert_json_response({ mailshot: SerializeMailshot.(mailshot), audience_count: User.count })
+  end
+
+  test "POST send is a no-op and returns 0 for an already-sent segment" do
+    mailshot = create(:mailshot, :sent)
+
+    Mailshot::SendToSegment.expects(:defer).never
+    post send_admin_mailshot_path(mailshot), params: { segment: "all_users" }, as: :json
+
+    assert_response :success
+    assert_equal 0, response.parsed_body["audience_count"]
+  end
+
+  test "POST send rejects a mailshot with no body" do
+    mailshot = create(:mailshot, body_markdown: "")
+
+    Mailshot::SendToSegment.expects(:defer).never
+    post send_admin_mailshot_path(mailshot), params: { segment: "all_users" }, as: :json
+
+    assert_json_error(:unprocessable_entity, error_type: :mailshot_body_blank)
+  end
+
+  test "POST send rejects an unknown segment" do
+    mailshot = create(:mailshot)
+
+    post send_admin_mailshot_path(mailshot), params: { segment: "nonsense" }, as: :json
+
+    assert_json_error(:unprocessable_entity, error_type: :unknown_segment, segment: "nonsense")
+  end
+end

--- a/test/controllers/admin/mailshots_controller_test.rb
+++ b/test/controllers/admin/mailshots_controller_test.rb
@@ -12,6 +12,9 @@ class Admin::MailshotsControllerTest < ApplicationControllerTest
   guard_admin! :admin_mailshot_path, args: [1], method: :get
   guard_admin! :admin_mailshot_path, args: [1], method: :patch
   guard_admin! :admin_mailshot_path, args: [1], method: :delete
+  guard_admin! :preview_admin_mailshot_path, args: [1], method: :post
+  guard_admin! :send_test_admin_mailshot_path, args: [1], method: :post
+  guard_admin! :send_admin_mailshot_path, args: [1], method: :post
 
   # INDEX
 

--- a/test/controllers/admin/mailshots_controller_test.rb
+++ b/test/controllers/admin/mailshots_controller_test.rb
@@ -135,13 +135,11 @@ class Admin::MailshotsControllerTest < ApplicationControllerTest
 
   # TEST SEND
 
-  test "POST test sends to the current admin without recording a send" do
+  test "POST test sends to the current admin" do
     mailshot = create(:mailshot)
 
-    assert_no_difference "User::Mailshot.count" do
-      assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
-        post send_test_admin_mailshot_path(mailshot), as: :json
-      end
+    assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+      post send_test_admin_mailshot_path(mailshot), as: :json
     end
 
     assert_response :success

--- a/test/controllers/admin/mailshots_controller_test.rb
+++ b/test/controllers/admin/mailshots_controller_test.rb
@@ -71,6 +71,18 @@ class Admin::MailshotsControllerTest < ApplicationControllerTest
     assert_equal "", Mailshot.last.body_markdown
   end
 
+  test "POST create rejects a preference key outside the allowed list" do
+    post admin_mailshots_path,
+      params: { mailshot: { slug: "x", subject: "x", email_communication_preferences_key: "event_emails" } },
+      as: :json
+
+    assert_json_error(
+      :unprocessable_entity,
+      error_type: :validation_error,
+      errors: { email_communication_preferences_key: ["is not included in the list"] }
+    )
+  end
+
   test "POST create returns validation errors" do
     post admin_mailshots_path,
       params: { mailshot: { body_markdown: "Hi" } },

--- a/test/factories/mailshots.rb
+++ b/test/factories/mailshots.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :mailshot do
+    sequence(:slug) { |n| "mailshot-#{n}" }
+    subject { "What's new at Jiki" }
+    body_markdown { "## Hello\n\nHere's the latest news." }
+    email_communication_preferences_key { "newsletters" }
+
+    trait :sent do
+      sent_to_audiences { ["all_users"] }
+    end
+  end
+end

--- a/test/factories/user_mailshots.rb
+++ b/test/factories/user_mailshots.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_mailshot, class: "User::Mailshot" do
+    user
+    mailshot
+  end
+end

--- a/test/mailers/mailshot_mailer_test.rb
+++ b/test/mailers/mailshot_mailer_test.rb
@@ -33,4 +33,14 @@ class MailshotMailerTest < ActionMailer::TestCase
 
     assert_nil mail.to
   end
+
+  test "does not send when the recipient's email has bounced" do
+    user = create(:user)
+    user.data.update!(email_bounced_at: Time.current)
+    mailshot = create(:mailshot)
+
+    mail = MailshotMailer.send_mailshot(user, mailshot)
+
+    assert_nil mail.to
+  end
 end

--- a/test/mailers/mailshot_mailer_test.rb
+++ b/test/mailers/mailshot_mailer_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class MailshotMailerTest < ActionMailer::TestCase
+  test "renders subject, recipient, from address and body" do
+    user = create(:user)
+    mailshot = create(:mailshot, subject: "Monthly news", body_markdown: "## Heading")
+
+    mail = MailshotMailer.send_mailshot(user, mailshot)
+
+    assert_equal "Monthly news", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["hello@hello.jiki.io"], mail.from
+    assert_match "Heading", mail.html_part.body.to_s
+    assert_match "Heading", mail.text_part.body.to_s
+  end
+
+  test "sets one-click unsubscribe headers for the newsletters preference" do
+    user = create(:user)
+    mailshot = create(:mailshot)
+
+    mail = MailshotMailer.send_mailshot(user, mailshot)
+
+    assert_match "key=newsletters", mail.header["List-Unsubscribe"].to_s
+    assert_equal "List-Unsubscribe=One-Click", mail.header["List-Unsubscribe-Post"].to_s
+  end
+
+  test "does not send when the user has opted out" do
+    user = create(:user)
+    user.data.update!(receive_newsletters: false)
+    mailshot = create(:mailshot)
+
+    mail = MailshotMailer.send_mailshot(user, mailshot)
+
+    assert_nil mail.to
+  end
+
+  test "force: true sends even when the user has opted out" do
+    user = create(:user)
+    user.data.update!(receive_newsletters: false)
+    mailshot = create(:mailshot)
+
+    mail = MailshotMailer.send_mailshot(user, mailshot, force: true)
+
+    assert_equal [user.email], mail.to
+  end
+end

--- a/test/mailers/mailshot_mailer_test.rb
+++ b/test/mailers/mailshot_mailer_test.rb
@@ -33,14 +33,4 @@ class MailshotMailerTest < ActionMailer::TestCase
 
     assert_nil mail.to
   end
-
-  test "force: true sends even when the user has opted out" do
-    user = create(:user)
-    user.data.update!(receive_newsletters: false)
-    mailshot = create(:mailshot)
-
-    mail = MailshotMailer.send_mailshot(user, mailshot, force: true)
-
-    assert_equal [user.email], mail.to
-  end
 end

--- a/test/models/mailshot_test.rb
+++ b/test/models/mailshot_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class MailshotTest < ActiveSupport::TestCase
+  test "defaults the preference key to newsletters" do
+    assert_equal "newsletters", create(:mailshot).email_communication_preferences_key
+  end
+
+  test "rejects a preference key outside the allowed list" do
+    mailshot = build(:mailshot, email_communication_preferences_key: "event_emails")
+
+    refute mailshot.valid?
+    assert_includes mailshot.errors[:email_communication_preferences_key], "is not included in the list"
+  end
+end

--- a/test/serializers/serialize_mailshot_test.rb
+++ b/test/serializers/serialize_mailshot_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class SerializeMailshotTest < ActiveSupport::TestCase
+  test "serializes a mailshot" do
+    mailshot = create(:mailshot,
+      slug: "june-news",
+      subject: "June news",
+      body_markdown: "## Hello",
+      sent_to_audiences: ["premium_users"])
+    create(:user_mailshot, mailshot:)
+
+    assert_equal(
+      {
+        id: mailshot.id,
+        slug: "june-news",
+        subject: "June news",
+        body_markdown: "## Hello",
+        email_communication_preferences_key: "newsletters",
+        sent_to_audiences: ["premium_users"],
+        sent_count: 1,
+        created_at: mailshot.created_at.iso8601,
+        updated_at: mailshot.updated_at.iso8601
+      },
+      SerializeMailshot.(mailshot)
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Adds an admin-authored bulk/marketing email system ("mailshots"), adapted from Exercism's `Mailshot`/`User::Mailshot` design and mapped onto Jiki's existing email infrastructure (`mail_to_user`, `Emailable`, `User::SendEmail`, Solid Queue).

The core requirement is **no duplicates**: a user can never receive the same mailshot twice.

## How dedup works

- `user_mailshots` has a **unique index on `[user_id, mailshot_id]`**. The per-user send does `create!` and rescues `RecordNotUnique` — the create *is* the dedup marker.
- Safe across **overlapping segments**, **job retries** (`retry_on` re-runs are idempotent), and **concurrent batches**.
- Batches use **keyset pagination** (`users.id > last_id`), so rows shifting mid-send can't skip or revisit a recipient.

## Send-eligibility (who gets emailed)

A user is skipped (and marked `skipped`) unless they: are not unsubscribed (`may_receive_emails?`), have not hard-bounced (`email_valid?`), are confirmed (`confirmed?`), and have `receive_newsletters: true`. The bounce + confirmed guards were added to `User::SendEmail`/`mail_to_user`, so they apply to **all non-devise emails**, not just mailshots (devise emails — password reset/confirmation — bypass `mail_to_user` and are unaffected).

## What's included

- **Models**: `Mailshot` (markdown body, named segments `all_users`/`premium_users`/`free_users`/`admin_users`, preference key locked to `newsletters`), `User::Mailshot` (the `Emailable` send record).
- **Commands**: `Mailshot::Send` (validates segment/body, records audience, defers), `Mailshot::SendToSegment` (keyset-batched, self-rescheduling on `:mailers`), `User::Mailshot::Send` (dedup + deliver), `Mailshot::SendTestEmail` (admin-only; deletes any prior record so tests repeat), `Mailshot::RenderPreview`.
- **Mailer**: `MailshotMailer` renders markdown into the shared MJML layout.
- **Admin API**: `Admin::MailshotsController` — CRUD + `preview`/`test`/`send`. Drafts can be created with a blank body; body presence is enforced at send time (in the command).
- **Serializers**: `SerializeMailshot` / `SerializeMailshots` (N+1-guarded count).

## Authoring & preview

Bodies are authored as markdown in the admin app and rendered server-side into the MJML layout, so preview (returned as HTML for an iframe) is pixel-accurate. The admin UI lives in the `admin` repo.

## Notes

- No config-gem change needed — Solid Queue workers listen on `"*"`.
- English-only content for now; the MJML chrome still localizes per recipient.
- `Mailshot::Send` raises `MailshotUnknownSegmentError` / `MailshotBlankBodyError` (defined in `config/initializers/exceptions.rb`); the controller rescues them into 422s.

## Testing

Full suite green. Tests cover command dedup/idempotency, keyset fan-out, send-eligibility (opt-out, bounced, unconfirmed), the serializer, and the controller (admin guards on every route incl. preview/test/send, CRUD, draft-without-body, blank-body/unknown-segment rejections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)