### PR TITLE
Award Scenario Handler badge for golf-scenarios exercise

### DIFF
--- a/app/models/badges/scenario_handler_badge.rb
+++ b/app/models/badges/scenario_handler_badge.rb
@@ -5,7 +5,7 @@ module Badges
                 "we write them to check our code works in different ways."
 
     def award_to?(user)
-      user.user_lessons.completed.joins(:lesson).where(lessons: { slug: 'owners-bouquets' }).exists?
+      user.user_lessons.completed.joins(:lesson).where(lessons: { slug: 'golf-scenarios' }).exists?
     end
   end
 end

--- a/test/models/badges/scenario_handler_badge_test.rb
+++ b/test/models/badges/scenario_handler_badge_test.rb
@@ -9,16 +9,16 @@ class Badges::ScenarioHandlerBadgeTest < ActiveSupport::TestCase
     refute badge.secret
   end
 
-  test "award_to? returns true when user completed owners-bouquets lesson" do
+  test "award_to? returns true when user completed golf-scenarios lesson" do
     badge = Badge.find_by_slug!('scenario_handler') # rubocop:disable Rails/DynamicFindBy
     user = create(:user)
-    lesson = create(:lesson, :exercise, slug: 'owners-bouquets')
+    lesson = create(:lesson, :exercise, slug: 'golf-scenarios')
     create(:user_lesson, :completed, user:, lesson:)
 
     assert badge.award_to?(user)
   end
 
-  test "award_to? returns false when user has not completed owners-bouquets lesson" do
+  test "award_to? returns false when user has not completed golf-scenarios lesson" do
     badge = Badge.find_by_slug!('scenario_handler') # rubocop:disable Rails/DynamicFindBy
     user = create(:user)
 
@@ -34,10 +34,10 @@ class Badges::ScenarioHandlerBadgeTest < ActiveSupport::TestCase
     refute badge.award_to?(user)
   end
 
-  test "award_to? returns false when user started but not completed owners-bouquets" do
+  test "award_to? returns false when user started but not completed golf-scenarios" do
     badge = Badge.find_by_slug!('scenario_handler') # rubocop:disable Rails/DynamicFindBy
     user = create(:user)
-    lesson = create(:lesson, :exercise, slug: 'owners-bouquets')
+    lesson = create(:lesson, :exercise, slug: 'golf-scenarios')
     create(:user_lesson, user:, lesson:) # Not completed
 
     refute badge.award_to?(user)


### PR DESCRIPTION
## Problem

A user reported completing the new **Golf Shot Scenarios** exercise without receiving the **Scenario Handler** badge. Completing the older **Owner's Bouquets** exercise still awarded it.

## Cause

`Badges::ScenarioHandlerBadge#award_to?` was hardcoded to the `owners-bouquets` lesson slug:

```ruby
user.user_lessons.completed.joins(:lesson).where(lessons: { slug: 'owners-bouquets' }).exists?
```

In the curriculum, `golf-scenarios` ("Golf Shot Scenarios") now precedes `owners-bouquets`, so it's the first exercise-with-scenarios a user encounters — but completing it never triggered the badge.

## Fix

Point the badge's `award_to?` at `golf-scenarios` and update the corresponding tests. The `AwardBadgeJob` for `scenario_handler` was already enqueued on every lesson completion, so no other plumbing changes were needed.

## Note

Existing users who already completed `golf-scenarios` but not `owners-bouquets` won't be retroactively awarded — badge granting only happens on lesson completion. A backfill would be a separate one-off task if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)