### PR TITLE
Apply font-weight 600 to strong tags in emails

### DIFF
--- a/app/views/layouts/mailer.mjml
+++ b/app/views/layouts/mailer.mjml
@@ -11,6 +11,7 @@
     %mj-style
       :plain
         a { font-weight: 500; }
+        strong, b { font-weight: 600; }
 
   %mj-body{ "background-color": "#ffffff" }
     = render 'mailers/shared/header', header_image: @header_image.presence || "default.jpg"


### PR DESCRIPTION
## Problem

Bold text (`<strong>`/`<b>`) in emails wasn't reliably getting a bold weight applied across clients.

## Cause

The shared mailer layout (`layouts/mailer.mjml`) loads Poppins at weights **400/500/600** and had an `mj-style` rule for anchor tags (`a { font-weight: 500; }`), but no rule for `strong`/`b`. The browser default `bold` maps to **700**, which isn't among the loaded weights — so bold text fell back inconsistently across email clients.

## Fix

Add an explicit rule so bold text uses the loaded Poppins 600 face:

```css
strong, b { font-weight: 600; }
```

This applies to every mailer rendered through the shared layout.

## Notes

- Pre-commit hook's Brakeman step currently crashes on its own version-check (`Brakeman.ensure_latest` → `undefined method 'date' for nil`), unrelated to this change. Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)