### PR TITLE
Bump websocket-driver to 0.8.2 to fix security advisories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
## Summary

Fixes the failing `scan_ruby` CI job (bundler-audit). The advisory DB was updated on 2026-07-08 to flag `websocket-driver` 0.8.0 for several vulnerabilities:

- CVE-2026-54463 — Memory exhaustion via abuse of protocol length headers
- CVE-2026-54464 — Resource limit bypass via message compression
- CVE-2026-54465 — Memory exhaustion in HTTP header parser
- GHSA-2x63-gw47-w4mm — Denial of service via malformed Host header

All are resolved in 0.8.2. `websocket-driver` is a transitive dependency (via actioncable), so only `Gemfile.lock` changes.

## Verification

- `bundler-audit check` passes with an up-to-date advisory DB
- Full test suite + brakeman pass via the pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)