### PR TITLE
Add Hungarian premium mailer translations

### DIFF
--- a/config/locales/mailers/premium_mailer.hu.yml
+++ b/config/locales/mailers/premium_mailer.hu.yml
@@ -10,7 +10,7 @@ hu:
 
         Ha bármilyen kérdésed van, csak válaszolj erre az e-mailre.
 
-        Üdv,
+        Üdv,  
         Jeremy és a csapat
     subscription_ended:
       subject: "A Jiki előfizetésed véget ért"
@@ -22,5 +22,5 @@ hu:
 
         Köszönjük, hogy kipróbáltad a Jiki Premiumot.
 
-        Üdv,
+        Üdv,  
         Jeremy és a csapat

--- a/config/locales/mailers/premium_mailer.hu.yml
+++ b/config/locales/mailers/premium_mailer.hu.yml
@@ -1,0 +1,26 @@
+hu:
+  premium_mailer:
+    welcome_to_premium:
+      subject: "Üdvözlünk a Jiki Premiumban!"
+      greeting: "Szia,"
+      body_markdown: |
+        Köszönjük, hogy előfizettél a Jiki Premiumra!
+
+        A [Premium oldalon](https://jiki.io/premium) megnézheted az összes funkciót, amihez hozzáférsz. Reméljük, rengeteg örömöd lelsz a Jiki használatában, és hamarosan látunk egy élő adásban!
+
+        Ha bármilyen kérdésed van, csak válaszolj erre az e-mailre.
+
+        Üdv,
+        Jeremy és a csapat
+    subscription_ended:
+      subject: "A Jiki előfizetésed véget ért"
+      greeting: "Szia,"
+      body_markdown: |
+        A Jiki Premium előfizetésed véget ért, és mostantól az ingyenes csomagunkat használod.
+
+        Továbbra is teljes hozzáférésed van a teljes Tanulj programozni szekciónkhoz. Ha szeretnél újra előfizetni, azt bármikor megteheted a [beállítások oldaladon](https://jiki.io/settings).
+
+        Köszönjük, hogy kipróbáltad a Jiki Premiumot.
+
+        Üdv,
+        Jeremy és a csapat

--- a/test/mailers/premium_mailer_test.rb
+++ b/test/mailers/premium_mailer_test.rb
@@ -17,6 +17,21 @@ class PremiumMailerTest < ActionMailer::TestCase
     assert_match "Thank you for subscribing to Jiki Premium", mail.text_part.body.to_s
   end
 
+  test "welcome_to_premium email renders with Hungarian locale" do
+    user = create(:user, :hungarian, name: "János Kovács")
+    mail = PremiumMailer.welcome_to_premium(user)
+
+    assert_equal "Üdvözlünk a Jiki Premiumban!", mail.subject
+    assert_equal ["hello@mail.jiki.io"], mail.from
+    assert_equal [user.email], mail.to
+
+    assert_match "Szia,", mail.html_part.body.to_s
+    assert_match "Köszönjük, hogy előfizettél a Jiki Premiumra", mail.html_part.body.to_s
+
+    assert_match "Szia,", mail.text_part.body.to_s
+    assert_match "Köszönjük, hogy előfizettél a Jiki Premiumra", mail.text_part.body.to_s
+  end
+
   test "welcome_to_premium email includes both HTML and text parts" do
     user = create(:user)
     mail = PremiumMailer.welcome_to_premium(user)
@@ -51,6 +66,21 @@ class PremiumMailerTest < ActionMailer::TestCase
 
     assert_match "Hi there,", mail.text_part.body.to_s
     assert_match "Your Jiki Premium subscription has ended", mail.text_part.body.to_s
+  end
+
+  test "subscription_ended email renders with Hungarian locale" do
+    user = create(:user, :hungarian, name: "János Kovács")
+    mail = PremiumMailer.subscription_ended(user)
+
+    assert_equal "A Jiki előfizetésed véget ért", mail.subject
+    assert_equal ["hello@mail.jiki.io"], mail.from
+    assert_equal [user.email], mail.to
+
+    assert_match "Szia,", mail.html_part.body.to_s
+    assert_match "A Jiki Premium előfizetésed véget ért", mail.html_part.body.to_s
+
+    assert_match "Szia,", mail.text_part.body.to_s
+    assert_match "A Jiki Premium előfizetésed véget ért", mail.text_part.body.to_s
   end
 
   test "subscription_ended email includes both HTML and text parts" do


### PR DESCRIPTION
Adds the missing `premium_mailer.hu.yml` — it was the only YAML-localized mailer without a Hungarian translation (account_mailer, devise_mailer, and onboarding_mailer all have both).

## What changed

- **`config/locales/mailers/premium_mailer.hu.yml`** — full key-tree parity with the en file, covering `welcome_to_premium` and `subscription_ended`. Tone and terminology match the existing hu mailer files (informal-but-polite "te" forms, "Szia," greeting, "Üdv, / Jeremy és a csapat" sign-off). Product names (`Jiki Premium`) are kept untranslated and URLs are left unchanged.
- **`test/mailers/premium_mailer_test.rb`** — adds Hungarian-locale rendering tests for both actions, following the pattern used by the account/onboarding mailer tests.

## Testing

`bin/rails test test/mailers/premium_mailer_test.rb` → 9 runs, 64 assertions, 0 failures. Full pre-commit suite (tests, rubocop, brakeman) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzdUrFppjKEVj8kvuiiJr2