### PR TITLE
Drop retired users.locale column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,6 @@
 class User < ApplicationRecord
   extend Mandate::Memoize
 
-  # Locale now lives on User::Data (see User::Data#locale). The users.locale
-  # column still exists but is being retired: ignoring it stops ActiveRecord
-  # defining accessors that would shadow the data record, so user.locale falls
-  # through method_missing to data. A later migration drops the column.
-  self.ignored_columns += %w[locale]
-
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20260703120000_drop_user_locale_column.rb
+++ b/db/migrate/20260703120000_drop_user_locale_column.rb
@@ -1,0 +1,9 @@
+class DropUserLocaleColumn < ActiveRecord::Migration[8.1]
+  # The locale column was retired in a previous deploy: nothing reads or writes
+  # users.locale any more (User ignored the column, delegating locale to the
+  # data record). It's now safe to drop. Merge this only once that deploy is
+  # fully rolled out.
+  def change
+    remove_column :users, :locale, :string, default: "en", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -570,7 +570,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_120000) do
     t.string "exercism_id"
     t.string "google_id"
     t.string "handle", null: false
-    t.string "locale", default: "en", null: false
     t.string "name"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"


### PR DESCRIPTION
Phase 2 of retiring `users.locale`. **Stacked on #500 — merge only after #500 is fully deployed.**

## Why two PRs
#500 keeps the `users.locale` column and stops using it (`User` ignores it via `ignored_columns`, delegating `locale` to the data record). Dropping the column in the same deploy is unsafe: during a rolling ECS deploy, draining tasks still read/write `users.locale` and would error the moment it disappears.

## This PR
- Migration dropping `users.locale`.
- Removes the now-unnecessary `ignored_columns` entry — with the column gone, `User#method_missing` delegates `locale`/`locale=` to the data record.

## Merge ordering
1. Merge & fully roll out #500.
2. Then merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)