### PR TITLE
Silently drop exercise submissions identical to the previous one

### DIFF
--- a/app/commands/exercise_submission/create.rb
+++ b/app/commands/exercise_submission/create.rb
@@ -48,7 +48,7 @@ class ExerciseSubmission::Create
 
   memoize
   def previous_submission
-    context.exercise_submissions.includes(:files).order(id: :desc).first
+    context.exercise_submissions.order(id: :desc).first
   end
 
   def duplicate_of_previous?
@@ -58,7 +58,7 @@ class ExerciseSubmission::Create
     # a previous empty-string file's digest.
     return false if files.any? { |f| f[:code].nil? }
 
-    previous_submission.files.map { |f| [f.filename, f.digest] }.sort ==
+    previous_submission.files.pluck(:filename, :digest).sort ==
       files.map { |f| [f[:filename].to_s, ExerciseSubmission::File::GenerateDigest.(f[:code])] }.sort
   end
 

--- a/app/commands/exercise_submission/create.rb
+++ b/app/commands/exercise_submission/create.rb
@@ -8,6 +8,10 @@ class ExerciseSubmission::Create
     validate_file_count!
     validate_unique_filenames!
 
+    # Identical re-runs are common (the frontend submits on every test run),
+    # so silently return the previous submission rather than storing a copy.
+    return previous_submission if duplicate_of_previous?
+
     ActiveRecord::Base.transaction do
       ExerciseSubmission.create!(
         context:,
@@ -40,6 +44,21 @@ class ExerciseSubmission::Create
     duplicates = filenames.select { |fn| filenames.count(fn) > 1 }.uniq
 
     raise DuplicateFilenameError, "Duplicate filenames: #{duplicates.join(', ')}" if duplicates.any?
+  end
+
+  memoize
+  def previous_submission
+    context.exercise_submissions.includes(:files).order(id: :desc).first
+  end
+
+  def duplicate_of_previous?
+    return false unless previous_submission
+    # A nil code is invalid - let File::Create raise rather than matching
+    # a previous empty-string file's digest.
+    return false if files.any? { |f| f[:code].nil? }
+
+    previous_submission.files.map { |f| [f.filename, f.digest] }.sort ==
+      files.map { |f| [f[:filename].to_s, ExerciseSubmission::File::GenerateDigest.(f[:code])] }.sort
   end
 
   memoize

--- a/app/commands/exercise_submission/create.rb
+++ b/app/commands/exercise_submission/create.rb
@@ -53,6 +53,7 @@ class ExerciseSubmission::Create
 
   def duplicate_of_previous?
     return false unless previous_submission
+
     # A nil code is invalid - let File::Create raise rather than matching
     # a previous empty-string file's digest.
     return false if files.any? { |f| f[:code].nil? }

--- a/app/commands/exercise_submission/file/create.rb
+++ b/app/commands/exercise_submission/file/create.rb
@@ -41,5 +41,5 @@ class ExerciseSubmission::File::Create
   end
 
   memoize
-  def digest = XXhash.xxh64(sanitized_content).to_s
+  def digest = ExerciseSubmission::File::GenerateDigest.(content)
 end

--- a/app/commands/exercise_submission/file/generate_digest.rb
+++ b/app/commands/exercise_submission/file/generate_digest.rb
@@ -1,0 +1,13 @@
+class ExerciseSubmission::File::GenerateDigest
+  include Mandate
+
+  initialize_with :content
+
+  def call = XXhash.xxh64(sanitized_content).to_s
+
+  private
+  memoize
+  def sanitized_content
+    content.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
+  end
+end

--- a/test/commands/exercise_submission/create_test.rb
+++ b/test/commands/exercise_submission/create_test.rb
@@ -132,4 +132,46 @@ class ExerciseSubmission::CreateTest < ActiveSupport::TestCase
       assert_equal 20, submission.files.count
     end
   end
+
+  test "returns previous submission when files are identical" do
+    user_lesson = create(:user_lesson)
+    files = [{ filename: "main.rb", code: "puts 'hello'" }]
+
+    previous = ExerciseSubmission::Create.(user_lesson, files)
+
+    User::ActivityLog::LogActivity.expects(:call).never
+
+    assert_no_difference -> { ExerciseSubmission.count } do
+      assert_equal previous, ExerciseSubmission::Create.(user_lesson, files)
+    end
+  end
+
+  test "creates new submission when code differs from previous" do
+    user_lesson = create(:user_lesson)
+
+    previous = ExerciseSubmission::Create.(user_lesson, [{ filename: "main.rb", code: "puts 'hello'" }])
+    submission = ExerciseSubmission::Create.(user_lesson, [{ filename: "main.rb", code: "puts 'goodbye'" }])
+
+    refute_equal previous, submission
+    assert submission.persisted?
+  end
+
+  test "creates new submission when filename differs from previous" do
+    user_lesson = create(:user_lesson)
+
+    previous = ExerciseSubmission::Create.(user_lesson, [{ filename: "main.rb", code: "puts 'hello'" }])
+    submission = ExerciseSubmission::Create.(user_lesson, [{ filename: "other.rb", code: "puts 'hello'" }])
+
+    refute_equal previous, submission
+  end
+
+  test "nil code raises rather than deduplicating against a previous empty file" do
+    user_lesson = create(:user_lesson)
+
+    ExerciseSubmission::Create.(user_lesson, [{ filename: "main.rb", code: "" }])
+
+    assert_raises(InvalidSubmissionError) do
+      ExerciseSubmission::Create.(user_lesson, [{ filename: "main.rb", code: nil }])
+    end
+  end
 end

--- a/test/commands/exercise_submission/create_test.rb
+++ b/test/commands/exercise_submission/create_test.rb
@@ -165,6 +165,31 @@ class ExerciseSubmission::CreateTest < ActiveSupport::TestCase
     refute_equal previous, submission
   end
 
+  test "creates new submission when file count differs from previous" do
+    user_lesson = create(:user_lesson)
+    files = [
+      { filename: "main.rb", code: "puts 'hello'" },
+      { filename: "helper.rb", code: "def help\nend" }
+    ]
+
+    Prosopite.pause do
+      previous = ExerciseSubmission::Create.(user_lesson, files)
+      submission = ExerciseSubmission::Create.(user_lesson, files.take(1))
+
+      refute_equal previous, submission
+    end
+  end
+
+  test "nil filename raises rather than deduplicating" do
+    user_lesson = create(:user_lesson)
+
+    ExerciseSubmission::Create.(user_lesson, [{ filename: "main.rb", code: "puts 'hello'" }])
+
+    assert_raises(InvalidSubmissionError) do
+      ExerciseSubmission::Create.(user_lesson, [{ filename: nil, code: "puts 'hello'" }])
+    end
+  end
+
   test "nil code raises rather than deduplicating against a previous empty file" do
     user_lesson = create(:user_lesson)
 

--- a/test/commands/exercise_submission/file/generate_digest_test.rb
+++ b/test/commands/exercise_submission/file/generate_digest_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class ExerciseSubmission::File::GenerateDigestTest < ActiveSupport::TestCase
+  test "digests content" do
+    assert_equal XXhash.xxh64("puts 'hello'").to_s, ExerciseSubmission::File::GenerateDigest.("puts 'hello'")
+  end
+
+  test "digests empty string" do
+    assert_equal XXhash.xxh64("").to_s, ExerciseSubmission::File::GenerateDigest.("")
+  end
+
+  test "same content gives same digest" do
+    assert_equal ExerciseSubmission::File::GenerateDigest.("abc"), ExerciseSubmission::File::GenerateDigest.("abc")
+  end
+
+  test "different content gives different digest" do
+    refute_equal ExerciseSubmission::File::GenerateDigest.("abc"), ExerciseSubmission::File::GenerateDigest.("abd")
+  end
+
+  test "strips invalid UTF-8 bytes before digesting" do
+    invalid = "hello\xC3world".dup.force_encoding("UTF-8")
+    refute invalid.valid_encoding?
+
+    assert_equal XXhash.xxh64("helloworld").to_s, ExerciseSubmission::File::GenerateDigest.(invalid)
+  end
+end


### PR DESCRIPTION
## Context

The frontend submits code on every test run, and auto-run fires on editor changes — so identical re-runs are common, and each one stored a full new `ExerciseSubmission` row plus an ActiveStorage/S3 blob. The per-file `digest` column was computed and stored but never read.

## Change

`ExerciseSubmission::Create` now compares the incoming files' digests against the context's latest submission and silently returns that submission when they match — no new rows, no S3 upload, no activity log. Digest generation is extracted into `ExerciseSubmission::File::GenerateDigest` (same UTF-8 sanitisation as storage) so the comparison and storage paths can't drift.

Edge case: a `nil` code never dedupes (it would otherwise digest-match a previous empty-string file) — it falls through to `File::Create`'s validation and 422s as before. Empty-string code remains a valid, stored submission (it's a signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLQQyUCUYzHbAJAchmFDSa