### PR TITLE
Return 422 instead of 500 for invalid streaks enabled param

### DIFF
--- a/app/commands/user/update_streaks_enabled.rb
+++ b/app/commands/user/update_streaks_enabled.rb
@@ -5,7 +5,18 @@ class User
     initialize_with :user, :enabled
 
     def call
-      user.data.update!(streaks_enabled: enabled)
+      user.data.update!(streaks_enabled: enabled?)
+    end
+
+    private
+    # The column is NOT NULL, so writing the raw param straight through 500s
+    # on a missing/null value (Sentry JIKI-API-R). Cast Rails-style and
+    # reject anything that casts to nil so the controller can 422 instead.
+    def enabled?
+      value = ActiveModel::Type::Boolean.new.cast(enabled)
+      raise InvalidBooleanError if value.nil?
+
+      value
     end
   end
 end

--- a/app/controllers/internal/settings_controller.rb
+++ b/app/controllers/internal/settings_controller.rb
@@ -53,6 +53,8 @@ class Internal::SettingsController < Internal::BaseController
   def streaks
     User::UpdateStreaksEnabled.(current_user, params[:enabled])
     render json: { settings: SerializeSettings.(current_user) }
+  rescue InvalidBooleanError
+    render_422(:streaks_update_failed, errors: { enabled: ["must be true or false"] })
   rescue ActiveRecord::RecordInvalid => e
     render_422(:streaks_update_failed, errors: e.record.errors.as_json)
   end

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -52,6 +52,7 @@ class BadgeCriteriaNotFulfilledError < RuntimeError; end
 
 # Settings errors
 class InvalidNotificationSlugError < RuntimeError; end
+class InvalidBooleanError < RuntimeError; end
 
 # Assistant conversation errors
 class AssistantConversationAccessDeniedError < RuntimeError; end

--- a/test/commands/user/update_streaks_enabled_test.rb
+++ b/test/commands/user/update_streaks_enabled_test.rb
@@ -18,4 +18,32 @@ class User::UpdateStreaksEnabledTest < ActiveSupport::TestCase
 
     refute user.data.reload.streaks_enabled
   end
+
+  test "casts string values" do
+    user = create(:user)
+
+    User::UpdateStreaksEnabled.(user, "true")
+    assert user.data.reload.streaks_enabled
+
+    User::UpdateStreaksEnabled.(user, "false")
+    refute user.data.reload.streaks_enabled
+  end
+
+  test "raises InvalidBooleanError for nil" do
+    user = create(:user)
+
+    assert_raises(InvalidBooleanError) do
+      User::UpdateStreaksEnabled.(user, nil)
+    end
+
+    refute user.data.reload.streaks_enabled
+  end
+
+  test "raises InvalidBooleanError for empty string" do
+    user = create(:user)
+
+    assert_raises(InvalidBooleanError) do
+      User::UpdateStreaksEnabled.(user, "")
+    end
+  end
 end

--- a/test/commands/user/update_streaks_enabled_test.rb
+++ b/test/commands/user/update_streaks_enabled_test.rb
@@ -27,6 +27,12 @@ class User::UpdateStreaksEnabledTest < ActiveSupport::TestCase
 
     User::UpdateStreaksEnabled.(user, "false")
     refute user.data.reload.streaks_enabled
+
+    User::UpdateStreaksEnabled.(user, "1")
+    assert user.data.reload.streaks_enabled
+
+    User::UpdateStreaksEnabled.(user, "0")
+    refute user.data.reload.streaks_enabled
   end
 
   test "raises InvalidBooleanError for nil" do

--- a/test/controllers/internal/settings_controller_test.rb
+++ b/test/controllers/internal/settings_controller_test.rb
@@ -137,6 +137,8 @@ class Internal::SettingsControllerTest < ApplicationControllerTest
     )
 
     patch locale_internal_settings_path, params: { value: "invalid" }, as: :json
+
+    assert_response :unprocessable_entity
   end
 
   # Handle tests

--- a/test/controllers/internal/settings_controller_test.rb
+++ b/test/controllers/internal/settings_controller_test.rb
@@ -137,8 +137,6 @@ class Internal::SettingsControllerTest < ApplicationControllerTest
     )
 
     patch locale_internal_settings_path, params: { value: "invalid" }, as: :json
-
-    assert_response :unprocessable_entity
   end
 
   # Handle tests
@@ -198,5 +196,17 @@ class Internal::SettingsControllerTest < ApplicationControllerTest
 
     json = response.parsed_body
     refute json["settings"]["streaks_enabled"]
+  end
+
+  test "PATCH streaks returns 422 when enabled is missing" do
+    patch streaks_internal_settings_path, params: {}, as: :json
+
+    assert_json_error(:unprocessable_entity, error_type: :streaks_update_failed, errors: { enabled: ["must be true or false"] })
+  end
+
+  test "PATCH streaks returns 422 when enabled is null" do
+    patch streaks_internal_settings_path, params: { enabled: nil }, as: :json
+
+    assert_json_error(:unprocessable_entity, error_type: :streaks_update_failed, errors: { enabled: ["must be true or false"] })
   end
 end


### PR DESCRIPTION
Fixes Sentry [JIKI-API-R](https://thalamus-ai.sentry.io/issues/JIKI-API-R) (`ActiveRecord::NotNullViolation` on `user_data.streaks_enabled` from `internal/settings#streaks`). GitHub mirror: #531.

## The bug

`Internal::SettingsController#streaks` passed `params[:enabled]` straight into `User::UpdateStreaksEnabled`, which wrote it directly to the NOT NULL `streaks_enabled` column. A request with a missing or null `enabled` (malformed/hand-crafted — the front-end always sends a boolean) hit Postgres with nil and 500'd, since `NotNullViolation` isn't covered by the controller's `RecordInvalid` rescue.

## The fix

The command casts with `ActiveModel::Type::Boolean` (accepting string forms like `"true"`/`"false"`) and raises `InvalidBooleanError` when the value casts to nil; the controller maps that to a 422 with `streaks_update_failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)