### PR TITLE
Allow staging.jiki.io origin in CORS

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,10 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins Jiki.config.frontend_base_url, Jiki.config.admin_base_url, "ihid.ngrok.dev"
+    # staging.jiki.io is a second frontend deployment that talks to this same
+    # (production) API from the browser, so its origin must be allowed alongside
+    # the canonical frontend_base_url (https://jiki.io).
+    origins Jiki.config.frontend_base_url, Jiki.config.admin_base_url, "https://staging.jiki.io", "ihid.ngrok.dev"
 
     resource "*",
       headers: :any,


### PR DESCRIPTION
## What

Adds `https://staging.jiki.io` to the CORS allowed origins in `config/initializers/cors.rb`.

## Why

`staging.jiki.io` is a new second deployment of the frontend (the `jiki-app-staging` Cloudflare Worker) that intentionally talks to **this same production API** from the browser, sharing the `.jiki.io` auth cookie. Because the CORS allowlist only contained the canonical `frontend_base_url` (`https://jiki.io`), every credentialed cross-origin request from staging (e.g. `GET /internal/me`) was being preflight-rejected:

```
Access to fetch at 'https://api.jiki.io/internal/me' from origin 'https://staging.jiki.io'
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present
```

## Approach

`frontend_base_url` is left untouched — it's `https://jiki.io` and is used for mailer links, OAuth redirect URIs, etc., which must stay pointing at production. This just adds the staging origin alongside it, mirroring the existing hardcoded `"ihid.ngrok.dev"` entry.

Since `credentials: true`, rack-cors echoes the specific matched origin, so listing staging explicitly is exactly what's needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)