### PR TITLE
Deploy C: backfill polymorphic names, rename projects tables

### DIFF
--- a/app/commands/assistant_conversation/find_or_create.rb
+++ b/app/commands/assistant_conversation/find_or_create.rb
@@ -4,14 +4,11 @@ class AssistantConversation::FindOrCreate
   initialize_with :user, :context
 
   def call
-    # Transitional read-both lookup (see AssistantConversation.for_context):
-    # challenge conversations may be stored under either polymorphic name
-    # until the backfill migration has run.
-    conversation = AssistantConversation.for_context(context).find_by(user:) ||
-                   AssistantConversation.create!(user:, context:)
-
-    conversation.tap do |c|
-      track_event! if c.previously_new_record?
+    AssistantConversation.find_or_create_by!(
+      user:,
+      context:
+    ).tap do |conversation|
+      track_event! if conversation.previously_new_record?
     end
   end
 

--- a/app/commands/challenge/search.rb
+++ b/app/commands/challenge/search.rb
@@ -38,16 +38,15 @@ class Challenge::Search
     return @challenges = @challenges.order(:title) unless user
 
     # Scope the join to the current user so other users' user_challenges don't filter challenges out.
-    # NB: the underlying tables are still named projects / user_projects.
     @challenges = @challenges.
       joins(sanitize_sql_array(
         [
-          "LEFT JOIN user_projects ON user_projects.project_id = projects.id AND user_projects.user_id = ?",
+          "LEFT JOIN user_challenges ON user_challenges.challenge_id = challenges.id AND user_challenges.user_id = ?",
           user.id
         ]
       )).
-      select("projects.*, CASE WHEN user_projects.user_id IS NOT NULL THEN 0 ELSE 1 END as lock_order").
-      order("lock_order ASC, projects.title ASC")
+      select("challenges.*, CASE WHEN user_challenges.user_id IS NOT NULL THEN 0 ELSE 1 END as lock_order").
+      order("lock_order ASC, challenges.title ASC")
   end
 
   def sanitize_sql_array(array)

--- a/app/models/assistant_conversation.rb
+++ b/app/models/assistant_conversation.rb
@@ -1,12 +1,4 @@
 class AssistantConversation < ApplicationRecord
   belongs_to :user
   belongs_to :context, polymorphic: true
-
-  # Transitional: challenge rows written before the rename still have the
-  # legacy "Project" context_type, so reads must accept both names until
-  # the backfill migration has run. Remove after the backfill.
-  scope :for_context, lambda { |context|
-    types = context.is_a?(Challenge) ? %w[Project Challenge] : [context.class.polymorphic_name]
-    where(context_type: types, context_id: context.id)
-  }
 end

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -1,15 +1,12 @@
 class Challenge < ApplicationRecord
   disable_sti!
 
-  # The database table hasn't been renamed from the old "projects" naming yet.
-  self.table_name = "projects"
-
   extend FriendlyId
   friendly_id :slug, use: [:history]
 
   # Associations
   belongs_to :unlocked_by_lesson, class_name: 'Lesson', optional: true
-  has_many :user_challenges, foreign_key: :project_id, inverse_of: :challenge, dependent: :destroy
+  has_many :user_challenges, dependent: :destroy
   has_many :users, through: :user_challenges
 
   # Validations

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,0 @@
-# LEGACY: Projects were renamed to Challenges, but polymorphic rows
-# (assistant_conversations.context_type, friendly_id_slugs.sluggable_type)
-# still store "Project", so the constant must keep resolving.
-# Remove once that data has been migrated.
-Project = Challenge

--- a/app/models/user_challenge.rb
+++ b/app/models/user_challenge.rb
@@ -1,28 +1,20 @@
 class UserChallenge < ApplicationRecord
-  # The database table hasn't been renamed from the old "user_projects" naming yet.
-  self.table_name = "user_projects"
-
   # Associations
   belongs_to :user
-  belongs_to :challenge, foreign_key: :project_id, inverse_of: :user_challenges
-
-  # Transitional: rows written before the rename still have the legacy
-  # "UserProject" context_type, so reads must accept both names until the
-  # backfill migration has run. Remove the lambda after the backfill.
-  has_many :exercise_submissions,
-    -> { unscope(where: :context_type).where(context_type: %w[UserProject UserChallenge]) },
-    as: :context, inverse_of: :context, dependent: :destroy
+  belongs_to :challenge
+  has_many :exercise_submissions, as: :context, dependent: :destroy
 
   # Validations
-  # NB: project_id is the not-yet-renamed foreign key column for challenge.
-  validates :project_id, uniqueness: { scope: :user_id }
+  validates :challenge_id, uniqueness: { scope: :user_id }
 
   # State helper methods
   def started? = started_at.present?
   def completed? = completed_at.present?
 
   def assistant_conversation
-    # Transitional read-both lookup (see AssistantConversation.for_context).
-    AssistantConversation.for_context(challenge).find_by(user:)
+    AssistantConversation.find_by(
+      user: user,
+      context: challenge
+    )
   end
 end

--- a/app/models/user_project.rb
+++ b/app/models/user_project.rb
@@ -1,4 +1,0 @@
-# LEGACY: UserProjects were renamed to UserChallenges, but polymorphic rows
-# (exercise_submissions.context_type) still store "UserProject", so the
-# constant must keep resolving. Remove once that data has been migrated.
-UserProject = UserChallenge

--- a/app/serializers/serialize_challenges.rb
+++ b/app/serializers/serialize_challenges.rb
@@ -34,10 +34,9 @@ class SerializeChallenges
 
   memoize
   def user_challenge_rows
-    # NB: project_id is the not-yet-renamed foreign key column for challenge.
     UserChallenge.
-      where(user_id: for_user.id, project_id: challenges.map(&:id)).
-      pluck(:project_id, :started_at, :completed_at).
+      where(user_id: for_user.id, challenge_id: challenges.map(&:id)).
+      pluck(:challenge_id, :started_at, :completed_at).
       to_h { |challenge_id, started_at, completed_at| [challenge_id, { started_at:, completed_at: }] }
   end
 

--- a/app/serializers/serialize_exercise_submission.rb
+++ b/app/serializers/serialize_exercise_submission.rb
@@ -6,18 +6,13 @@ class SerializeExerciseSubmission
   def call
     {
       uuid: submission.uuid,
-      context_type: context_type,
+      context_type: submission.context_type,
       context_slug: context_slug,
       files: submission.files.map { |file| serialize_file(file) }
     }
   end
 
   private
-  # Rows written before the rename still store the legacy "UserProject"
-  # context_type, so use the class name instead of the raw column.
-  # Remove after the backfill migration.
-  def context_type = submission.context.class.name
-
   def context_slug
     case submission.context
     when UserLesson

--- a/db/migrate/20260710120000_rename_projects_to_challenges.rb
+++ b/db/migrate/20260710120000_rename_projects_to_challenges.rb
@@ -1,19 +1,6 @@
 class RenameProjectsToChallenges < ActiveRecord::Migration[8.1]
   def up
     # -- Backfill polymorphic type names --------------------------------------
-    # Dedupe conversations double-created during the step A -> step B rollout
-    # window (an old-name and a new-name row can coexist for the same
-    # user+context because the unique index treats the two strings as
-    # different contexts). Keep the new-name row.
-    execute <<~SQL
-      DELETE FROM assistant_conversations AS legacy
-      USING assistant_conversations AS kept
-      WHERE legacy.context_type = 'Project'
-        AND kept.context_type = 'Challenge'
-        AND legacy.user_id = kept.user_id
-        AND legacy.context_id = kept.context_id
-    SQL
-
     execute "UPDATE assistant_conversations SET context_type = 'Challenge' WHERE context_type = 'Project'"
     execute "UPDATE exercise_submissions SET context_type = 'UserChallenge' WHERE context_type = 'UserProject'"
     execute "UPDATE friendly_id_slugs SET sluggable_type = 'Challenge' WHERE sluggable_type = 'Project'"

--- a/db/migrate/20260710120000_rename_projects_to_challenges.rb
+++ b/db/migrate/20260710120000_rename_projects_to_challenges.rb
@@ -1,0 +1,49 @@
+class RenameProjectsToChallenges < ActiveRecord::Migration[8.1]
+  def up
+    # -- Backfill polymorphic type names --------------------------------------
+    # Dedupe conversations double-created during the step A -> step B rollout
+    # window (an old-name and a new-name row can coexist for the same
+    # user+context because the unique index treats the two strings as
+    # different contexts). Keep the new-name row.
+    execute <<~SQL
+      DELETE FROM assistant_conversations AS legacy
+      USING assistant_conversations AS kept
+      WHERE legacy.context_type = 'Project'
+        AND kept.context_type = 'Challenge'
+        AND legacy.user_id = kept.user_id
+        AND legacy.context_id = kept.context_id
+    SQL
+
+    execute "UPDATE assistant_conversations SET context_type = 'Challenge' WHERE context_type = 'Project'"
+    execute "UPDATE exercise_submissions SET context_type = 'UserChallenge' WHERE context_type = 'UserProject'"
+    execute "UPDATE friendly_id_slugs SET sluggable_type = 'Challenge' WHERE sluggable_type = 'Project'"
+
+    # -- Rename the tables -----------------------------------------------------
+    rename_column :user_projects, :project_id, :challenge_id
+    rename_table :projects, :challenges
+    rename_table :user_projects, :user_challenges
+
+    # Compatibility views so in-flight step B code keeps working during the
+    # rolling deploy. Dropped in a follow-up migration once this deploy has
+    # fully rolled out.
+    execute <<~SQL
+      CREATE VIEW projects AS SELECT * FROM challenges;
+      CREATE VIEW user_projects AS
+        SELECT id, user_id, challenge_id AS project_id, started_at, completed_at, created_at, updated_at
+        FROM user_challenges;
+    SQL
+  end
+
+  def down
+    execute "DROP VIEW user_projects"
+    execute "DROP VIEW projects"
+
+    rename_table :user_challenges, :user_projects
+    rename_table :challenges, :projects
+    rename_column :user_projects, :challenge_id, :project_id
+
+    execute "UPDATE friendly_id_slugs SET sluggable_type = 'Project' WHERE sluggable_type = 'Challenge'"
+    execute "UPDATE exercise_submissions SET context_type = 'UserProject' WHERE context_type = 'UserChallenge'"
+    execute "UPDATE assistant_conversations SET context_type = 'Project' WHERE context_type = 'Challenge'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_05_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_10_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -82,6 +82,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120000) do
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_badges_on_name", unique: true
     t.index ["type"], name: "index_badges_on_type", unique: true
+  end
+
+  create_table "challenges", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description", null: false
+    t.string "exercise_slug", null: false
+    t.string "slug", null: false
+    t.string "title", null: false
+    t.bigint "unlocked_by_lesson_id"
+    t.datetime "updated_at", null: false
+    t.string "uuid", null: false
+    t.index ["slug"], name: "index_challenges_on_slug", unique: true
+    t.index ["unlocked_by_lesson_id"], name: "index_challenges_on_unlocked_by_lesson_id"
+    t.index ["uuid"], name: "index_challenges_on_uuid", unique: true
   end
 
   create_table "concepts", force: :cascade do |t|
@@ -253,20 +267,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120000) do
     t.index ["user_id"], name: "index_premium_entitlements_on_user_id"
   end
 
-  create_table "projects", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.text "description", null: false
-    t.string "exercise_slug", null: false
-    t.string "slug", null: false
-    t.string "title", null: false
-    t.bigint "unlocked_by_lesson_id"
-    t.datetime "updated_at", null: false
-    t.string "uuid", null: false
-    t.index ["slug"], name: "index_projects_on_slug", unique: true
-    t.index ["unlocked_by_lesson_id"], name: "index_projects_on_unlocked_by_lesson_id"
-    t.index ["uuid"], name: "index_projects_on_uuid", unique: true
-  end
-
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
     t.string "concurrency_key", null: false
     t.datetime "created_at", null: false
@@ -411,6 +411,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120000) do
     t.index ["user_id"], name: "index_user_activity_data_on_user_id", unique: true
   end
 
+  create_table "user_challenges", force: :cascade do |t|
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.bigint "challenge_id", null: false
+    t.datetime "started_at"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["challenge_id"], name: "index_user_challenges_on_challenge_id"
+    t.index ["user_id", "challenge_id"], name: "index_user_challenges_on_user_id_and_challenge_id", unique: true
+  end
+
   create_table "user_courses", force: :cascade do |t|
     t.datetime "completed_at"
     t.bigint "course_id", null: false
@@ -536,17 +547,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120000) do
     t.index ["user_id"], name: "index_user_notifications_on_user_id"
   end
 
-  create_table "user_projects", force: :cascade do |t|
-    t.datetime "completed_at"
-    t.datetime "created_at", null: false
-    t.bigint "project_id", null: false
-    t.datetime "started_at"
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.index ["project_id"], name: "index_user_projects_on_project_id"
-    t.index ["user_id", "project_id"], name: "index_user_projects_on_user_id_and_project_id", unique: true
-  end
-
   create_table "user_videos", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "created_at", null: false
@@ -587,6 +587,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120000) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "assistant_conversations", "users"
   add_foreign_key "badge_translations", "badges"
+  add_foreign_key "challenges", "lessons", column: "unlocked_by_lesson_id"
   add_foreign_key "concepts", "lessons", column: "unlocked_by_lesson_id"
   add_foreign_key "exercise_submission_files", "exercise_submissions"
   add_foreign_key "lesson_concepts", "concepts"
@@ -597,7 +598,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120000) do
   add_foreign_key "levels", "courses"
   add_foreign_key "payments", "users"
   add_foreign_key "premium_entitlements", "users"
-  add_foreign_key "projects", "lessons", column: "unlocked_by_lesson_id"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
@@ -607,6 +607,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120000) do
   add_foreign_key "user_acquired_badges", "badges"
   add_foreign_key "user_acquired_badges", "users"
   add_foreign_key "user_activity_data", "users"
+  add_foreign_key "user_challenges", "challenges"
+  add_foreign_key "user_challenges", "users"
   add_foreign_key "user_courses", "courses"
   add_foreign_key "user_courses", "user_levels", column: "current_user_level_id"
   add_foreign_key "user_courses", "users"
@@ -620,7 +622,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_120000) do
   add_foreign_key "user_mailshots", "mailshots"
   add_foreign_key "user_mailshots", "users"
   add_foreign_key "user_notifications", "users"
-  add_foreign_key "user_projects", "projects"
-  add_foreign_key "user_projects", "users"
   add_foreign_key "user_videos", "users"
 end

--- a/test/commands/assistant_conversation/find_or_create_test.rb
+++ b/test/commands/assistant_conversation/find_or_create_test.rb
@@ -88,18 +88,4 @@ class AssistantConversation::FindOrCreateTest < ActiveSupport::TestCase
 
     AssistantConversation::FindOrCreate.(user, lesson)
   end
-  # Transitional read-both behaviour: delete this test when the transitional
-  # code is removed after the backfill migration.
-  test "finds existing challenge conversation stored under the legacy Project context_type" do
-    user = create(:user)
-    challenge = create(:challenge)
-    existing_conversation = create(:assistant_conversation, user:, context: challenge)
-    existing_conversation.update_column(:context_type, "Project")
-
-    assert_no_difference 'AssistantConversation.count' do
-      conversation = AssistantConversation::FindOrCreate.(user, challenge)
-
-      assert_equal existing_conversation.id, conversation.id
-    end
-  end
 end

--- a/test/models/user_challenge_test.rb
+++ b/test/models/user_challenge_test.rb
@@ -61,47 +61,4 @@ class UserChallengeTest < ActiveSupport::TestCase
     user_challenge = build(:user_challenge)
     refute user_challenge.completed?
   end
-  # Transitional read-both behaviour: rows written before the rename are
-  # stored under the legacy "Project"/"UserProject" polymorphic names, new
-  # rows under "Challenge"/"UserChallenge". Delete these tests when the
-  # transitional read-both code is removed after the backfill migration.
-  test "assistant_conversation finds conversation stored under the new Challenge context_type" do
-    user_challenge = create(:user_challenge)
-    conversation = create(:assistant_conversation, user: user_challenge.user, context: user_challenge.challenge)
-
-    assert_equal "Challenge", conversation.context_type
-    assert_equal conversation, user_challenge.assistant_conversation
-  end
-
-  test "assistant_conversation finds conversation stored under the legacy Project context_type" do
-    user_challenge = create(:user_challenge)
-    conversation = create(:assistant_conversation, user: user_challenge.user, context: user_challenge.challenge)
-    conversation.update_column(:context_type, "Project")
-
-    assert_equal conversation, user_challenge.assistant_conversation
-  end
-
-  test "exercise_submissions includes rows stored under both polymorphic names" do
-    user_challenge = create(:user_challenge)
-    legacy_submission = create(:exercise_submission, context: user_challenge)
-    legacy_submission.update_column(:context_type, "UserProject")
-    new_submission = create(:exercise_submission, context: user_challenge)
-
-    assert_equal "UserChallenge", new_submission.context_type
-    assert_equal [legacy_submission, new_submission].sort_by(&:id),
-      user_challenge.exercise_submissions.order(:id).to_a
-  end
-
-  test "destroying a user_challenge destroys submissions stored under both polymorphic names" do
-    user_challenge = create(:user_challenge)
-    legacy_submission = create(:exercise_submission, context: user_challenge)
-    legacy_submission.update_column(:context_type, "UserProject")
-    create(:exercise_submission, context: user_challenge)
-
-    assert_difference "ExerciseSubmission.count", -2 do
-      Prosopite.pause do
-        user_challenge.destroy!
-      end
-    end
-  end
 end


### PR DESCRIPTION
**⚠️ Do not merge until #528 (Deploy B) is fully rolled out.** Deploy sequence: #527 (A) → #528 (B) → this (C).

Final step of the projects → challenges migration.

## Migration (runs before this deploy's tasks start)
Safe at this point because the whole fleet is B code: writes the new names, reads both.

1. **Dedupe** assistant conversations double-created during the A→B rollout window — the unique index on `(user_id, context_type, context_id)` can't catch a `'Project'` row and a `'Challenge'` row for the same user+context. Keeps the new-name row.
2. **Backfill**: `assistant_conversations.context_type` `'Project'`→`'Challenge'`, `exercise_submissions.context_type` `'UserProject'`→`'UserChallenge'`, `friendly_id_slugs.sluggable_type` `'Project'`→`'Challenge'`.
3. **Renames**: `projects`→`challenges`, `user_projects`→`user_challenges`, `project_id`→`challenge_id`, then creates **compatibility views** (`projects`, `user_projects`) so in-flight B tasks keep working during the rolling deploy. A trivial follow-up migration drops the views once this deploy has rolled out.

## Code cleanup (now that data + tables match the code)
- Removes the transitional read-both code: `AssistantConversation.for_context`, the `exercise_submissions` association lambda; `FindOrCreate` returns to `find_or_create_by!`.
- Deletes the `Project = Challenge` / `UserProject = UserChallenge` constant aliases.
- Drops the `self.table_name` overrides; queries use `challenge_id` / `user_challenges` / `challenges` natively.
- `SerializeExerciseSubmission` reads `context_type` straight from the column again.

## Before merging
`db/schema.rb` was hand-edited to match the migration (needed for tests to run without touching the dev DB). Run `bin/rails db:migrate` and commit the regenerated `schema.rb` — foreign-key constraint names may dump slightly differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)