### PR TITLE
Track trial flag on assistant_conversation_started event

### DIFF
--- a/app/commands/assistant_conversation/find_or_create.rb
+++ b/app/commands/assistant_conversation/find_or_create.rb
@@ -20,7 +20,8 @@ class AssistantConversation::FindOrCreate
       properties: {
         context_type: context.class.name.downcase,
         context_id: context.id,
-        context_slug: context.try(:slug)
+        context_slug: context.try(:slug),
+        trial: !user.premium?
       }.compact
     )
   end

--- a/test/commands/assistant_conversation/find_or_create_test.rb
+++ b/test/commands/assistant_conversation/find_or_create_test.rb
@@ -52,7 +52,27 @@ class AssistantConversation::FindOrCreateTest < ActiveSupport::TestCase
       properties: {
         context_type: "lesson",
         context_id: lesson.id,
-        context_slug: "basic-movement"
+        context_slug: "basic-movement",
+        trial: true
+      }
+    )
+
+    AssistantConversation::FindOrCreate.(user, lesson)
+  end
+
+  test "sets trial to false for premium users" do
+    user = create(:user)
+    make_premium(user)
+    lesson = create(:lesson, :exercise, slug: "basic-movement")
+
+    Analytics::TrackEvent.expects(:defer).with(
+      user,
+      "assistant_conversation_started",
+      properties: {
+        context_type: "lesson",
+        context_id: lesson.id,
+        context_slug: "basic-movement",
+        trial: false
       }
     )
 


### PR DESCRIPTION
## What

Adds a `trial` property to the `assistant_conversation_started` PostHog event, set to `!user.premium?`, so we can distinguish conversations started by free (trial) vs premium users.

- `trial: true` for standard/free users
- `trial: false` for premium users

The flag survives `.compact` (which only strips `nil`, not `false`), so it's always present on the event.

## Testing

- Updated the existing event test to assert `trial: true`
- Added a test asserting `trial: false` for premium users

🤖 Generated with [Claude Code](https://claude.com/claude-code)