### PR TITLE
Update mailer copy: rename Build with Jeremy to Learn to Build

### DIFF
--- a/config/locales/mailers/onboarding_mailer.en.yml
+++ b/config/locales/mailers/onboarding_mailer.en.yml
@@ -7,15 +7,15 @@ en:
       body_markdown: |
         For the last few years I've been **slowly learning Japanese**. I visit Japan regularly and try and immerse myself in the language, but it's hard, because nowadays, with the help of Google Translate, it's pretty easy to spend time in Japan and not speak a word of Japanese. **So my brain can be lazy**, but I can get along fine.
 
-        Coding has recently started to take that same journey. For the last 30 years, if you wanted to do anything with tech, **you had to learn to code**. It was the only way for you to communicate with a computer. But over the last two years, with LLMs, that's changed. You can now use your native language and tell the LLM what you want it to do, and **it'll write the code for you** - translating your instructions to the computer.
+        Coding has recently started to take that same journey. For the last 30 years, if you wanted to do anything with tech, **you had to learn to code**. It was the only way for you to communicate with a computer. But over the last two years, with the rise of agentic coding, that's changed. You can now use your native language and tell an AI agent what you want it to do, and **it'll write the code for you** - translating your instructions to the computer.
 
         Just like I don't have to wait to be fluent in Japanese before I can explore Japan, **it no longer makes any sense to spend years getting good at coding** before you start building things.
 
         But if I want to really get into Japanese culture and make Japanese friends, I need to learn Japanese. And, if you want to get into tech, you still need to learn to code. Code is no longer the gatekeeper, but it's **the difference between "getting by" and actually thriving**.
 
         To get good fast, split your learning time into two chunks:
-        1. **Learn to code.** Work through Jiki's Coding Fundamentals and you'll have great foundations.
-        2. **Make stuff.** Work through "Build with Jeremy", getting into the weeds, creating products that people can actually use!
+        1. **Learn to code.** Work through Jiki's Coding Fundamentals course and you'll have great foundations.
+        2. **Make stuff.** Work through "Learn to Build", getting into the weeds, creating products that people can actually use!
 
         If you want to learn more about my thoughts on **how to get into tech in 2026**, read [this blog post](https://jiki.io/blog/how-to-get-into-tech-in-2026).
 
@@ -47,13 +47,13 @@ en:
       body_markdown: |
         I really believe that **now is the best possible time to get into tech**. There's never been an easier time to learn the fundamentals and to quickly be able to make things.
 
-        But (and this is a big but!) where a lot of people are going wrong is that they're handing over the reins entirely to an LLM and not actually learning. And that feels great for a little bit - you can magically make all this stuff appear - but if all you're doing is telling Claude or ChatGPT what to do, you're not actually learning anything!
+        But (and this is a big but!) where a lot of people are going wrong is that they're handing over the reins entirely to an AI agent and not actually learning. And that feels great for a little bit - you can magically make all this stuff appear - but if all you're doing is telling Claude or ChatGPT what to do, you're not actually learning anything!
 
-        So I'm putting together **step-by-step projects** that you can work with, where I _WANT_ you to use LLMs to do a lot of the work for you. But where I want you to make sure **you actually understand what's happening** at each stage.
+        So I'm putting together **step-by-step projects** that you can work with, where I _WANT_ you to use AI agents to do a lot of the work for you. But where I want you to make sure **you actually understand what's happening** at each stage.
 
-        The point of these projects is to be able to learn **all the different parts of building software**. You can join me as I build things, and I'll explain exactly what I'm doing and why, then you can work with an LLM to apply those same ideas to your projects.
+        The point of these projects is to be able to learn **all the different parts of building software**. You can join me as I build things, and I'll explain exactly what I'm doing and why, then you can work with an AI agent to apply those same ideas to your projects.
 
-        Just **don't get addicted to the dopamine hits** of the LLM doing your work for you. Make sure you take the time to understand what's going on!
+        Just **don't get addicted to the dopamine hits** of the AI agent doing your work for you. Make sure you take the time to understand what's going on!
 
         Hopefully I'll see you [on a livestream](https://youtube.com/@jiki-coding) soon!
 
@@ -69,7 +69,7 @@ en:
         But **Jiki costs money to run**, and we need to be able to pay our rents and afford food (🍜) and caffeine (☕), so we've added a Premium tier that adds some extra benefits that I think will really help you:
         - **Ask Jiki**: Our AI chat to help you quickly get unstuck or explore your questions.
         - **Premium Projects**: Harder exercises, where you can combine the skills you're learning.
-        - **Build with Jeremy**: Tons more content where you can learn alongside me.
+        - **Learn to Build**: Tons more content where you can learn alongside me.
         - **Badges**: Showcase your support on the site and in community spaces with Premium badges.
 
         We've made it super-affordable using **Purchasing Power Parity**. That means that Premium costs about the same as two takeaway drinks in your country, so it should feel like a reasonable price wherever you are in the world.

--- a/config/locales/mailers/premium_mailer.en.yml
+++ b/config/locales/mailers/premium_mailer.en.yml
@@ -18,7 +18,7 @@ en:
       body_markdown: |
         Your Jiki Premium subscription has ended and you're now on our free plan.
 
-        You still have full access to all our core Coding Fundamentals track. If you'd like to resubscribe, you can do so anytime on your [settings page](https://jiki.io/settings).
+        You still have full access to our entire Learn to Code section. If you'd like to resubscribe, you can do so anytime on your [settings page](https://jiki.io/settings).
 
         Thanks for trying Jiki Premium.
 


### PR DESCRIPTION
## Summary
- Renames "Build with Jeremy" to "Learn to Build" across onboarding/premium mailer copy
- Updates LLM-specific phrasing to AI agent to match current terminology

## Test plan
- [x] `bin/rails test` passes (pre-commit hook)
- [x] `bin/rubocop -a` / `bin/brakeman` clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)