### PR TITLE
Add Spanish content locales: es-es (Spain) and es-419 (Latin America)

### DIFF
--- a/app/commands/user/determine_locale.rb
+++ b/app/commands/user/determine_locale.rb
@@ -11,11 +11,11 @@ class User::DetermineLocale
   # A tag whose language is absent here simply collapses to its base language.
   LANGUAGE_VARIANTS = {
     "pt" => { bare: "pt-BR", regions: { "BR" => "pt-BR" }.freeze, fallback: "pt-PT" },
-    # Spanish ships two content variants: es-es (Peninsular/Spain) and es-419
+    # Spanish ships two content variants: es-ES (Peninsular/Spain) and es-419
     # (neutral Latin American). Only the ES region maps to Peninsular; every
     # other region collapses to es-419. A region-less "es" defaults to es-419,
     # since Latin America is the far larger Spanish-speaking audience.
-    "es" => { bare: "es-419", regions: { "ES" => "es-es" }.freeze, fallback: "es-419" }
+    "es" => { bare: "es-419", regions: { "ES" => "es-ES" }.freeze, fallback: "es-419" }
   }.freeze
 
   # Returns exactly one member of I18n::SUPPORTED_LOCALES, or nil when no

--- a/app/commands/user/determine_locale.rb
+++ b/app/commands/user/determine_locale.rb
@@ -11,7 +11,11 @@ class User::DetermineLocale
   # A tag whose language is absent here simply collapses to its base language.
   LANGUAGE_VARIANTS = {
     "pt" => { bare: "pt-BR", regions: { "BR" => "pt-BR" }.freeze, fallback: "pt-PT" },
-    "es" => { bare: "es", regions: { "ES" => "es" }.freeze, fallback: "es-419" }
+    # Spanish ships two content variants: es-es (Peninsular/Spain) and es-419
+    # (neutral Latin American). Only the ES region maps to Peninsular; every
+    # other region collapses to es-419. A region-less "es" defaults to es-419,
+    # since Latin America is the far larger Spanish-speaking audience.
+    "es" => { bare: "es-419", regions: { "ES" => "es-es" }.freeze, fallback: "es-419" }
   }.freeze
 
   # Returns exactly one member of I18n::SUPPORTED_LOCALES, or nil when no

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -5,7 +5,7 @@ module I18n
   # Locales that are fully supported and production-ready.
   # Production ships English only for now; other environments carry the
   # full set so translation work can continue in dev/test.
-  SUPPORTED_LOCALES = (Jiki.env.production? ? %w[en] : %w[en hu]).freeze
+  SUPPORTED_LOCALES = (Jiki.env.production? ? %w[en] : %w[en hu es-es es-419]).freeze
 
   # Locales that are work-in-progress and not yet production-ready
   WIP_LOCALES = %w[fr].freeze

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -5,7 +5,12 @@ module I18n
   # Locales that are fully supported and production-ready.
   # Production ships English only for now; other environments carry the
   # full set so translation work can continue in dev/test.
-  SUPPORTED_LOCALES = (Jiki.env.production? ? %w[en] : %w[en hu es-es es-419]).freeze
+  SUPPORTED_LOCALES = (Jiki.env.production? ? %w[en] : %w[
+    en
+    hu
+    es-es es-419
+    pt-PT pt-BR
+  ]).freeze
 
   # Locales that are work-in-progress and not yet production-ready
   WIP_LOCALES = %w[fr].freeze

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -8,7 +8,7 @@ module I18n
   SUPPORTED_LOCALES = (Jiki.env.production? ? %w[en] : %w[
     en
     hu
-    es-es es-419
+    es-ES es-419
     pt-PT pt-BR
   ]).freeze
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,3 +37,5 @@ en:
     fr: "French"
     es-es: "Spanish (Spain)"
     es-419: "Spanish (Latin America)"
+    pt-PT: "Portuguese (Portugal)"
+    pt-BR: "Portuguese (Brazil)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
     en: "English"
     hu: "Hungarian"
     fr: "French"
-    es-es: "Spanish (Spain)"
+    es-ES: "Spanish (Spain)"
     es-419: "Spanish (Latin America)"
     pt-PT: "Portuguese (Portugal)"
     pt-BR: "Portuguese (Brazil)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,3 +35,5 @@ en:
     en: "English"
     hu: "Hungarian"
     fr: "French"
+    es-es: "Spanish (Spain)"
+    es-419: "Spanish (Latin America)"

--- a/test/commands/user/determine_locale_test.rb
+++ b/test/commands/user/determine_locale_test.rb
@@ -76,6 +76,8 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
     with_supported_locales(FULL_SET) do
       assert_equal "pt-BR", User::DetermineLocale.(%w[PT-br])
       assert_equal "es-419", User::DetermineLocale.(%w[ES-419])
+      assert_equal "es-ES", User::DetermineLocale.(%w[es-es]) # lowercase region normalises to canonical es-ES
+      assert_equal "es-ES", User::DetermineLocale.(%w[ES-es])
       assert_equal "hu", User::DetermineLocale.(%w[HU])
     end
   end

--- a/test/commands/user/determine_locale_test.rb
+++ b/test/commands/user/determine_locale_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class User::DetermineLocaleTest < ActiveSupport::TestCase
   # The eventual full content-locale set. The resolver must be correct against
   # this even though production currently ships a subset.
-  FULL_SET = %w[en hu nl ja de fr pt-PT pt-BR es-es es-419].freeze
+  FULL_SET = %w[en hu nl ja de fr pt-PT pt-BR es-ES es-419].freeze
 
   # Every row from the brief's acceptance oracle, evaluated against the full
   # content set: [Accept-Language preference list] => expected result.
@@ -19,7 +19,7 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
     %w[pt-BR] => "pt-BR",                 # exact
     %w[pt-PT] => "pt-PT",                 # exact
     %w[pt] => "pt-BR",                    # bare pt -> Brazilian (CLDR)
-    %w[es-ES en] => "es-es",              # Spain -> Peninsular
+    %w[es-ES en] => "es-ES",              # Spain -> Peninsular (exact match)
     %w[es] => "es-419",                   # bare es -> Latin American (larger audience)
     %w[es-MX es-419 en] => "es-419",      # es-MX collapses straight to es-419
     %w[es-AR en] => "es-419",             # Latin American region
@@ -102,9 +102,9 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
 
   test "exact es-419 beats an earlier es region rule only when listed first" do
     with_supported_locales(FULL_SET) do
-      # es-MX would collapse to es-419, but es-ES appears first and exact-fails,
-      # then collapses to es-es (Peninsular) before es-MX is reached in pass 2.
-      assert_equal "es-es", User::DetermineLocale.(%w[es-ES es-MX])
+      # es-ES matches exactly (Peninsular) and wins because it appears first,
+      # before es-MX (which would collapse to es-419) is reached.
+      assert_equal "es-ES", User::DetermineLocale.(%w[es-ES es-MX])
     end
   end
 

--- a/test/commands/user/determine_locale_test.rb
+++ b/test/commands/user/determine_locale_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class User::DetermineLocaleTest < ActiveSupport::TestCase
   # The eventual full content-locale set. The resolver must be correct against
   # this even though production currently ships a subset.
-  FULL_SET = %w[en hu nl ja de fr pt-PT pt-BR es es-419].freeze
+  FULL_SET = %w[en hu nl ja de fr pt-PT pt-BR es-es es-419].freeze
 
   # Every row from the brief's acceptance oracle, evaluated against the full
   # content set: [Accept-Language preference list] => expected result.
@@ -19,11 +19,13 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
     %w[pt-BR] => "pt-BR",                 # exact
     %w[pt-PT] => "pt-PT",                 # exact
     %w[pt] => "pt-BR",                    # bare pt -> Brazilian (CLDR)
-    %w[es-ES en] => "es",                 # Spain -> Peninsular
-    %w[es] => "es",                       # bare es -> Peninsular
+    %w[es-ES en] => "es-es",              # Spain -> Peninsular
+    %w[es] => "es-419",                   # bare es -> Latin American (larger audience)
     %w[es-MX es-419 en] => "es-419",      # es-MX collapses straight to es-419
     %w[es-AR en] => "es-419",             # Latin American region
-    %w[es-419] => "es-419",               # exact
+    %w[es-CL en] => "es-419",             # Firefox/Safari send country codes, not es-419
+    %w[es-PE en] => "es-419",             # ditto
+    %w[es-419] => "es-419",               # exact (Chromium sends this directly)
     %w[it-IT fr en] => "fr",              # it unsupported, next pref
     %w[zh-CN ja] => "ja",                 # zh unsupported, exact ja
     %w[xx-YY] => nil                      # nothing matches -> nil, caller applies the default
@@ -101,8 +103,8 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
   test "exact es-419 beats an earlier es region rule only when listed first" do
     with_supported_locales(FULL_SET) do
       # es-MX would collapse to es-419, but es-ES appears first and exact-fails,
-      # then collapses to es (Peninsular) before es-MX is reached in pass 2.
-      assert_equal "es", User::DetermineLocale.(%w[es-ES es-MX])
+      # then collapses to es-es (Peninsular) before es-MX is reached in pass 2.
+      assert_equal "es-es", User::DetermineLocale.(%w[es-ES es-MX])
     end
   end
 


### PR DESCRIPTION
## What

Adds two distinct Spanish content locales instead of a single generic `es`, and makes both Portuguese variants live:

- **`es-ES`** — Peninsular / Spain Spanish
- **`es-419`** — neutral Latin American Spanish
- **`pt-PT`** / **`pt-BR`** — added to the live (non-prod) set (negotiation was already wired)

Peninsular and Latin American Spanish differ enough (vocabulary — *ordenador*/*computadora*, *móvil*/*celular*; *vosotros* vs *ustedes*; tone) to justify separate content rather than one generic variant.

## API changes (this PR)

- **`config/initializers/i18n.rb`** — add `es-ES`, `es-419`, `pt-PT`, `pt-BR` to the non-prod `SUPPORTED_LOCALES` set (matching how `hu` is gated), grouped by language. Production stays `en`-only until translations land; promote there in a follow-up when ready.
- **`app/commands/user/determine_locale.rb`** — the Peninsular id is `es-ES` (BCP-47 casing, consistent with `pt-PT`/`pt-BR`). Accept-Language negotiation now resolves:
  - `es-419` → `es-419` (Chromium sends this directly)
  - `es-CL` / `es-PE` / `es-AR` / any non-ES region → `es-419` (Firefox & Safari send **country codes**, not the `419` bloc code — this is the case most likely to regress, so it's explicitly tested)
  - `es-ES` → `es-ES`
  - bare `es` (no region) → `es-419`, since Latin America is the far larger audience
- **`config/locales/en.yml`** — display names for all four.
- Tests updated + new country-code coverage.

## Front-end work required (for the FE agent to pick up)

The API now emits these canonical locale ids: **`es-ES`, `es-419`, `pt-PT`, `pt-BR`** (plus `en`, `hu`, WIP `fr`). BCP-47 casing: lowercase language, uppercase region. The front-end needs matching changes:

1. **Add the locales to the served set** — extend `ALL_LOCALES` (and the env-gated `SUPPORTED_LOCALES`) in `app/lib/locales.ts`, mirroring the API's non-prod gating. Add `messages/es-ES.json`, `messages/es-419.json`, `messages/pt-PT.json`, `messages/pt-BR.json`.

2. **hreflang mapping — the important one.** Google's hreflang only accepts ISO-639-1 language + ISO-3166-1 **Alpha-2** region. `es-419` (UN M.49) is **rejected**. So the hreflang builder must map the internal id to a Google-valid value:
   - `es-419` → **`es`** (generic Spanish — the valid neutral form)
   - `es-ES` → `es-ES`, `pt-PT` → `pt-PT`, `pt-BR` → `pt-BR` (all valid, pass through)
   - Do **not** emit `es-419` in any `hreflang` attribute — Google silently ignores it.
   Keep this mapping in one place (the hreflang emission point in the `[locale]` layouts / `sitemap.ts`), keyed off the id. `<html lang>` can keep the full id (`es-419` is valid BCP-47 there); only hreflang needs the collapse.

3. **URL slugs — use the canonical id verbatim, plus a 308 case-normalization redirect.** The URL slug **is** the canonical id, cased as-is: `/es-ES/`, `/es-419/`, `/pt-PT/`, `/pt-BR/`. This matches next-intl's default (case-sensitive) locale matching, so no lowercase-matching workaround is needed. To stop a mistyped/lowercased inbound link (e.g. `/es-es/`) from 404ing or creating a duplicate URL, add a **308 permanent redirect to the canonical casing** in `app/middleware.ts`:
   - Match the incoming locale segment against supported locales **case-insensitively**; if it matches one but isn't the exact canonical casing, `308` → the canonical form. Keep it scoped to known locale segments (bounded normalization, not a blanket lowercase of all paths).
   - next-intl doesn't do this out of the box (see next-intl issue #775), so it's an explicit few-line middleware addition.
   - General rule to keep all locales consistent: **a slug carries a region suffix only when the language has more than one live variant** — so `es`/`pt` are always suffixed, but single-variant languages stay bare (`/en/`, and `/fr/` if/when French ships — *not* `/fr-fr/`).

4. **Translator brief** — write the `es-419` catalog as neutral pan-LatAm Spanish (not country-specific).

### Context / rationale
Verified browser behaviour: Chromium sends `es-419` in `Accept-Language`; Firefox/Safari send country codes like `es-AR`/`es-CL`. Both must route to the LatAm variant, which the API negotiation now handles. The `es-419`→`es` hreflang collapse is the one Google-specific gotcha (Portuguese has none — both regions are ISO-valid) and belongs on the FE since that's where hreflang is emitted. URL paths are case-sensitive per RFC 3986, so the canonical-cased slug + 308 normalization keeps routing correct without lowercasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)