### PR TITLE
Localize hardcoded English email chrome

### DIFF
--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -20,6 +20,7 @@ class NotificationsMailer < ApplicationMailer
     content = badge.content_for_locale(user.locale)
     @subject = content[:email_subject]
     @content_markdown = content[:email_content_markdown]
+    @badge_name = content[:name]
     @image_url = badge.email_image_url
     @header_image = "badge-earned.jpg"
 

--- a/app/mailers/progression_mailer.rb
+++ b/app/mailers/progression_mailer.rb
@@ -18,6 +18,7 @@ class ProgressionMailer < ApplicationMailer
     content = @level.content_for_locale(@user.locale)
     @subject = content[:milestone_email_subject]
     @content_markdown = content[:milestone_email_content_markdown]
+    @level_title = content[:title]
     @image_url = @level.milestone_email_image_url
     @header_image = "milestone-#{(@level.position % 3) + 1}.jpg"
 

--- a/app/views/mailers/shared/_footer.mjml
+++ b/app/views/mailers/shared/_footer.mjml
@@ -1,5 +1,7 @@
 -# Email footer with branding and links
 -# Receives: user (required), unsubscribe_key (optional)
+- link_style = "color: #64748b; text-decoration: underline; font-weight: 500;"
+- jiki_link = link_to("Jiki", "https://jiki.io", style: link_style)
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-divider{ "border-color": "#e2e7ed", "border-width": "1px", "padding": "24px 0" }
@@ -7,13 +9,11 @@
 %mj-section{ "background-color": "#ffffff", "padding-bottom": "24px" }
   %mj-column
     %mj-text{ align: "center", "font-size": "14px", color: "#64748b" }
-      != 'You are receiving this email because you have an account at <a href="https://jiki.io" style="color: #64748b; text-decoration: underline; font-weight: 500;">Jiki</a>.'
+      != t("mailers.shared.footer.account_notice_html", jiki_link: jiki_link)
       - if user&.unsubscribe_token
-        Want to change how you receive these emails? You can
-        %a{ href: unsubscribe_url(token: user.unsubscribe_token), style: "color: #64748b; text-decoration: underline; font-weight: 500;" }
-          update your preferences
+        - preferences_link = link_to(t("mailers.shared.footer.update_preferences"), unsubscribe_url(token: user.unsubscribe_token), style: link_style)
         - if unsubscribe_key.present?
-          or
-          %a{ href: unsubscribe_url(token: user.unsubscribe_token, key: unsubscribe_key), style: "color: #64748b; text-decoration: underline; font-weight: 500;" }
-            unsubscribe
-          from this list.
+          - unsubscribe_link = link_to(t("mailers.shared.footer.unsubscribe"), unsubscribe_url(token: user.unsubscribe_token, key: unsubscribe_key), style: link_style)
+          != t("mailers.shared.footer.manage_with_unsubscribe_html", preferences_link: preferences_link, unsubscribe_link: unsubscribe_link)
+        - else
+          != t("mailers.shared.footer.manage_preferences_only_html", preferences_link: preferences_link)

--- a/app/views/notifications_mailer/badge_earned.mjml
+++ b/app/views/notifications_mailer/badge_earned.mjml
@@ -1,10 +1,10 @@
 - content_for :title, @subject
-- content_for :preview, "You've earned a new badge!"
+- content_for :preview, t("notifications_mailer.badge_earned.preview")
 
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     %mj-text
-      Hi there,
+      = t("notifications_mailer.badge_earned.greeting")
 
     - if @image_url.present?
       %mj-image{ src: @image_url, alt: @badge.name, width: "100%" }
@@ -12,6 +12,6 @@
     %mj-text
       = markdown_to_html(@content_markdown)
       %p
-        Cheers,
+        = t("notifications_mailer.badge_earned.signoff")
         %br
-        Jeremy &amp; Team
+        = t("notifications_mailer.badge_earned.team")

--- a/app/views/notifications_mailer/badge_earned.mjml
+++ b/app/views/notifications_mailer/badge_earned.mjml
@@ -7,7 +7,7 @@
       = t("notifications_mailer.badge_earned.greeting")
 
     - if @image_url.present?
-      %mj-image{ src: @image_url, alt: @badge.name, width: "100%" }
+      %mj-image{ src: @image_url, alt: @badge_name, width: "100%" }
 
     %mj-text
       = markdown_to_html(@content_markdown)

--- a/app/views/notifications_mailer/badge_earned.text.erb
+++ b/app/views/notifications_mailer/badge_earned.text.erb
@@ -1,6 +1,6 @@
-Hi there,
+<%= t("notifications_mailer.badge_earned.greeting") %>
 
 <%= markdown_to_text(@content_markdown) %>
 
-Cheers,
-Jeremy & Team
+<%= t("notifications_mailer.badge_earned.signoff") %>
+<%= t("notifications_mailer.badge_earned.team") %>

--- a/app/views/progression_mailer/level_completed.mjml
+++ b/app/views/progression_mailer/level_completed.mjml
@@ -1,15 +1,15 @@
 - content_for :title, @subject
-- content_for :preview, "You've completed #{@level.title}!"
+- content_for :preview, t("progression_mailer.level_completed.preview", level_title: @level_title)
 
 %mj-section{ "background-color": "#ffffff" }
   %mj-column
     - if @image_url.present?
-      %mj-image{ src: @image_url, alt: @level.title, width: "100%" }
+      %mj-image{ src: @image_url, alt: @level_title, width: "100%" }
 
     %mj-text
-      %p Hi there,
+      %p= t("progression_mailer.level_completed.greeting")
       = markdown_to_html(@content_markdown)
       %p
-        Cheers,
+        = t("progression_mailer.level_completed.signoff")
         %br
-        Jeremy &amp; Team
+        = t("progression_mailer.level_completed.team")

--- a/app/views/progression_mailer/level_completed.text.erb
+++ b/app/views/progression_mailer/level_completed.text.erb
@@ -1,6 +1,6 @@
-Hi there,
+<%= t("progression_mailer.level_completed.greeting") %>
 
 <%= markdown_to_text(@content_markdown) %>
 
-Cheers,
-Jeremy & Team
+<%= t("progression_mailer.level_completed.signoff") %>
+<%= t("progression_mailer.level_completed.team") %>

--- a/config/locales/mailers/notifications_mailer.en.yml
+++ b/config/locales/mailers/notifications_mailer.en.yml
@@ -1,0 +1,7 @@
+en:
+  notifications_mailer:
+    badge_earned:
+      preview: "You've earned a new badge!"
+      greeting: "Hi there,"
+      signoff: "Cheers,"
+      team: "Jeremy & Team"

--- a/config/locales/mailers/notifications_mailer.hu.yml
+++ b/config/locales/mailers/notifications_mailer.hu.yml
@@ -1,0 +1,7 @@
+hu:
+  notifications_mailer:
+    badge_earned:
+      preview: "Új jelvényt szereztél!"
+      greeting: "Szia,"
+      signoff: "Üdv,"
+      team: "Jeremy és a csapat"

--- a/config/locales/mailers/progression_mailer.en.yml
+++ b/config/locales/mailers/progression_mailer.en.yml
@@ -1,0 +1,7 @@
+en:
+  progression_mailer:
+    level_completed:
+      preview: "You've completed %{level_title}!"
+      greeting: "Hi there,"
+      signoff: "Cheers,"
+      team: "Jeremy & Team"

--- a/config/locales/mailers/progression_mailer.hu.yml
+++ b/config/locales/mailers/progression_mailer.hu.yml
@@ -1,0 +1,7 @@
+hu:
+  progression_mailer:
+    level_completed:
+      preview: "Teljesítetted ezt: %{level_title}!"
+      greeting: "Szia,"
+      signoff: "Üdv,"
+      team: "Jeremy és a csapat"

--- a/config/locales/mailers/shared.en.yml
+++ b/config/locales/mailers/shared.en.yml
@@ -1,0 +1,9 @@
+en:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "You are receiving this email because you have an account at %{jiki_link}."
+        manage_preferences_only_html: "Want to change how you receive these emails? You can %{preferences_link}"
+        manage_with_unsubscribe_html: "Want to change how you receive these emails? You can %{preferences_link} or %{unsubscribe_link} from this list."
+        update_preferences: "update your preferences"
+        unsubscribe: "unsubscribe"

--- a/config/locales/mailers/shared.hu.yml
+++ b/config/locales/mailers/shared.hu.yml
@@ -1,0 +1,9 @@
+hu:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Ezt az e-mailt azért kapod, mert van egy fiókod a %{jiki_link} oldalon."
+        manage_preferences_only_html: "Szeretnéd módosítani, hogyan kapod ezeket az e-maileket? Ezt megteheted itt: %{preferences_link}"
+        manage_with_unsubscribe_html: "Szeretnéd módosítani, hogyan kapod ezeket az e-maileket? %{preferences_link}, vagy %{unsubscribe_link} erről a listáról."
+        update_preferences: "módosítsd a beállításaidat"
+        unsubscribe: "iratkozz le"

--- a/test/mailers/notifications_mailer_test.rb
+++ b/test/mailers/notifications_mailer_test.rb
@@ -22,6 +22,49 @@ class NotificationsMailerTest < ActionMailer::TestCase
     assert mail.html_part.body.to_s.present?
   end
 
+  test "badge_earned renders English chrome and footer by default" do
+    mail = NotificationsMailer.badge_earned(@user, @badge)
+
+    html = mail.html_part.body.to_s
+    text = mail.text_part.body.to_s
+
+    # Greeting and sign-off
+    assert_match "Hi there,", html
+    assert_match "Cheers,", html
+    assert_match "Hi there,", text
+    assert_match "Jeremy & Team", text
+
+    # Preview
+    assert_match "You&#39;ve earned a new badge!", html
+
+    # Shared footer chrome
+    assert_match "You are receiving this email because you have an account at", html
+    assert_match "update your preferences", html
+    assert_match "unsubscribe", html
+  end
+
+  test "badge_earned renders Hungarian chrome and footer for hu user" do
+    user = create(:user, :hungarian)
+
+    mail = NotificationsMailer.badge_earned(user, @badge)
+
+    html = mail.html_part.body.to_s
+    text = mail.text_part.body.to_s
+
+    # Greeting and sign-off
+    assert_match "Szia,", html
+    assert_match "Üdv,", html
+    assert_match "Jeremy és a csapat", text
+
+    # Preview
+    assert_match "Új jelvényt szereztél!", html
+
+    # Shared footer chrome (Hungarian)
+    assert_match "Ezt az e-mailt azért kapod", html
+    assert_match "módosítsd a beállításaidat", html
+    assert_match "iratkozz le", html
+  end
+
   test "badge_earned sets @header_image to badge-earned.jpg" do
     mail = NotificationsMailer.badge_earned(@user, @badge)
 

--- a/test/mailers/progression_mailer_test.rb
+++ b/test/mailers/progression_mailer_test.rb
@@ -12,6 +12,56 @@ class ProgressionMailerTest < ActionMailer::TestCase
     assert mail.html_part.body.to_s.present?
   end
 
+  test "level_completed renders English chrome and footer by default" do
+    user = create(:user, locale: "en")
+    level = create(:level)
+
+    mail = ProgressionMailer.level_completed(UserLevel.new(user:, level:))
+
+    html = mail.html_part.body.to_s
+    text = mail.text_part.body.to_s
+
+    # Greeting and sign-off
+    assert_match "Hi there,", html
+    assert_match "Cheers,", html
+    assert_match "Hi there,", text
+    assert_match "Cheers,", text
+    assert_match "Jeremy & Team", text
+
+    # Preview uses the (English) level title
+    assert_match "completed #{level.title}!", html
+
+    # Shared footer chrome
+    assert_match "You are receiving this email because you have an account at", html
+    assert_match "update your preferences", html
+    assert_match "unsubscribe", html
+    assert_match "from this list.", html
+  end
+
+  test "level_completed renders Hungarian chrome, footer and localized title" do
+    user = create(:user, :hungarian)
+    level = create(:level, :with_translations)
+
+    mail = ProgressionMailer.level_completed(UserLevel.new(user:, level:))
+
+    html = mail.html_part.body.to_s
+    text = mail.text_part.body.to_s
+
+    # Greeting and sign-off
+    assert_match "Szia,", html
+    assert_match "Üdv,", html
+    assert_match "Szia,", text
+    assert_match "Jeremy és a csapat", text
+
+    # Preview uses the localized (Hungarian) level title
+    assert_match "Teljesítetted ezt: Magyar cím!", html
+
+    # Shared footer chrome (Hungarian)
+    assert_match "Ezt az e-mailt azért kapod", html
+    assert_match "módosítsd a beállításaidat", html
+    assert_match "iratkozz le", html
+  end
+
   test "level_completed sets @header_image based on level.position % 3" do
     user = create(:user)
     level = create(:level)


### PR DESCRIPTION
## What & why

Several mailer template strings were hardcoded English and shipped to every recipient regardless of `user.locale`, even though mailers already render inside `I18n.with_locale(user.locale)`. This extracts them all to `t()` lookups with new en + hu YAML under `config/locales/mailers/`, following the existing account/devise/onboarding pattern.

## Extracted strings

**Shared footer** (`mailers.shared.footer.*`, new `shared.{en,hu}.yml`)
- "You are receiving this email because you have an account at {Jiki}."
- "Want to change how you receive these emails? You can {update your preferences}" (preferences-only branch)
- "Want to change how you receive these emails? You can {update your preferences} or {unsubscribe} from this list." (with-unsubscribe branch)

Footer links are mid-sentence, so keys are full sentences with `%{...link}` HTML interpolation (`link_to` produces html_safe anchors) — Hungarian word order differs freely (the "or unsubscribe from this list" clause reorders naturally in hu). `unsubscribe_url` usage is unchanged.

**ProgressionMailer#level_completed** (`progression_mailer.{en,hu}.yml`)
- greeting "Hi there,", sign-off "Cheers," / "Jeremy & Team", preview "You've completed %{level_title}!"
- Preview now interpolates the **localized** level title (`content[:title]` from `content_for_locale`), assigned to `@level_title` in the mailer — previously it used the English `@level.title`.

**NotificationsMailer#badge_earned** (`notifications_mailer.{en,hu}.yml`)
- greeting, sign-off, preview "You've earned a new badge!"

DB-driven subject/body content is left untouched.

## Other hardcoded strings found

None beyond the listed ones. All other mailers (account, devise, onboarding, premium, mailshot) already use `t()` or render DB content. The header `alt="Jiki"` is a brand name; the text layout has no chrome.

Per task scope: did **not** add `premium_mailer.hu.yml` and did **not** touch URL construction/locale-prefixing (separate tasks).

## Verification

- Rendered both en and hu `level_completed` emails via `rails runner` and inspected the compiled HTML — MRML compiles cleanly, footer links embed mid-sentence with correct per-locale word order and properly escaped `&amp;` in unsubscribe URLs.
- Mailer suite: 65 runs, 322 assertions, 0 failures. Added en+hu chrome+footer assertions to the progression and badge tests (html + text parts).
- Full `bin/rails test` green under the pre-commit hook (rubocop + brakeman also passed).

## Notes for the broader Hungarian-enablement effort

- The i18n load path picks up nested `config/locales/mailers/*.yml` automatically.
- `content_for_locale` returns all translatable fields including `title`, so localized titles are available to mailers when a `*::Translation` row exists (falls back to English otherwise).
- Heads-up: the full parallel test suite intermittently hits `PG::TRDeadlockDetected` deadlocks (User::UpdateStreaksEnabled and friends) unrelated to this change; they pass in isolation / with `PARALLEL_WORKERS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzdUrFppjKEVj8kvuiiJr2