### PR TITLE
Update video playback IDs for four re-exported lessons

### DIFF
--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -1320,7 +1320,7 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "VufydOA5JfsskzFptgYVi3BKg2aE0002ukkGZDQDtlrMc"
+                "id": "crld00MTVkFCyPjeLB1oK4iz00BbUSyZLcWTKzCD01Mejs"
               }
             ]
           }
@@ -1385,7 +1385,7 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "B7kisBeI2abPcdXs7DOghy3RZLxpDiAiNqqnUkIW2aM"
+                "id": "NauVD1prYbb01N9N02LCAHbrSkV8ziUs1AGST02dVM4IZU"
               }
             ]
           }
@@ -1482,7 +1482,7 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "zMLm4cwlLFcTWW6lXoKp8w0046ng01oQxst01tdTvBecnk"
+                "id": "CkkTxQwQH8LwilAQjWaYhJysSL02u3gRa8Ce01BrXGaFI"
               }
             ]
           }
@@ -1517,7 +1517,7 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "pGvxokynFybaWS8802EC9DanC2W901VO2AmStMpF8uQVA"
+                "id": "nneymd6yNj2Sjop1xvhQsIUq7RigZoDyr02OVJxF4lqQ"
               }
             ]
           }


### PR DESCRIPTION
## Summary
- Point arrays, building-arrays, dictionaries, and updating-dictionaries at their new Mux playback IDs after re-rendering/re-publishing.

## Test plan
- [x] `bin/rails test` (via pre-commit hook)
- [x] `bin/brakeman` (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)