### PR TITLE
Handle OAuth signup race on duplicate email

### DIFF
--- a/app/commands/auth/find_or_create_from_oauth.rb
+++ b/app/commands/auth/find_or_create_from_oauth.rb
@@ -67,6 +67,11 @@ module Auth
         retries += 1
         handle = User::GenerateHandle.(email)
         retry
+      rescue ActiveRecord::RecordNotUnique
+        # A concurrent request (e.g. a double-click on the OAuth button, or a
+        # password signup racing this one) created the user between our email
+        # lookup and this INSERT. The account exists now, so link and use it.
+        find_by_email! || raise
       end
     end
 
@@ -79,7 +84,10 @@ module Auth
     def id_column = :"#{provider}_id"
 
     def id = payload['id']
-    def email = payload['email']
+
+    # Devise stores emails downcased (case_insensitive_keys), so downcase
+    # before looking up or the linking path misses existing accounts.
+    def email = payload['email']&.downcase
     def name = payload['name']
     def preferred_handle = payload['handle']
     def avatar_url = payload['avatar_url']

--- a/test/commands/auth/find_or_create_from_oauth_test.rb
+++ b/test/commands/auth/find_or_create_from_oauth_test.rb
@@ -156,6 +156,42 @@ class Auth::FindOrCreateFromOauthTest < ActiveSupport::TestCase
     })
   end
 
+  test "links existing user by email when payload email has different casing" do
+    existing_user = create(:user, email: 'existing@exercism.org', exercism_id: nil)
+
+    assert_no_difference 'User.count' do
+      user = find_or_create_exercism({ 'id' => '789', 'email' => 'Existing@Exercism.ORG', 'name' => 'Existing User' })
+
+      assert_equal existing_user.id, user.id
+      assert_equal '789', user.exercism_id
+    end
+  end
+
+  test "recovers when a concurrent request creates the user between lookup and insert" do
+    # Simulate the race: the email lookup finds nothing, but by the time we
+    # INSERT, a concurrent request has created the user.
+    concurrent_user = create(:user, email: 'raced@gmail.com', google_id: nil)
+    User.stubs(:find_by).with(google_id: 'google-123').returns(nil)
+    User.stubs(:find_by).with(email: 'raced@gmail.com').returns(nil, concurrent_user)
+    User.expects(:create!).raises(ActiveRecord::RecordNotUnique)
+
+    assert_no_difference 'User.count' do
+      user = find_or_create_google({ 'id' => 'google-123', 'email' => 'raced@gmail.com', 'name' => 'Raced User' })
+
+      assert_equal concurrent_user.id, user.id
+      assert_equal 'google-123', user.google_id
+      assert user.confirmed?
+    end
+  end
+
+  test "reraises RecordNotUnique when no user exists with the email" do
+    User.expects(:create!).raises(ActiveRecord::RecordNotUnique)
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      find_or_create_google({ 'id' => 'google-123', 'email' => 'ghost@gmail.com', 'name' => 'Ghost User' })
+    end
+  end
+
   test "generates random password for new users" do
     user = find_or_create_exercism({ 'id' => '1530', 'email' => 'password@exercism.org', 'name' => 'Password Test' })
 


### PR DESCRIPTION
## Problem

Sentry has been reporting `ActiveRecord::RecordNotUnique` on `index_users_on_email` from `Auth::GoogleOauthController#create` (#518).

In `Auth::FindOrCreateFromOauth`, two concurrent requests for the same email (double-click on the OAuth button, a frontend retry, or an OAuth signup racing a password signup) can both miss the email lookup and both attempt an INSERT. The first wins; the second passes the Devise uniqueness validation (the row didn't exist at SELECT time) but hits the unique index at INSERT time. `RecordNotUnique` isn't rescued anywhere, so the user gets a 500 even though their account now exists.

## Fix

- Rescue `ActiveRecord::RecordNotUnique` in `create_user!` and fall back to the email lookup — the loser of the race links its provider id to the account the concurrent request created and signs in normally, making the command idempotent. If the email lookup still finds nothing (the conflict was on some other column), re-raise.
- Downcase the payload email before lookups. Devise stores emails downcased (`case_insensitive_keys`), so a mixed-case email from a provider would previously skip the account-linking path and fall through to a doomed create.

Fixes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)