### PR TITLE
Also retry mail delivery on SES ExpiredTokenException

### DIFF
--- a/app/jobs/mail_delivery_job.rb
+++ b/app/jobs/mail_delivery_job.rb
@@ -2,14 +2,19 @@
 # ApplicationJob, so it gets no retries: a single transient failure leaves the
 # email permanently in Solid Queue's failed executions, unsent.
 #
-# On ECS, the SDK's credential fetch from the container metadata endpoint
-# occasionally times out, surfacing as MissingCredentialsError when the SES
-# request is signed. Signing happens strictly BEFORE any HTTP call to SES, so
-# retrying this error can never double-send an email.
+# On ECS, the task's credentials occasionally go stale, surfacing as one of:
+# - MissingCredentialsError: the credential fetch from the container metadata
+#   endpoint timed out, caught when the SES request is signed — strictly
+#   BEFORE any HTTP call to SES (Sentry JIKI-API-N).
+# - SESV2 ExpiredTokenException: the worker signed with credentials past
+#   expiry and SES rejected the request at auth — an auth rejection happens
+#   before SES accepts the message, so the email was not sent (JIKI-API-T).
 #
-# Do NOT broaden this to other errors (e.g. network timeouts, generic
-# StandardError): those can fire AFTER SES has accepted the message, and a
-# retry would send the email twice.
+# In both cases no email can have been sent, so retrying can never
+# double-send. Do NOT broaden this to other errors (e.g. network timeouts,
+# generic StandardError): those can fire AFTER SES has accepted the message,
+# and a retry would send the email twice.
 class MailDeliveryJob < ActionMailer::MailDeliveryJob
   retry_on Aws::Errors::MissingCredentialsError, wait: :polynomially_longer, attempts: 10
+  retry_on Aws::SESV2::Errors::ExpiredTokenException, wait: :polynomially_longer, attempts: 10
 end

--- a/test/jobs/mail_delivery_job_test.rb
+++ b/test/jobs/mail_delivery_job_test.rb
@@ -14,6 +14,17 @@ class MailDeliveryJobTest < ActiveJob::TestCase
     end
   end
 
+  test "retries on Aws::SESV2::Errors::ExpiredTokenException instead of failing" do
+    user = create(:user)
+    OnboardingMailer.stubs(:community).raises(
+      Aws::SESV2::Errors::ExpiredTokenException.new(nil, "The security token included in the request is expired")
+    )
+
+    assert_enqueued_with(job: MailDeliveryJob) do
+      MailDeliveryJob.perform_now("OnboardingMailer", "community", "deliver_now", args: [user])
+    end
+  end
+
   test "does not retry other errors" do
     user = create(:user)
     OnboardingMailer.stubs(:community).raises(RuntimeError, "boom")


### PR DESCRIPTION
Fixes Sentry [JIKI-API-T](https://thalamus-ai.sentry.io/issues/JIKI-API-T) (4 events, 2026-07-18, e.g. `ProgressionMailer.level_completed`). GitHub mirror: #544.

Same underlying cause as JIKI-API-N (#540): stale ECS task credentials. That fix covered `MissingCredentialsError` (no credentials at signing time); this covers the sibling symptom — the worker signs with credentials past expiry and **SES rejects the request at auth** with `ExpiredTokenException`. Our `retry_on` didn't match it, so those 4 emails failed permanently into `solid_queue_failed_executions`.

**Why retrying cannot double-send:** the stacktrace shows the error raised from SES's error *response* (`raise response.error`) — an auth rejection, issued before SES accepts the message. Nothing was sent, so a retry is provably safe. The deliberate exclusion of ambiguous errors (network timeouts etc., which can fire after acceptance) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)