### PR TITLE
Retry mail delivery on transient AWS credential failures

### DIFF
--- a/app/jobs/mail_delivery_job.rb
+++ b/app/jobs/mail_delivery_job.rb
@@ -1,0 +1,15 @@
+# Rails' default ActionMailer::MailDeliveryJob inherits ActiveJob::Base, not
+# ApplicationJob, so it gets no retries: a single transient failure leaves the
+# email permanently in Solid Queue's failed executions, unsent.
+#
+# On ECS, the SDK's credential fetch from the container metadata endpoint
+# occasionally times out, surfacing as MissingCredentialsError when the SES
+# request is signed. Signing happens strictly BEFORE any HTTP call to SES, so
+# retrying this error can never double-send an email.
+#
+# Do NOT broaden this to other errors (e.g. network timeouts, generic
+# StandardError): those can fire AFTER SES has accepted the message, and a
+# retry would send the email twice.
+class MailDeliveryJob < ActionMailer::MailDeliveryJob
+  retry_on Aws::Errors::MissingCredentialsError, wait: :polynomially_longer, attempts: 10
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,5 +56,10 @@ module Api
 
     # Configure ActiveJob to use Solid Queue as the queue adapter
     config.active_job.queue_adapter = :solid_queue
+
+    # Use our MailDeliveryJob subclass so transient AWS credential failures
+    # are retried instead of permanently dropping the email (see the class
+    # for why only that error is safe to retry).
+    config.action_mailer.delivery_job = "MailDeliveryJob"
   end
 end

--- a/test/commands/account_deletion/request_deletion_test.rb
+++ b/test/commands/account_deletion/request_deletion_test.rb
@@ -4,7 +4,7 @@ class AccountDeletion::RequestDeletionTest < ActiveSupport::TestCase
   test "sends account deletion confirmation email" do
     user = create(:user)
 
-    assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+    assert_enqueued_with(job: MailDeliveryJob) do
       AccountDeletion::RequestDeletion.(user)
     end
   end

--- a/test/commands/mailshot/send_test_email_test.rb
+++ b/test/commands/mailshot/send_test_email_test.rb
@@ -6,7 +6,7 @@ class Mailshot::SendTestEmailTest < ActiveSupport::TestCase
     mailshot = create(:mailshot)
 
     assert_difference "User::Mailshot.count", 1 do
-      assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+      assert_enqueued_jobs 1, only: MailDeliveryJob do
         Mailshot::SendTestEmail.(mailshot, admin)
       end
     end
@@ -18,7 +18,7 @@ class Mailshot::SendTestEmailTest < ActiveSupport::TestCase
     create(:user_mailshot, user: admin, mailshot:)
 
     assert_no_difference "User::Mailshot.count" do
-      assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+      assert_enqueued_jobs 1, only: MailDeliveryJob do
         Mailshot::SendTestEmail.(mailshot, admin)
       end
     end

--- a/test/commands/user/downgrade_to_standard_test.rb
+++ b/test/commands/user/downgrade_to_standard_test.rb
@@ -14,7 +14,7 @@ class User::DowngradeToStandardTest < ActiveSupport::TestCase
     user = create(:user)
     user.data.update!(membership_type: "premium")
 
-    assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+    assert_enqueued_jobs 1, only: MailDeliveryJob do
       User::DowngradeToStandard.(user)
     end
   end
@@ -23,7 +23,7 @@ class User::DowngradeToStandardTest < ActiveSupport::TestCase
     user = create(:user)
     assert user.data.standard?
 
-    assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+    assert_no_enqueued_jobs only: MailDeliveryJob do
       User::DowngradeToStandard.(user)
     end
 

--- a/test/commands/user/mailshot/send_test.rb
+++ b/test/commands/user/mailshot/send_test.rb
@@ -6,7 +6,7 @@ class User::Mailshot::SendTest < ActiveSupport::TestCase
     mailshot = create(:mailshot)
 
     assert_difference "User::Mailshot.count", 1 do
-      assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+      assert_enqueued_jobs 1, only: MailDeliveryJob do
         User::Mailshot::Send.(user, mailshot)
       end
     end
@@ -25,7 +25,7 @@ class User::Mailshot::SendTest < ActiveSupport::TestCase
     User::SendEmail.expects(:call).never
 
     assert_no_difference "User::Mailshot.count" do
-      assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      assert_no_enqueued_jobs only: MailDeliveryJob do
         User::Mailshot::Send.(user, mailshot)
       end
     end
@@ -36,7 +36,7 @@ class User::Mailshot::SendTest < ActiveSupport::TestCase
     user.data.update!(receive_newsletters: false)
     mailshot = create(:mailshot)
 
-    assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+    assert_no_enqueued_jobs only: MailDeliveryJob do
       User::Mailshot::Send.(user, mailshot)
     end
 

--- a/test/commands/user/notification/send_email_test.rb
+++ b/test/commands/user/notification/send_email_test.rb
@@ -6,7 +6,7 @@ class User::Notification::SendEmailTest < ActiveSupport::TestCase
     notification = User::Notifications::OnboardingCodingNotification.create!(user:)
 
     assert_enqueued_with(
-      job: ActionMailer::MailDeliveryJob,
+      job: MailDeliveryJob,
       args: ["OnboardingMailer", "coding", "deliver_now", { args: [user] }]
     ) do
       User::Notification::SendEmail.(notification)
@@ -29,7 +29,7 @@ class User::Notification::SendEmailTest < ActiveSupport::TestCase
         notification = klass.create!(user:)
 
         assert_enqueued_with(
-          job: ActionMailer::MailDeliveryJob,
+          job: MailDeliveryJob,
           args: ["OnboardingMailer", expected_action, "deliver_now", { args: [user] }]
         ) do
           User::Notification::SendEmail.(notification)

--- a/test/commands/user/send_welcome_email_test.rb
+++ b/test/commands/user/send_welcome_email_test.rb
@@ -5,7 +5,7 @@ class User::SendWelcomeEmailTest < ActiveSupport::TestCase
     user = create(:user)
 
     assert_enqueued_with(
-      job: ActionMailer::MailDeliveryJob,
+      job: MailDeliveryJob,
       args: ["AccountMailer", "welcome", "deliver_now", { args: [user] }]
     ) do
       User::SendWelcomeEmail.(user)

--- a/test/commands/user/send_welcome_to_premium_email_test.rb
+++ b/test/commands/user/send_welcome_to_premium_email_test.rb
@@ -5,7 +5,7 @@ class User::SendWelcomeToPremiumEmailTest < ActiveSupport::TestCase
     user = create(:user)
 
     assert_enqueued_with(
-      job: ActionMailer::MailDeliveryJob,
+      job: MailDeliveryJob,
       args: ["PremiumMailer", "welcome_to_premium", "deliver_now", { args: [user] }]
     ) do
       User::SendWelcomeToPremiumEmail.(user)

--- a/test/commands/user/upgrade_to_premium_test.rb
+++ b/test/commands/user/upgrade_to_premium_test.rb
@@ -22,7 +22,7 @@ class User::UpgradeToPremiumTest < ActiveSupport::TestCase
     user = create(:user)
     user.data.update!(membership_type: "premium")
 
-    assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+    assert_no_enqueued_jobs only: MailDeliveryJob do
       User::UpgradeToPremium.(user)
     end
 

--- a/test/commands/user_level/complete_test.rb
+++ b/test/commands/user_level/complete_test.rb
@@ -89,7 +89,7 @@ class UserLevel::CompleteTest < ActiveSupport::TestCase
     create(:user_lesson, user: user_level.user, lesson:, completed_at: Time.current)
 
     # Level factory already includes email fields by default
-    assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+    assert_enqueued_jobs 1, only: MailDeliveryJob do
       UserLevel::Complete.(user_level)
     end
   end
@@ -110,7 +110,7 @@ class UserLevel::CompleteTest < ActiveSupport::TestCase
     next_user_level = UserLevel.find_by(user: user_course.user, level: level2)
     refute_nil next_user_level
 
-    assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+    assert_no_enqueued_jobs only: MailDeliveryJob do
       assert_no_difference -> { user_course.user.user_levels.count } do
         UserLevel::Complete.(user_level)
         assert_equal old_completed_at.to_i, user_level.reload.completed_at.to_i

--- a/test/controllers/admin/mailshots_controller_test.rb
+++ b/test/controllers/admin/mailshots_controller_test.rb
@@ -153,7 +153,7 @@ class Admin::MailshotsControllerTest < ApplicationControllerTest
   test "POST test sends to the current admin" do
     mailshot = create(:mailshot)
 
-    assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+    assert_enqueued_jobs 1, only: MailDeliveryJob do
       post send_test_admin_mailshot_path(mailshot), as: :json
     end
 

--- a/test/controllers/auth/account_deletions_controller_test.rb
+++ b/test/controllers/auth/account_deletions_controller_test.rb
@@ -8,7 +8,7 @@ class Auth::AccountDeletionsControllerTest < ApplicationControllerTest
     user = create(:user)
     sign_in_user(user)
 
-    assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+    assert_enqueued_with(job: MailDeliveryJob) do
       post auth_account_deletion_request_path, as: :json
     end
 

--- a/test/jobs/mail_delivery_job_test.rb
+++ b/test/jobs/mail_delivery_job_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class MailDeliveryJobTest < ActiveJob::TestCase
+  test "is configured as ActionMailer's delivery job" do
+    assert_equal MailDeliveryJob, ActionMailer::Base.delivery_job
+  end
+
+  test "retries on Aws::Errors::MissingCredentialsError instead of failing" do
+    user = create(:user)
+    OnboardingMailer.stubs(:community).raises(Aws::Errors::MissingCredentialsError)
+
+    assert_enqueued_with(job: MailDeliveryJob) do
+      MailDeliveryJob.perform_now("OnboardingMailer", "community", "deliver_now", args: [user])
+    end
+  end
+
+  test "does not retry other errors" do
+    user = create(:user)
+    OnboardingMailer.stubs(:community).raises(RuntimeError, "boom")
+
+    assert_no_enqueued_jobs do
+      assert_raises(RuntimeError) do
+        MailDeliveryJob.perform_now("OnboardingMailer", "community", "deliver_now", args: [user])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes Sentry [JIKI-API-N](https://thalamus-ai.sentry.io/issues/JIKI-API-N) (`Aws::Errors::MissingCredentialsError` in `ActionMailer::MailDeliveryJob`, 79 events over 18 days — ~4 emails/day permanently dropped). GitHub mirror: #497.

## The bug

On ECS, the AWS SDK fetches task-role credentials from the container metadata endpoint per client construction, and the `aws-actionmailer-ses` gem builds a new SES client per message. When that fetch times out, the credential chain silently resolves to nil and the failure surfaces as `MissingCredentialsError` at request-signing time. `ActionMailer::MailDeliveryJob` inherits `ActiveJob::Base`, not `ApplicationJob`, so it gets no `retry_on`: the job fails once into Solid Queue's failed executions and the email is never sent.

## The fix

A `MailDeliveryJob` subclass (wired via `config.action_mailer.delivery_job`) that retries **only** `Aws::Errors::MissingCredentialsError`.

## Why this cannot double-send

Request signing happens strictly *before* any HTTP call to SES, so when this error raises, no request has left the box — retrying is provably safe. Other errors (network timeouts, generic `StandardError`) are deliberately **not** retried: those can fire *after* SES has accepted the message, and a retry would send the email twice. Everything else keeps today's fail-into-failed-executions behavior.

## Recovery of already-dropped emails

The ~79 failed jobs are still in `solid_queue_failed_executions` and can be manually retried to send the dropped emails (mostly `OnboardingMailer`). Worth doing after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)