### PR TITLE
Update video playback IDs for four re-exported lessons

### DIFF
--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -194,7 +194,7 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "un00mYM015o9oXAP5xLL2Ljw9VyvvsKaDbcrAZnMEoJZY"
+                "id": "wD902h8Md3cYuXUoh00P0201ZKDl1p02Lm7GHaMlDsJIoa00U"
               }
             ]
           }
@@ -400,7 +400,7 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "hVhR01LLjp1PCDJChQY901D023Qgp2XdwaTrtS5cQIaVtg"
+                "id": "HqCtx5KALIqtL02wSgOCy83zuqzycMR8oy01BdHCmVSGM"
               }
             ]
           }
@@ -908,7 +908,7 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "8O5kYQGSWQDvhQIihRrd7pL6xF01lbNrYNKPlPYj9fEs"
+                "id": "Iwn2PLYrpnbXeU5hNXebvbci2WOtuD9w1FhVs8wzgFo"
               }
             ]
           }
@@ -933,7 +933,7 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "lvw25p9x1rt7AvJVFGvINVvrmgsVcmOnYF02TzdjBBgE"
+                "id": "HQ8t4J78TeM3BGzTMTm5CHiefqTUlv006hzXNg85AlMU"
               }
             ]
           }


### PR DESCRIPTION
Point four re-exported lessons at their new Mux playback IDs after re-rendering/re-publishing:

- functions-that-return-things → `HqCtx5KALIqtL02wSgOCy83zuqzycMR8oy01BdHCmVSGM`
- making-functions-with-inputs → `Iwn2PLYrpnbXeU5hNXebvbci2WOtuD9w1FhVs8wzgFo`
- repeat-loop → `wD902h8Md3cYuXUoh00P0201ZKDl1p02Lm7GHaMlDsJIoa00U`
- making-functions-with-return-values → `HQ8t4J78TeM3BGzTMTm5CHiefqTUlv006hzXNg85AlMU`

🤖 Generated with [Claude Code](https://claude.com/claude-code)