### PR TITLE
Always run init-localstack on bin/dev boot

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -30,10 +30,13 @@ else
     -e LAMBDA_DOCKER_FLAGS=--add-host=local.jiki.io:host-gateway \
     --add-host=local.jiki.io:host-gateway \
     --name localstack-jiki $(jq -r '.localstack' .dockerimages.json)
-
-  # Initialize LocalStack (create S3 buckets)
-  echo "Initializing LocalStack..."
-  bin/init-localstack
 fi
+
+# Always initialize LocalStack (create any missing S3 buckets).
+# LocalStack has no persistence, and a long-running container can predate
+# newly-added buckets, so run this on every boot. init-localstack is
+# idempotent (it skips buckets that already exist).
+echo "Initializing LocalStack..."
+bin/init-localstack
 
 hivemind Procfile.dev


### PR DESCRIPTION
## Problem

`bin/dev` only ran `bin/init-localstack` when it started a **fresh** LocalStack container. If a `localstack-jiki` container was already running, `bin/dev` took the "already running" branch and skipped bucket creation entirely.

This surfaced as:

```
Aws::S3::Errors::NoSuchBucket (The specified bucket does not exist):
app/commands/exercise_submission/create.rb:11
```

A container that had been up for days predated the `active-storage` bucket being added to the init list, so ActiveStorage attachments (e.g. exercise submission files) failed with `NoSuchBucket`. Restarting `bin/dev` never fixed it, because the container was still running so init was skipped.

## Fix

Move `bin/init-localstack` out of the `else` branch so it runs on **every** boot. It's already idempotent — it `head_bucket`s and only creates missing buckets — so this is safe and self-heals missing buckets without recreating the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)