### PR TITLE
Fix uniqueness-validation race in lesson/level/course start commands

### DIFF
--- a/app/commands/user_lesson/start.rb
+++ b/app/commands/user_lesson/start.rb
@@ -49,7 +49,15 @@ class UserLesson::Start
       raise LessonInProgressError, "Complete current lesson before starting a new one"
     end
 
-    # Check if trying to start lesson in a different level
+    # Check if trying to start lesson in a different level.
+    #
+    # This deliberately only blocks when the current level's lessons are ALL
+    # complete: at that point the only legitimate way forward is the explicit
+    # level-completion flow (UserLevel::Complete), which advances
+    # current_user_level — so a cross-level start here means the client
+    # skipped that step. While the current level still has unfinished
+    # lessons, cross-level starts are permitted (e.g. revisiting lessons in
+    # other levels); the in-progress check above still guards each level.
     current_level = user_course.current_user_level&.level
     return unless current_level && current_level.id != lesson.level_id
     return unless all_lessons_complete?(current_level)

--- a/app/commands/user_lesson/start.rb
+++ b/app/commands/user_lesson/start.rb
@@ -13,8 +13,8 @@ class UserLesson::Start
     validate_can_start_lesson!
 
     ActiveRecord::Base.transaction do
-      UserLesson.create_or_find_by!(user:, lesson:) { |ul| ul.started_at = Time.current }.tap do |user_lesson|
-        # Guard against a concurrent request winning the race in create_or_find_by!
+      UserLesson.find_create_or_find_by!(user:, lesson:) { |ul| ul.started_at = Time.current }.tap do |user_lesson|
+        # Guard against a concurrent request winning the race in find_create_or_find_by!
         if user_lesson.just_created?
           user_level.update!(current_user_lesson: user_lesson)
           user_course.update!(current_user_level: user_level)

--- a/config/initializers/active_record.rb
+++ b/config/initializers/active_record.rb
@@ -8,7 +8,17 @@ class ActiveRecord::Base
   def self.find_create_or_find_by!(*args, &block)
     find_by!(*args)
   rescue ActiveRecord::RecordNotFound
-    create_or_find_by!(*args, &block)
+    begin
+      create_or_find_by!(*args, &block)
+    rescue ActiveRecord::RecordInvalid => e
+      # create_or_find_by! only rescues the DB-level RecordNotUnique. If the
+      # model also has a uniqueness validation on the same columns, a row
+      # committed by a concurrent request is seen by the validation's SELECT
+      # first, raising RecordInvalid before the DB constraint gets a chance.
+      raise unless e.record.errors.any? { |error| error.type == :taken }
+
+      find_by!(*args)
+    end
   end
 
   def self.create_or_find!(attributes, &block)

--- a/test/commands/user_lesson/start_test.rb
+++ b/test/commands/user_lesson/start_test.rb
@@ -33,6 +33,38 @@ class UserLesson::StartTest < ActiveSupport::TestCase
     end
   end
 
+  test "returns existing user_lesson when a concurrent request wins the race" do
+    user_level = create(:user_level)
+    lesson = create(:lesson, :exercise, level: user_level.level)
+    existing = create(:user_lesson, user: user_level.user, lesson:, completed_at: nil)
+    user_level.update!(current_user_lesson: existing)
+
+    # Simulate losing a double-submit race: the short-circuit lookup ran
+    # before the winner committed, so it sees nothing, and the uniqueness
+    # validation inside create! then rejects the insert (JIKI-API-M).
+    UserLesson.stubs(:find_by).returns(nil)
+    UserLesson.stubs(:find_by!).raises(ActiveRecord::RecordNotFound).then.returns(UserLesson.find(existing.id))
+
+    result = nil
+    assert_no_difference -> { UserLesson.count } do
+      result = UserLesson::Start.(user_level.user, lesson)
+    end
+    assert_equal existing.id, result.id
+  end
+
+  test "does not update tracking pointers when losing the creation race" do
+    user_level = create(:user_level)
+    lesson = create(:lesson, :exercise, level: user_level.level)
+    existing = create(:user_lesson, user: user_level.user, lesson:, completed_at: nil)
+
+    UserLesson.stubs(:find_by).returns(nil)
+    UserLesson.stubs(:find_by!).raises(ActiveRecord::RecordNotFound).then.returns(UserLesson.find(existing.id))
+
+    UserLesson::Start.(user_level.user, lesson)
+
+    assert_nil user_level.reload.current_user_lesson_id
+  end
+
   test "raises UserLevelNotFoundError when not enrolled in course" do
     user = create(:user)
     lesson = create(:lesson, :exercise)

--- a/test/commands/user_lesson/start_test.rb
+++ b/test/commands/user_lesson/start_test.rb
@@ -60,8 +60,10 @@ class UserLesson::StartTest < ActiveSupport::TestCase
     UserLesson.stubs(:find_by).returns(nil)
     UserLesson.stubs(:find_by!).raises(ActiveRecord::RecordNotFound).then.returns(UserLesson.find(existing.id))
 
-    UserLesson::Start.(user_level.user, lesson)
+    result = UserLesson::Start.(user_level.user, lesson)
 
+    # Guard that the race path actually ran and returned the winner's row
+    assert_equal existing.id, result.id
     assert_nil user_level.reload.current_user_lesson_id
   end
 

--- a/test/models/active_record_extensions_test.rb
+++ b/test/models/active_record_extensions_test.rb
@@ -23,9 +23,10 @@ class ActiveRecordExtensionsTest < ActiveSupport::TestCase
   test "find_create_or_find_by! recovers when uniqueness validation loses a race" do
     user_lesson = create(:user_lesson)
 
-    # Simulate a concurrent request committing the row between the initial
-    # lookup and create!: the first find_by! misses, then the uniqueness
-    # validation inside create! sees the committed row and raises RecordInvalid.
+    # The row already exists in the DB (the race "winner"); stubbing the
+    # first find_by! to miss recreates the loser's view. create! then runs
+    # for real and its uniqueness validation sees the committed row, raising
+    # RecordInvalid — the exact failure mode from Sentry JIKI-API-M.
     UserLesson.stubs(:find_by!).raises(ActiveRecord::RecordNotFound).then.returns(user_lesson)
 
     result = nil

--- a/test/models/active_record_extensions_test.rb
+++ b/test/models/active_record_extensions_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+# Tests for the ActiveRecord::Base extensions in config/initializers/active_record.rb
+class ActiveRecordExtensionsTest < ActiveSupport::TestCase
+  test "find_create_or_find_by! finds existing record" do
+    user_lesson = create(:user_lesson)
+
+    result = UserLesson.find_create_or_find_by!(user: user_lesson.user, lesson: user_lesson.lesson)
+
+    assert_equal user_lesson.id, result.id
+  end
+
+  test "find_create_or_find_by! creates when missing" do
+    user = create(:user)
+    lesson = create(:lesson, :exercise)
+
+    result = UserLesson.find_create_or_find_by!(user:, lesson:) { |ul| ul.started_at = Time.current }
+
+    assert result.persisted?
+    assert result.started_at.present?
+  end
+
+  test "find_create_or_find_by! recovers when uniqueness validation loses a race" do
+    user_lesson = create(:user_lesson)
+
+    # Simulate a concurrent request committing the row between the initial
+    # lookup and create!: the first find_by! misses, then the uniqueness
+    # validation inside create! sees the committed row and raises RecordInvalid.
+    UserLesson.stubs(:find_by!).raises(ActiveRecord::RecordNotFound).then.returns(user_lesson)
+
+    result = nil
+    assert_no_difference -> { UserLesson.count } do
+      result = UserLesson.find_create_or_find_by!(user: user_lesson.user, lesson: user_lesson.lesson)
+    end
+    assert_equal user_lesson.id, result.id
+  end
+
+  test "find_create_or_find_by! re-raises RecordInvalid for non-uniqueness failures" do
+    user = create(:user)
+    lesson = create(:lesson, :exercise)
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      UserLesson.find_create_or_find_by!(user:, lesson:) { |ul| ul.difficulty_rating = 99 }
+    end
+  end
+end


### PR DESCRIPTION
Fixes the race behind Sentry [JIKI-API-M](https://thalamus-ai.sentry.io/issues/JIKI-API-M) ("Validation failed: User has already been taken" from `internal/user_lessons#start`, 2 events / 2 users).

## The bug

`create_or_find_by!` only rescues the DB-level `RecordNotUnique`, but `UserLesson` also has `validates :user_id, uniqueness: { scope: :lesson_id }`. When a double-submit races, the loser's `create!` runs the uniqueness validation's SELECT, which sees the winner's committed row and raises `RecordInvalid` *before* the DB constraint gets a chance — so the rescue never fires and the request 500s. This is a documented footgun in the `create_or_find_by!` docs.

`UserLevel` and `UserCourse` have the same model validations, so `UserLevel::Start` and `UserCourse::Enroll` (which use `find_create_or_find_by!`) carried the identical latent race.

## The fix

- `find_create_or_find_by!` now rescues `RecordInvalid` when the failure is a `:taken` uniqueness error and falls back to re-finding the winner's row. Any other validation failure still raises.
- `UserLesson::Start` uses `find_create_or_find_by!` instead of calling `create_or_find_by!` directly, picking up the fix along with `UserLevel::Start` and `UserCourse::Enroll`.
- Tests cover the race at both the helper and command level (including that the losing request doesn't clobber tracking pointers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)