### PR TITLE
Derive user locale from Accept-Language preferences

### DIFF
--- a/app/commands/user/bootstrap.rb
+++ b/app/commands/user/bootstrap.rb
@@ -22,12 +22,7 @@ class User::Bootstrap
     user.data.update_column(:country_code, code)
   end
 
-  def set_locales!
-    locales = User::ParseAcceptLanguage.(accept_language)
-    return if locales.empty?
-
-    user.data.update_column(:locales, locales)
-  end
+  def set_locales! = User::UpdateLocales.(user, accept_language)
 
   # Email-signup users are unconfirmed at this point — they'll get the welcome
   # email via User#after_confirmation. OAuth users are pre-confirmed so we send

--- a/app/commands/user/bootstrap.rb
+++ b/app/commands/user/bootstrap.rb
@@ -1,10 +1,11 @@
 class User::Bootstrap
   include Mandate
 
-  initialize_with :user, :provider, attribution: nil, country_code: nil
+  initialize_with :user, :provider, attribution: nil, country_code: nil, accept_language: nil
 
   def call
     set_country_code!
+    set_locales!
     send_welcome_email!
     enroll_in_course!
     award_member_badge!
@@ -19,6 +20,13 @@ class User::Bootstrap
     return if code.blank? || code == "XX"
 
     user.data.update_column(:country_code, code)
+  end
+
+  def set_locales!
+    locales = User::ParseAcceptLanguage.(accept_language)
+    return if locales.empty?
+
+    user.data.update_column(:locales, locales)
   end
 
   # Email-signup users are unconfirmed at this point — they'll get the welcome

--- a/app/commands/user/parse_accept_language.rb
+++ b/app/commands/user/parse_accept_language.rb
@@ -1,0 +1,55 @@
+class User::ParseAcceptLanguage
+  include Mandate
+
+  initialize_with :header
+
+  # Headers are client-controlled, so cap how much we store.
+  MAX_LOCALES = 10
+
+  # A language tag like "en", "en-GB" or "zh-Hant-TW". Deliberately excludes
+  # the "*" wildcard — it carries no preference information worth storing.
+  TAG_REGEX = /\A[A-Za-z]{2,8}(-[A-Za-z0-9]{1,8})*\z/
+
+  def call
+    weighted_tags.
+      sort_by.with_index { |(_, quality), index| [-quality, index] }.
+      map(&:first).
+      uniq.
+      first(MAX_LOCALES)
+  end
+
+  private
+  def weighted_tags
+    header.to_s.split(",").filter_map do |entry|
+      tag, *params = entry.split(";").map(&:strip)
+      next unless tag&.match?(TAG_REGEX)
+
+      quality = quality_from(params)
+      next unless quality.positive?
+
+      [normalize(tag), quality]
+    end
+  end
+
+  def quality_from(params)
+    params.each do |param|
+      match = param.match(/\Aq\s*=\s*(\d(?:\.\d{1,3})?)\z/i)
+      return match[1].to_f if match
+    end
+    1.0
+  end
+
+  # Canonical casing: language lowercase, region uppercase, script titlecase
+  # (en-gb -> en-GB, ZH-hant -> zh-Hant).
+  def normalize(tag)
+    language, *subtags = tag.split("-")
+    normalized = subtags.map do |subtag|
+      case subtag.length
+      when 2 then subtag.upcase
+      when 4 then subtag.capitalize
+      else subtag.downcase
+      end
+    end
+    [language.downcase, *normalized].join("-")
+  end
+end

--- a/app/commands/user/search.rb
+++ b/app/commands/user/search.rb
@@ -21,7 +21,8 @@ class User::Search
     filter_name!
     filter_email!
 
-    @users.order(:name).page(page).per(per)
+    # data is needed for locale in SerializeAdminUser
+    @users.includes(:data).order(:name).page(page).per(per)
   end
 
   private

--- a/app/commands/user/update_locale.rb
+++ b/app/commands/user/update_locale.rb
@@ -5,7 +5,7 @@ class User
     initialize_with :user, :new_locale
 
     def call
-      user.data.update!(explicit_locale: new_locale)
+      user.update!(locale: new_locale)
     end
   end
 end

--- a/app/commands/user/update_locale.rb
+++ b/app/commands/user/update_locale.rb
@@ -5,7 +5,7 @@ class User
     initialize_with :user, :new_locale
 
     def call
-      user.update!(locale: new_locale)
+      user.data.update!(explicit_locale: new_locale)
     end
   end
 end

--- a/app/commands/user/update_locales.rb
+++ b/app/commands/user/update_locales.rb
@@ -1,9 +1,11 @@
 class User::UpdateLocales
   include Mandate
 
-  initialize_with :user, :accept_language
+  initialize_with :user, :accept_language, force: false
 
   def call
+    return if user.data.locales.present? && !force
+
     locales = User::ParseAcceptLanguage.(accept_language)
     return if locales.empty?
 

--- a/app/commands/user/update_locales.rb
+++ b/app/commands/user/update_locales.rb
@@ -1,0 +1,12 @@
+class User::UpdateLocales
+  include Mandate
+
+  initialize_with :user, :accept_language
+
+  def call
+    locales = User::ParseAcceptLanguage.(accept_language)
+    return if locales.empty?
+
+    user.data.update_column(:locales, locales)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,6 @@ class ApplicationController < ActionController::API
   # be derived from them until/unless they make an explicit choice.
   def set_user_locales
     return unless user_signed_in?
-    return if current_user.data.locales.present?
 
     User::UpdateLocales.(current_user, request.headers["Accept-Language"])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,10 +75,7 @@ class ApplicationController < ActionController::API
     return unless user_signed_in?
     return if current_user.data.locales.present?
 
-    locales = User::ParseAcceptLanguage.(request.headers["Accept-Language"])
-    return if locales.empty?
-
-    current_user.data.update_column(:locales, locales)
+    User::UpdateLocales.(current_user, request.headers["Accept-Language"])
   end
 
   def set_country_code

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::API
 
   before_action :set_current_user_agent
   before_action :set_current_user_ip
+  before_action :set_user_locales
   before_action :set_locale
   before_action :set_country_code
   before_action :extend_session_cookie!
@@ -66,6 +67,18 @@ class ApplicationController < ActionController::API
 
   def set_locale
     I18n.locale = params[:locale] || current_user&.locale || I18n.default_locale
+  end
+
+  # Capture the browser's language preferences once, so the user's locale can
+  # be derived from them until/unless they make an explicit choice.
+  def set_user_locales
+    return unless user_signed_in?
+    return if current_user.data.locales.present?
+
+    locales = User::ParseAcceptLanguage.(request.headers["Accept-Language"])
+    return if locales.empty?
+
+    current_user.data.update_column(:locales, locales)
   end
 
   def set_country_code

--- a/app/controllers/auth/exercism_oauth_controller.rb
+++ b/app/controllers/auth/exercism_oauth_controller.rb
@@ -7,7 +7,8 @@ module Auth
       if user.previously_new_record?
         User::Bootstrap.(user, "exercism",
           attribution: signup_attribution_params,
-          country_code: request.headers["CF-IPCountry"])
+          country_code: request.headers["CF-IPCountry"],
+          accept_language: request.headers["Accept-Language"])
       end
 
       User::Exercism::ReconcileEntitlements.(

--- a/app/controllers/auth/google_oauth_controller.rb
+++ b/app/controllers/auth/google_oauth_controller.rb
@@ -7,7 +7,8 @@ module Auth
       if user.previously_new_record?
         User::Bootstrap.(user, "google",
           attribution: signup_attribution_params,
-          country_code: request.headers["CF-IPCountry"])
+          country_code: request.headers["CF-IPCountry"],
+          accept_language: request.headers["Accept-Language"])
       end
 
       sign_in_with_2fa_guard!(user, sign_in_type: user.previously_new_record? ? :signup : :login)

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -10,7 +10,8 @@ class Auth::RegistrationsController < Devise::RegistrationsController
       if resource.persisted?
         User::Bootstrap.(resource, "email",
           attribution: signup_attribution_params,
-          country_code: request.headers["CF-IPCountry"])
+          country_code: request.headers["CF-IPCountry"],
+          accept_language: request.headers["Accept-Language"])
       end
     end
   end
@@ -35,7 +36,12 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  # The frontend can pass an explicit locale choice at signup. An unsupported
+  # value is treated as no signal (locale falls back to Accept-Language
+  # derivation) rather than failing the registration.
   def sign_up_params
-    params.require(:user).permit(:email, :password, :password_confirmation, :name, :handle)
+    params.require(:user).permit(:email, :password, :password_confirmation, :name, :handle, :locale).tap do |permitted|
+      permitted.delete(:locale) unless I18n::SUPPORTED_LOCALES.include?(permitted[:locale])
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,11 +33,19 @@ class User < ApplicationRecord
     build_activity_data if new_record? && !activity_data
   end
 
-  validates :locale, presence: true, inclusion: { in: %w[en hu] }
   validates :handle, presence: true, uniqueness: true
 
   # OAuth users have random passwords, so skip password validation for them
   validates :password, presence: true, if: -> { new_record? && encrypted_password.blank? && !uses_oauth? }
+
+  # Locale is derived on User::Data (see there). Defined here rather than left
+  # to the data delegation below so it can be assigned during User.new, which
+  # runs before after_initialize has built the data record.
+  def locale = (data || build_data).locale
+
+  def locale=(value)
+    (data || build_data).locale = value
+  end
 
   def uses_oauth? = exercism_id.present? || google_id.present?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,14 +38,9 @@ class User < ApplicationRecord
   # OAuth users have random passwords, so skip password validation for them
   validates :password, presence: true, if: -> { new_record? && encrypted_password.blank? && !uses_oauth? }
 
-  # Locale is derived on User::Data (see there). Defined here rather than left
-  # to the data delegation below so it can be assigned during User.new, which
-  # runs before after_initialize has built the data record.
-  def locale = (data || build_data).locale
-
-  def locale=(value)
-    (data || build_data).locale = value
-  end
+  # Build data on demand so delegated methods (see method_missing below) work
+  # during User.new attribute assignment, which runs before after_initialize.
+  def data = super || build_data
 
   def uses_oauth? = exercism_id.present? || google_id.present?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,12 @@
 class User < ApplicationRecord
   extend Mandate::Memoize
 
+  # Locale now lives on User::Data (see User::Data#locale). The users.locale
+  # column still exists but is being retired: ignoring it stops ActiveRecord
+  # defining accessors that would shadow the data record, so user.locale falls
+  # through method_missing to data. A later migration drops the column.
+  self.ignored_columns += %w[locale]
+
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user/data.rb
+++ b/app/models/user/data.rb
@@ -12,6 +12,18 @@ class User::Data < ApplicationRecord
   # Welcome emails are transactional — no preference check.
   def email_communication_preferences_key(_kind = nil) = nil
 
+  validates :explicit_locale, inclusion: { in: I18n::SUPPORTED_LOCALES }, allow_nil: true
+
+  # Locale is derived, never stored directly: an explicit user choice always
+  # wins, then the best match from the browser's Accept-Language preferences
+  # (stored in locales), then the default. Assigning locale records an
+  # explicit choice.
+  def locale = explicit_locale || locale_from_preferences || I18n.default_locale.to_s
+
+  def locale=(value)
+    self.explicit_locale = value.presence
+  end
+
   # Notification preference slugs mapped to column names
   NOTIFICATION_SLUGS = {
     "newsletters" => :receive_newsletters,
@@ -81,6 +93,20 @@ class User::Data < ApplicationRecord
   def may_receive_emails? = email_complaint_at.nil?
 
   private
+  # Walk the preferences in order, taking an exact match against a supported
+  # locale when there is one, else a language-part match (en-GB satisfies en,
+  # pt satisfies pt-BR).
+  def locale_from_preferences
+    locales.each do |tag|
+      return tag if I18n::SUPPORTED_LOCALES.include?(tag)
+
+      language = tag.split("-").first
+      match = I18n::SUPPORTED_LOCALES.find { |supported| supported.split("-").first == language }
+      return match if match
+    end
+    nil
+  end
+
   def generate_unsubscribe_token!
     self.unsubscribe_token ||= SecureRandom.uuid
   end

--- a/app/serializers/serialize_user.rb
+++ b/app/serializers/serialize_user.rb
@@ -9,6 +9,7 @@ class SerializeUser
       membership_type: user.data.membership_type,
       email: user.email,
       name: user.name,
+      locale: user.locale,
       avatar_url: user.avatar_url,
       uses_oauth: user.uses_oauth?,
       email_confirmed: user.confirmed?,

--- a/db/migrate/20260702120000_add_explicit_locale_and_locales_to_user_data.rb
+++ b/db/migrate/20260702120000_add_explicit_locale_and_locales_to_user_data.rb
@@ -1,13 +1,12 @@
-class ReplaceUserLocaleWithExplicitLocaleAndLocales < ActiveRecord::Migration[8.1]
+class AddExplicitLocaleAndLocalesToUserData < ActiveRecord::Migration[8.1]
   # Locale becomes a derived value: an explicit user choice (explicit_locale)
   # wins, otherwise it's resolved at runtime from the browser's Accept-Language
   # preferences (locales). Both live on user_data alongside country_code.
-  # Every existing user has the old column's default ("en"), which was never an
-  # explicit choice, so it isn't migrated — their locale will be derived from
-  # their headers instead.
+  #
+  # The old users.locale column is deliberately left in place for now: this
+  # deploy stops reading it (User ignores the column), and a later migration
+  # drops it once no running code references it any more.
   def change
-    remove_column :users, :locale, :string, default: "en", null: false
-
     add_column :user_data, :explicit_locale, :string
     add_column :user_data, :locales, :string, array: true, default: [], null: false
   end

--- a/db/migrate/20260702120000_replace_user_locale_with_explicit_locale_and_locales.rb
+++ b/db/migrate/20260702120000_replace_user_locale_with_explicit_locale_and_locales.rb
@@ -1,0 +1,14 @@
+class ReplaceUserLocaleWithExplicitLocaleAndLocales < ActiveRecord::Migration[8.1]
+  # Locale becomes a derived value: an explicit user choice (explicit_locale)
+  # wins, otherwise it's resolved at runtime from the browser's Accept-Language
+  # preferences (locales). Both live on user_data alongside country_code.
+  # Every existing user has the old column's default ("en"), which was never an
+  # explicit choice, so it isn't migrated — their locale will be derived from
+  # their headers instead.
+  def change
+    remove_column :users, :locale, :string, default: "en", null: false
+
+    add_column :user_data, :explicit_locale, :string
+    add_column :user_data, :locales, :string, array: true, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -570,6 +570,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_120000) do
     t.string "exercism_id"
     t.string "google_id"
     t.string "handle", null: false
+    t.string "locale", default: "en", null: false
     t.string "name"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_28_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -433,8 +433,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_120000) do
     t.datetime "email_complaint_at"
     t.string "email_complaint_type"
     t.string "email_verification_token"
+    t.string "explicit_locale"
     t.date "last_active_on"
     t.datetime "last_email_opened_at"
+    t.string "locales", default: [], null: false, array: true
     t.string "membership_type", default: "standard", null: false
     t.boolean "notifications_enabled", default: true, null: false
     t.datetime "otp_enabled_at"
@@ -568,7 +570,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_120000) do
     t.string "exercism_id"
     t.string "google_id"
     t.string "handle", null: false
-    t.string "locale", default: "en", null: false
     t.string "name"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"

--- a/test/commands/user/bootstrap_test.rb
+++ b/test/commands/user/bootstrap_test.rb
@@ -228,30 +228,12 @@ class User::BootstrapTest < ActiveSupport::TestCase
     assert_nil user.data.reload.country_code
   end
 
-  test "sets locales from accept_language" do
+  test "calls User::UpdateLocales with accept_language" do
     create(:course, slug: "coding-fundamentals")
     user = create(:user)
+
+    User::UpdateLocales.expects(:call).with(user, "hu, en-GB;q=0.9, en;q=0.8")
 
     User::Bootstrap.(user, "email", accept_language: "hu, en-GB;q=0.9, en;q=0.8")
-
-    assert_equal %w[hu en-GB en], user.data.reload.locales
-  end
-
-  test "does not set locales when accept_language is nil" do
-    create(:course, slug: "coding-fundamentals")
-    user = create(:user)
-
-    User::Bootstrap.(user, "email")
-
-    assert_empty user.data.reload.locales
-  end
-
-  test "does not set locales when accept_language is unparseable" do
-    create(:course, slug: "coding-fundamentals")
-    user = create(:user)
-
-    User::Bootstrap.(user, "email", accept_language: "!!!")
-
-    assert_empty user.data.reload.locales
   end
 end

--- a/test/commands/user/bootstrap_test.rb
+++ b/test/commands/user/bootstrap_test.rb
@@ -227,4 +227,31 @@ class User::BootstrapTest < ActiveSupport::TestCase
 
     assert_nil user.data.reload.country_code
   end
+
+  test "sets locales from accept_language" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+
+    User::Bootstrap.(user, "email", accept_language: "hu, en-GB;q=0.9, en;q=0.8")
+
+    assert_equal %w[hu en-GB en], user.data.reload.locales
+  end
+
+  test "does not set locales when accept_language is nil" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+
+    User::Bootstrap.(user, "email")
+
+    assert_empty user.data.reload.locales
+  end
+
+  test "does not set locales when accept_language is unparseable" do
+    create(:course, slug: "coding-fundamentals")
+    user = create(:user)
+
+    User::Bootstrap.(user, "email", accept_language: "!!!")
+
+    assert_empty user.data.reload.locales
+  end
 end

--- a/test/commands/user/parse_accept_language_test.rb
+++ b/test/commands/user/parse_accept_language_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class User::ParseAcceptLanguageTest < ActiveSupport::TestCase
+  test "parses a simple header" do
+    assert_equal %w[en], User::ParseAcceptLanguage.("en")
+  end
+
+  test "preserves header order for equal qualities" do
+    assert_equal %w[hu en-GB en], User::ParseAcceptLanguage.("hu, en-GB, en")
+  end
+
+  test "orders by q-value" do
+    assert_equal %w[hu en-GB en], User::ParseAcceptLanguage.("en;q=0.7, hu, en-GB;q=0.9")
+  end
+
+  test "normalizes casing" do
+    assert_equal %w[en-GB pt-BR zh-Hant], User::ParseAcceptLanguage.("EN-gb, pt-br, ZH-HANT")
+  end
+
+  test "deduplicates after normalization" do
+    assert_equal %w[en-GB], User::ParseAcceptLanguage.("en-GB, EN-gb;q=0.5")
+  end
+
+  test "ignores wildcard" do
+    assert_equal %w[hu], User::ParseAcceptLanguage.("hu, *;q=0.5")
+  end
+
+  test "ignores entries with q=0" do
+    assert_equal %w[hu], User::ParseAcceptLanguage.("hu, en;q=0")
+  end
+
+  test "ignores malformed entries" do
+    assert_equal %w[en], User::ParseAcceptLanguage.("en, x, not a locale, 123, en--GB, -en")
+  end
+
+  test "handles whitespace and stray semicolon params" do
+    assert_equal %w[hu en], User::ParseAcceptLanguage.(" hu ; q = 0.9 , en;q=0.8;level=1")
+  end
+
+  test "returns empty array for nil" do
+    assert_empty User::ParseAcceptLanguage.(nil)
+  end
+
+  test "returns empty array for blank string" do
+    assert_empty User::ParseAcceptLanguage.("")
+  end
+
+  test "returns empty array for garbage" do
+    assert_empty User::ParseAcceptLanguage.("!!!, ???")
+  end
+
+  test "caps the number of stored locales" do
+    header = ("aa".."zz").first(30).join(", ")
+    assert_equal 10, User::ParseAcceptLanguage.(header).length
+  end
+end

--- a/test/commands/user/update_locale_test.rb
+++ b/test/commands/user/update_locale_test.rb
@@ -7,6 +7,7 @@ class User::UpdateLocaleTest < ActiveSupport::TestCase
     User::UpdateLocale.(user, "hu")
 
     assert_equal "hu", user.reload.locale
+    assert_equal "hu", user.data.explicit_locale
   end
 
   test "raises on invalid locale" do

--- a/test/commands/user/update_locales_test.rb
+++ b/test/commands/user/update_locales_test.rb
@@ -18,4 +18,24 @@ class User::UpdateLocalesTest < ActiveSupport::TestCase
 
     assert_empty user.data.reload.locales
   end
+
+  test "does not overwrite existing locales" do
+    user = create(:user)
+    user.data.update_column(:locales, %w[hu])
+    User::ParseAcceptLanguage.expects(:call).never
+
+    User::UpdateLocales.(user, "en")
+
+    assert_equal %w[hu], user.data.reload.locales
+  end
+
+  test "overwrites existing locales with force: true" do
+    user = create(:user)
+    user.data.update_column(:locales, %w[hu])
+    User::ParseAcceptLanguage.expects(:call).with("en").returns(%w[en])
+
+    User::UpdateLocales.(user, "en", force: true)
+
+    assert_equal %w[en], user.data.reload.locales
+  end
 end

--- a/test/commands/user/update_locales_test.rb
+++ b/test/commands/user/update_locales_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class User::UpdateLocalesTest < ActiveSupport::TestCase
+  test "stores parsed locales from the Accept-Language header" do
+    user = create(:user)
+    User::ParseAcceptLanguage.expects(:call).with("hu, en;q=0.8").returns(%w[hu en])
+
+    User::UpdateLocales.(user, "hu, en;q=0.8")
+
+    assert_equal %w[hu en], user.data.reload.locales
+  end
+
+  test "does not store anything when no locales are parsed" do
+    user = create(:user)
+    User::ParseAcceptLanguage.expects(:call).with(nil).returns([])
+
+    User::UpdateLocales.(user, nil)
+
+    assert_empty user.data.reload.locales
+  end
+end

--- a/test/controllers/auth/registrations_controller_test.rb
+++ b/test/controllers/auth/registrations_controller_test.rb
@@ -125,6 +125,86 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
     assert_equal "JP", User.find_by(email: "jp2@example.com").data.country_code
   end
 
+  test "POST signup forwards Accept-Language header to User::Bootstrap" do
+    User::Bootstrap.expects(:call).with(
+      instance_of(User),
+      "email",
+      has_entries(accept_language: "hu, en;q=0.8")
+    )
+
+    post user_registration_path,
+      params: with_turnstile(
+        user: {
+          email: "hu@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          name: "HU User",
+          handle: "huuser"
+        }
+      ),
+      headers: { "Accept-Language" => "hu, en;q=0.8" },
+      as: :json
+
+    assert_response :created
+  end
+
+  test "POST signup persists locales from Accept-Language header" do
+    post user_registration_path,
+      params: with_turnstile(
+        user: {
+          email: "hu2@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          name: "HU User",
+          handle: "huuser2"
+        }
+      ),
+      headers: { "Accept-Language" => "hu, en;q=0.8" },
+      as: :json
+
+    assert_response :created
+
+    user = User.find_by(email: "hu2@example.com")
+    assert_equal %w[hu en], user.data.locales
+    assert_nil user.data.explicit_locale
+  end
+
+  test "POST signup sets explicit_locale from locale param" do
+    post user_registration_path,
+      params: with_turnstile(
+        user: {
+          email: "hu3@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          name: "HU User",
+          handle: "huuser3",
+          locale: "hu"
+        }
+      ),
+      as: :json
+
+    assert_response :created
+    assert_equal "hu", User.find_by(email: "hu3@example.com").data.explicit_locale
+  end
+
+  test "POST signup ignores an unsupported locale param" do
+    post user_registration_path,
+      params: with_turnstile(
+        user: {
+          email: "de@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          name: "DE User",
+          handle: "deuser",
+          locale: "de"
+        }
+      ),
+      as: :json
+
+    assert_response :created
+    assert_nil User.find_by(email: "de@example.com").data.explicit_locale
+  end
+
   test "POST signup does not call User::Bootstrap on failed registration" do
     assert_no_enqueued_jobs do
       post user_registration_path, params: with_turnstile(

--- a/test/controllers/internal/me_controller_test.rb
+++ b/test/controllers/internal/me_controller_test.rb
@@ -47,4 +47,38 @@ class Internal::MeControllerTest < ApplicationControllerTest
     assert_response :success
     assert_nil @current_user.data.reload.country_code
   end
+
+  test "sets locales from Accept-Language header when empty" do
+    assert_empty @current_user.data.locales
+
+    get internal_me_path, headers: { "Accept-Language" => "hu, en-GB;q=0.9, en;q=0.8" }, as: :json
+
+    assert_response :success
+    assert_equal %w[hu en-GB en], @current_user.data.reload.locales
+  end
+
+  test "does not overwrite existing locales" do
+    @current_user.data.update_column(:locales, %w[hu])
+
+    get internal_me_path, headers: { "Accept-Language" => "en" }, as: :json
+
+    assert_response :success
+    assert_equal %w[hu], @current_user.data.reload.locales
+  end
+
+  test "ignores unparseable Accept-Language header" do
+    get internal_me_path, headers: { "Accept-Language" => "!!!" }, as: :json
+
+    assert_response :success
+    assert_empty @current_user.data.reload.locales
+  end
+
+  test "GET show returns locale derived from stored locales" do
+    @current_user.data.update_column(:locales, %w[hu en])
+
+    get internal_me_path, as: :json
+
+    assert_response :success
+    assert_equal "hu", response.parsed_body["user"]["locale"]
+  end
 end

--- a/test/controllers/internal/settings_controller_test.rb
+++ b/test/controllers/internal/settings_controller_test.rb
@@ -122,7 +122,7 @@ class Internal::SettingsControllerTest < ApplicationControllerTest
   test "PATCH locale fails with invalid locale" do
     patch locale_internal_settings_path, params: { value: "invalid" }, as: :json
 
-    assert_json_error(:unprocessable_entity, error_type: :locale_update_failed, errors: { explicit_locale: ["is not included in the list"] })
+    assert_json_error(:unprocessable_entity, error_type: :locale_update_failed, errors: { "data.explicit_locale": ["is not included in the list"] })
     assert_equal "en", @user.reload.locale
   end
 

--- a/test/controllers/internal/settings_controller_test.rb
+++ b/test/controllers/internal/settings_controller_test.rb
@@ -122,7 +122,7 @@ class Internal::SettingsControllerTest < ApplicationControllerTest
   test "PATCH locale fails with invalid locale" do
     patch locale_internal_settings_path, params: { value: "invalid" }, as: :json
 
-    assert_json_error(:unprocessable_entity, error_type: :locale_update_failed, errors: { locale: ["is not included in the list"] })
+    assert_json_error(:unprocessable_entity, error_type: :locale_update_failed, errors: { explicit_locale: ["is not included in the list"] })
     assert_equal "en", @user.reload.locale
   end
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     password_confirmation { password }
     name { Faker::Name.name }
     handle { Faker::Internet.unique.username(specifier: 5..15, separators: %w[_]) }
-    locale { "en" }
     confirmed_at { Time.current }
 
     trait :hungarian do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -53,21 +53,62 @@ class UserTest < ActiveSupport::TestCase
     assert user.valid?
   end
 
-  test "locale is required" do
-    user = build(:user, locale: nil)
-    refute user.valid?
-    assert_includes user.errors[:locale], "can't be blank"
+  test "locale defaults to en" do
+    user = create(:user)
+    assert_equal "en", user.locale
   end
 
-  test "locale must be en or hu" do
+  test "locale uses explicit choice over Accept-Language preferences" do
+    user = create(:user, locale: "hu")
+    user.data.update!(locales: %w[en])
+
+    assert_equal "hu", user.locale
+  end
+
+  test "locale is derived from an exact Accept-Language match" do
+    user = create(:user)
+    user.data.update!(locales: %w[hu en])
+
+    assert_equal "hu", user.locale
+  end
+
+  test "locale is derived from a language-part match" do
+    user = create(:user)
+    user.data.update!(locales: %w[hu-HU en])
+
+    assert_equal "hu", user.locale
+  end
+
+  test "locale skips unsupported preferences" do
+    user = create(:user)
+    user.data.update!(locales: %w[fr de hu])
+
+    assert_equal "hu", user.locale
+  end
+
+  test "locale falls back to en when no preference is supported" do
+    user = create(:user)
+    user.data.update!(locales: %w[fr de])
+
+    assert_equal "en", user.locale
+  end
+
+  test "assigning locale sets explicit_locale" do
+    user = create(:user, locale: "hu")
+    assert_equal "hu", user.data.explicit_locale
+
+    user.update!(locale: nil)
+    assert_nil user.data.reload.explicit_locale
+  end
+
+  test "explicit_locale must be a supported locale" do
     user = build(:user, locale: "fr")
     refute user.valid?
-    assert_includes user.errors[:locale], "is not included in the list"
-
-    user.locale = "en"
-    assert user.valid?
 
     user.locale = "hu"
+    assert user.valid?
+
+    user.locale = nil
     assert user.valid?
   end
 

--- a/test/serializers/serialize_user_test.rb
+++ b/test/serializers/serialize_user_test.rb
@@ -11,6 +11,7 @@ class SerializeUserTest < ActiveSupport::TestCase
         membership_type: "standard",
         email: "test@example.com",
         name: "Test User",
+        locale: "en",
         avatar_url: "https://example.com/avatar.png",
         uses_oauth: false,
         email_confirmed: user.confirmed?,
@@ -143,6 +144,23 @@ class SerializeUserTest < ActiveSupport::TestCase
     result = SerializeUser.(user)
 
     refute result[:uses_oauth]
+  end
+
+  test "serializes locale derived from Accept-Language preferences" do
+    user = create(:user)
+    user.data.update!(locales: %w[hu en])
+
+    result = SerializeUser.(user)
+
+    assert_equal "hu", result[:locale]
+  end
+
+  test "serializes explicitly chosen locale" do
+    user = create(:user, locale: "hu")
+
+    result = SerializeUser.(user)
+
+    assert_equal "hu", result[:locale]
   end
 
   test "serializes admin: false for regular user" do


### PR DESCRIPTION
## Summary

Locale becomes a derived value instead of a stored column. Two new fields on `user_data` replace `users.locale`:

- **`locales`** — the user's full parsed Accept-Language preference list (q-sorted, casing-normalized, deduped, capped at 10), captured once on any authenticated API call and at signup (email + both OAuth providers). Stored losslessly with region tags intact so newly launched locales (e.g. `pt-BR`) light up automatically for users who never made an explicit choice.
- **`explicit_locale`** — an explicit user choice, set via the settings PATCH or an optional `locale` param at signup (unsupported values are treated as no signal rather than failing registration).

`User#locale` derives at runtime: explicit choice → best supported match from preferences (exact tag first, then language-part, so `en-GB` satisfies `en` and `pt` would satisfy `pt-BR`) → `en`. All existing consumers (mailers, `set_locale`, translations, serializers) work unchanged.

Existing users all had the old column's default (`"en"`), which was never an explicit choice, so nothing is migrated — their locale will derive from their headers on next request.

Also exposes `locale` on `/internal/me` via `SerializeUser`.

## Notes for review

- The invalid-locale error key from `PATCH /internal/settings/locale` changed from `locale` to `explicit_locale`.
- `User::Search` now preloads `data` (locale in `SerializeAdminUser` reads through it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)