### PR TITLE
Enforce within-level lesson ordering when starting a lesson

### DIFF
--- a/app/commands/user_lesson/start.rb
+++ b/app/commands/user_lesson/start.rb
@@ -49,6 +49,14 @@ class UserLesson::Start
       raise LessonInProgressError, "Complete current lesson before starting a new one"
     end
 
+    # Enforce within-level ordering: a lesson may only start once every
+    # lesson before it in its level is complete. Without this, a deep link
+    # into a later lesson's page (or a code submission to it, which
+    # auto-starts) silently skips the user ahead in the gap between
+    # completing one lesson and starting the next — wedging their dashboard
+    # and making the advertised frontier lesson 422 (Sentry JIKI-API-S).
+    raise LessonNotUnlockedError, "Complete earlier lessons in this level first" unless earlier_lessons_complete?
+
     # Check if trying to start lesson in a different level.
     #
     # This deliberately only blocks when the current level's lessons are ALL
@@ -63,6 +71,13 @@ class UserLesson::Start
     return unless all_lessons_complete?(current_level)
 
     raise LevelNotCompletedError, "Complete the current level before starting lessons in the next level"
+  end
+
+  def earlier_lessons_complete?
+    lesson.level.lessons.
+      where(position: ...lesson.position).
+      where.not(id: UserLesson.where(user:).completed.select(:lesson_id)).
+      none?
   end
 
   def all_lessons_complete?(level)

--- a/app/controllers/internal/exercise_submissions_controller.rb
+++ b/app/controllers/internal/exercise_submissions_controller.rb
@@ -7,6 +7,7 @@ class Internal::ExerciseSubmissionsController < Internal::BaseController
   rescue_from InvalidSubmissionError, with: :render_invalid_submission_error
   rescue_from UserLevelNotFoundError, with: :render_level_not_found_error
   rescue_from LessonInProgressError, with: :render_lesson_in_progress_error
+  rescue_from LessonNotUnlockedError, with: :render_lesson_not_unlocked_error
   rescue_from LevelNotCompletedError, with: :render_level_not_completed_error
 
   def latest
@@ -92,6 +93,15 @@ class Internal::ExerciseSubmissionsController < Internal::BaseController
     render json: {
       error: {
         type: "lesson_in_progress",
+        message: exception.message
+      }
+    }, status: :forbidden
+  end
+
+  def render_lesson_not_unlocked_error(exception)
+    render json: {
+      error: {
+        type: "lesson_not_unlocked",
         message: exception.message
       }
     }, status: :forbidden

--- a/app/controllers/internal/user_lessons_controller.rb
+++ b/app/controllers/internal/user_lessons_controller.rb
@@ -19,6 +19,8 @@ class Internal::UserLessonsController < Internal::BaseController
     }
   rescue LessonInProgressError
     render_422(:lesson_in_progress)
+  rescue LessonNotUnlockedError
+    render_422(:lesson_not_unlocked)
   rescue UserLevelNotFoundError
     render_403(:user_level_not_found)
   rescue LevelNotCompletedError
@@ -35,6 +37,8 @@ class Internal::UserLessonsController < Internal::BaseController
     render_422(:user_level_not_found)
   rescue LessonInProgressError
     render_422(:lesson_in_progress)
+  rescue LessonNotUnlockedError
+    render_422(:lesson_not_unlocked)
   end
 
   def rate

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -44,6 +44,7 @@ class InvalidLanguageError < RuntimeError; end
 class UserLevelNotFoundError < RuntimeError; end
 class UserLessonNotFoundError < RuntimeError; end
 class LessonInProgressError < RuntimeError; end
+class LessonNotUnlockedError < RuntimeError; end
 class LevelNotCompletedError < RuntimeError; end
 class ChallengeLockedError < RuntimeError; end
 

--- a/config/locales/api_errors.en.yml
+++ b/config/locales/api_errors.en.yml
@@ -43,6 +43,7 @@ en:
 
     # User progression errors
     lesson_in_progress: "Complete current lesson before starting a new one"
+    lesson_not_unlocked: "Complete earlier lessons in this level first"
     level_not_completed: "Complete the current level first"
     challenge_locked: "Complete the lesson that unlocks this challenge first"
     user_lesson_not_found: "User lesson not found"

--- a/test/commands/user_lesson/start_test.rb
+++ b/test/commands/user_lesson/start_test.rb
@@ -103,6 +103,30 @@ class UserLesson::StartTest < ActiveSupport::TestCase
     assert_equal "Complete current lesson before starting a new one", error.message
   end
 
+  test "raises LessonNotUnlockedError when skipping an unstarted earlier lesson" do
+    user_level = create(:user_level)
+    create(:lesson, :exercise, level: user_level.level)
+    lesson2 = create(:lesson, :exercise, level: user_level.level)
+
+    error = assert_raises(LessonNotUnlockedError) do
+      UserLesson::Start.(user_level.user, lesson2)
+    end
+
+    assert_equal "Complete earlier lessons in this level first", error.message
+  end
+
+  test "raises LessonNotUnlockedError when an earlier lesson is started but incomplete" do
+    user_level = create(:user_level)
+    lesson1 = create(:lesson, :exercise, level: user_level.level)
+    lesson2 = create(:lesson, :exercise, level: user_level.level)
+    create(:user_lesson, user: user_level.user, lesson: lesson1, completed_at: nil)
+    user_level.update!(current_user_lesson: nil)
+
+    assert_raises(LessonNotUnlockedError) do
+      UserLesson::Start.(user_level.user, lesson2)
+    end
+  end
+
   test "allows starting new lesson when previous is completed" do
     user_level = create(:user_level)
     lesson1 = create(:lesson, :exercise, level: user_level.level)

--- a/test/controllers/internal/exercise_submissions_controller_test.rb
+++ b/test/controllers/internal/exercise_submissions_controller_test.rb
@@ -246,4 +246,16 @@ class Internal::ExerciseSubmissionsControllerTest < ApplicationControllerTest
     assert_equal "invalid_submission", json_response["error"]["type"]
     assert_match(/code.*required/i, json_response["error"]["message"])
   end
+
+  test "POST create returns 403 when the lesson is not unlocked" do
+    lesson2 = create(:lesson, :exercise, level: @level)
+    files = [{ filename: "main.rb", code: "puts 'hello'" }]
+
+    post internal_lesson_exercise_submissions_path(lesson_slug: lesson2.slug),
+      params: { submission: { files: } },
+      as: :json
+
+    assert_response :forbidden
+    assert_equal "lesson_not_unlocked", response.parsed_body["error"]["type"]
+  end
 end

--- a/test/controllers/internal/user_lessons_controller_test.rb
+++ b/test/controllers/internal/user_lessons_controller_test.rb
@@ -343,6 +343,15 @@ class Internal::UserLessonsControllerTest < ApplicationControllerTest
   end
 
   # Error handler tests
+  test "POST start returns 422 when earlier lessons are not complete" do
+    lesson2 = create(:lesson, :exercise, level: @level)
+
+    post start_internal_user_lesson_path(lesson_slug: lesson2.slug),
+      as: :json
+
+    assert_json_error(:unprocessable_entity, error_type: :lesson_not_unlocked)
+  end
+
   test "POST start returns 422 when lesson in progress" do
     lesson1 = create(:lesson, :exercise, level: @level)
     lesson2 = create(:lesson, :exercise, level: @level)


### PR DESCRIPTION
Closes the server-side hole behind Sentry [JIKI-API-S](https://thalamus-ai.sentry.io/issues/JIKI-API-S) (422 `lesson_in_progress`, 2 users so far). GitHub mirror: #538.

## The hole

`UserLesson::Start` had no within-level position check — only an "is a different lesson in progress" check and a cross-level guard. But `UserLesson::Complete` clears `current_user_lesson`, so in the gap between completing one lesson and starting the next, **any** unstarted lesson in the level could be started. Two front-end paths exploit this unintentionally:

- The lesson page (`Lesson.tsx`) unconditionally calls `startLesson` on mount for any slug — so a bookmark, synced-history, or shared deep link into a later lesson silently skips the user ahead.
- Submitting code to a lesson auto-starts it (`ExerciseSubmissionsController#create`) with the same lack of ordering.

Once skipped ahead, the user's dashboard wedges (the serializer suppresses the frontier while the skipped-ahead lesson is incomplete) and starting the previously-advertised frontier lesson 422s — the exact Sentry events. Verified empirically with a probe test before writing the fix: complete lesson 1 → `Start.(user, lesson3)` succeeded and made lesson 3 current → `Start.(user, lesson2)` raised `LessonInProgressError`.

## The fix

`UserLesson::Start` raises the new `LessonNotUnlockedError` unless every lesson positioned before the target in its level is complete. Controllers map it following their existing conventions: 422 `lesson_not_unlocked` from `user_lessons#start`/`#complete`, 403 from exercise submissions.

Unaffected: starting the frontier lesson, replaying completed lessons (idempotent short-circuit runs before validation), and users already stranded in a skipped-ahead state — their in-progress lesson has a row, so they can finish it and recover naturally.

## Note for the front-end

Deep links into locked lessons now get a clean 422/403 instead of silently skipping. The lesson page currently renders these as a raw error screen — the planned follow-up in the front-end repo is to treat `lesson_in_progress`/`lesson_not_unlocked` as a redirect-to-dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)