### PR TITLE
Mailshot preview text + send from Jeremy Walker

### DIFF
--- a/app/controllers/admin/mailshots_controller.rb
+++ b/app/controllers/admin/mailshots_controller.rb
@@ -69,10 +69,10 @@ class Admin::MailshotsController < Admin::BaseController
   end
 
   def mailshot_params
-    params.require(:mailshot).permit(:slug, :subject, :body_markdown, :email_communication_preferences_key)
+    params.require(:mailshot).permit(:slug, :subject, :preview_text, :body_markdown, :email_communication_preferences_key)
   end
 
   def preview_params
-    params.require(:mailshot).permit(:subject, :body_markdown)
+    params.require(:mailshot).permit(:subject, :preview_text, :body_markdown)
   end
 end

--- a/app/mailers/mailshot_mailer.rb
+++ b/app/mailers/mailshot_mailer.rb
@@ -5,6 +5,9 @@
 class MailshotMailer < ApplicationMailer
   self.email_category = :marketing
 
+  # Mailshots come from Jeremy personally rather than the default "Jiki" name.
+  FROM_NAME = "Jeremy Walker".freeze
+
   def send_mailshot(user, mailshot)
     @mailshot = mailshot
     @header_image = "newsletter.jpg"
@@ -12,6 +15,7 @@ class MailshotMailer < ApplicationMailer
     mail_to_user(
       user,
       unsubscribe_key: mailshot.unsubscribe_key,
+      from: "#{FROM_NAME} <#{Jiki.config.marketing_from_email}>",
       subject: mailshot.subject
     )
   end

--- a/app/serializers/serialize_mailshot.rb
+++ b/app/serializers/serialize_mailshot.rb
@@ -8,6 +8,7 @@ class SerializeMailshot
       id: mailshot.id,
       slug: mailshot.slug,
       subject: mailshot.subject,
+      preview_text: mailshot.preview_text,
       body_markdown: mailshot.body_markdown,
       email_communication_preferences_key: mailshot.email_communication_preferences_key,
       sent_to_audiences: mailshot.sent_to_audiences,

--- a/app/views/mailshot_mailer/send_mailshot.mjml
+++ b/app/views/mailshot_mailer/send_mailshot.mjml
@@ -1,5 +1,5 @@
 - content_for :title, @mailshot.subject
-- content_for :preview, @mailshot.subject
+- content_for :preview, @mailshot.preview_text
 
 %mj-section{ "background-color": "#ffffff" }
   %mj-column

--- a/db/migrate/20260623120000_add_preview_text_to_mailshots.rb
+++ b/db/migrate/20260623120000_add_preview_text_to_mailshots.rb
@@ -1,0 +1,5 @@
+class AddPreviewTextToMailshots < ActiveRecord::Migration[8.1]
+  def change
+    add_column :mailshots, :preview_text, :string, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_22_120200) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_23_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -217,6 +217,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_120200) do
     t.text "body_markdown", default: "", null: false
     t.datetime "created_at", null: false
     t.string "email_communication_preferences_key", default: "newsletters", null: false
+    t.string "preview_text", default: "", null: false
     t.jsonb "sent_to_audiences", default: [], null: false
     t.string "slug", null: false
     t.string "subject", null: false

--- a/test/mailers/mailshot_mailer_test.rb
+++ b/test/mailers/mailshot_mailer_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class MailshotMailerTest < ActionMailer::TestCase
-  test "renders subject, recipient, from address and body" do
+  test "renders subject, recipient, from and body" do
     user = create(:user)
     mailshot = create(:mailshot, subject: "Monthly news", body_markdown: "## Heading")
 
@@ -10,8 +10,18 @@ class MailshotMailerTest < ActionMailer::TestCase
     assert_equal "Monthly news", mail.subject
     assert_equal [user.email], mail.to
     assert_equal ["hello@hello.jiki.io"], mail.from
+    assert_equal "Jeremy Walker <hello@hello.jiki.io>", mail[:from].value
     assert_match "Heading", mail.html_part.body.to_s
     assert_match "Heading", mail.text_part.body.to_s
+  end
+
+  test "uses preview_text as the preheader" do
+    user = create(:user)
+    mailshot = create(:mailshot, subject: "Monthly news", preview_text: "Three new exercises inside")
+
+    html = MailshotMailer.send_mailshot(user, mailshot).html_part.body.to_s
+
+    assert_match "Three new exercises inside", html
   end
 
   test "sets one-click unsubscribe headers for the newsletters preference" do

--- a/test/serializers/serialize_mailshot_test.rb
+++ b/test/serializers/serialize_mailshot_test.rb
@@ -5,6 +5,7 @@ class SerializeMailshotTest < ActiveSupport::TestCase
     mailshot = create(:mailshot,
       slug: "june-news",
       subject: "June news",
+      preview_text: "The latest from Jiki",
       body_markdown: "## Hello",
       sent_to_audiences: ["premium_users"])
     create(:user_mailshot, mailshot:)
@@ -14,6 +15,7 @@ class SerializeMailshotTest < ActiveSupport::TestCase
         id: mailshot.id,
         slug: "june-news",
         subject: "June news",
+        preview_text: "The latest from Jiki",
         body_markdown: "## Hello",
         email_communication_preferences_key: "newsletters",
         sent_to_audiences: ["premium_users"],


### PR DESCRIPTION
Follow-ups to the mailshots feature (#487).

## 1. Preview text (preheader)

Adds a `preview_text` column to mailshots. The MJML preheader — the snippet shown in the inbox list / Gmail preview — now uses `preview_text` instead of duplicating the subject line. It's editable via the admin (permitted in create/update + preview params) and serialized.

If left blank, no subject is used as the preheader (clients fall back to the body start), fixing the "subject duplicated at the start of the email" issue.

## 2. From "Jeremy Walker"

Mailshots are sent from `Jeremy Walker <marketing_from_email>` rather than the default `Jiki <…>` name. The address is unchanged (still the marketing from-address); only the display name differs.

## Admin UI note

The admin app needs a `preview_text` field added to the mailshot form (and can display it in preview) — separate `admin` repo change.

## Testing

Full suite green. New/updated tests: serializer includes `preview_text`; mailer asserts the `Jeremy Walker <…>` from-name and that the preheader renders `preview_text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)