### PR TITLE
Fall back to subscription metadata in SubscriptionCreated webhook

### DIFF
--- a/app/commands/stripe/webhook/subscription_created.rb
+++ b/app/commands/stripe/webhook/subscription_created.rb
@@ -12,6 +12,12 @@ class Stripe::Webhook::SubscriptionCreated
       return
     end
 
+    # Ensure the Stripe customer is linked. When we resolved the user via
+    # subscription metadata (because checkout.session.completed never set the
+    # customer id), link it now so future subscription.updated/deleted webhooks
+    # can find the user by customer id.
+    link_customer!
+
     # Sync subscription to user (handles both active and incomplete states)
     Stripe::SyncSubscriptionToUser.(user, subscription, interval)
 
@@ -22,9 +28,31 @@ class Stripe::Webhook::SubscriptionCreated
   memoize
   def subscription = event.data.object
 
+  # Resolve the user by Stripe customer id, falling back to the user_id we
+  # stamp into the subscription metadata at checkout. The fallback prevents a
+  # dropped or out-of-order checkout.session.completed webhook (which is what
+  # sets the customer id) from silently stranding a paid subscriber.
   memoize
   def user
+    user_from_customer || user_from_metadata
+  end
+
+  def user_from_customer
+    return nil if subscription.customer.blank?
+
     User.joins(:data).find_by(user_data: { stripe_customer_id: subscription.customer })
+  end
+
+  def user_from_metadata
+    user_id = subscription.metadata&.[](:user_id) || subscription.metadata&.[]('user_id')
+    user_id.present? ? User.find_by(id: user_id) : nil
+  end
+
+  def link_customer!
+    return if subscription.customer.blank?
+    return if user.data.stripe_customer_id.present?
+
+    user.data.update!(stripe_customer_id: subscription.customer)
   end
 
   memoize

--- a/test/commands/stripe/webhook/subscription_created_test.rb
+++ b/test/commands/stripe/webhook/subscription_created_test.rb
@@ -147,9 +147,10 @@ class Stripe::Webhook::SubscriptionCreatedTest < ActiveSupport::TestCase
     event = mock
     event.stubs(:data).returns(mock(object: subscription))
 
-    assert_nothing_raised do
-      Stripe::Webhook::SubscriptionCreated.(event)
-    end
+    # The subscription must be dropped, not synced to some arbitrary user.
+    Stripe::SyncSubscriptionToUser.expects(:call).never
+
+    Stripe::Webhook::SubscriptionCreated.(event)
   end
 
   private

--- a/test/commands/stripe/webhook/subscription_created_test.rb
+++ b/test/commands/stripe/webhook/subscription_created_test.rb
@@ -104,8 +104,56 @@ class Stripe::Webhook::SubscriptionCreatedTest < ActiveSupport::TestCase
     assert_equal "never_subscribed", user.data.subscription_status
   end
 
+  test "resolves user via subscription metadata when customer is not linked" do
+    # The user has no stripe_customer_id - e.g. checkout.session.completed was
+    # dropped or arrived after this event, so it never linked the customer.
+    user = create(:user)
+
+    event = mock_event(
+      price_id: Jiki.config.stripe_premium_monthly_price_id,
+      metadata: { user_id: user.id.to_s }
+    )
+
+    Stripe::Webhook::SubscriptionCreated.(event)
+
+    user.data.reload
+    assert user.premium?
+    assert_equal "active", user.data.subscription_status
+    # The customer id is backfilled so future webhooks can find the user by it.
+    assert_equal "cus_123", user.data.stripe_customer_id
+  end
+
+  test "prefers customer lookup over metadata" do
+    customer_user = create(:user)
+    customer_user.data.update!(stripe_customer_id: "cus_123")
+    metadata_user = create(:user)
+
+    # metadata is deliberately not stubbed: the customer lookup must win and
+    # short-circuit before metadata is ever read.
+    event = mock_event(price_id: Jiki.config.stripe_premium_monthly_price_id)
+
+    Stripe::Webhook::SubscriptionCreated.(event)
+
+    assert customer_user.data.reload.premium?
+    refute metadata_user.data.reload.premium?
+  end
+
+  test "does nothing when user cannot be found by customer or metadata" do
+    subscription = mock
+    subscription.stubs(:status).returns("active")
+    subscription.stubs(:customer).returns("cus_unknown")
+    subscription.stubs(:metadata).returns({})
+
+    event = mock
+    event.stubs(:data).returns(mock(object: subscription))
+
+    assert_nothing_raised do
+      Stripe::Webhook::SubscriptionCreated.(event)
+    end
+  end
+
   private
-  def mock_event(price_id:, status: "active", period_end: 1.month.from_now)
+  def mock_event(price_id:, status: "active", period_end: 1.month.from_now, customer: "cus_123", metadata: nil)
     price = mock
     price.stubs(:id).returns(price_id)
 
@@ -117,10 +165,13 @@ class Stripe::Webhook::SubscriptionCreatedTest < ActiveSupport::TestCase
     items.stubs(:data).returns([item])
 
     subscription = mock
-    subscription.stubs(:customer).returns("cus_123")
+    subscription.stubs(:customer).returns(customer)
     subscription.stubs(:id).returns("sub_123")
     subscription.stubs(:status).returns(status)
     subscription.stubs(:items).returns(items)
+    # Only stub metadata when the test exercises the fallback; strict Mocha
+    # errors on stubs that go unused when the customer lookup short-circuits.
+    subscription.stubs(:metadata).returns(metadata) unless metadata.nil?
 
     event = mock
     event.stubs(:data).returns(mock(object: subscription))


### PR DESCRIPTION
## Why

A support ticket (user *Animaashi*) reported paying for premium but having no access. Investigation found the user's Stripe subscription was **active and paid**, but their Jiki account was still `standard` with `stripe_customer_id = nil` — no webhook had linked them.

Root cause of the stranding: `Stripe::Webhook::SubscriptionCreated` resolves the user **only** by `stripe_customer_id`, which is written by the *separate* `checkout.session.completed` webhook (`CheckoutCompleted`). If that webhook is dropped or arrives **after** `customer.subscription.created`, `SubscriptionCreated` can't find the user, logs `"user not found for customer"`, and drops the event — leaving a paying customer on the free tier.

Notably `CheckoutCompleted` already guards against this by falling back to `session.metadata[:user_id]`; `SubscriptionCreated` had no such fallback, despite the subscription carrying the same `metadata[:user_id]` (stamped via `subscription_data.metadata` at checkout).

Scope of impact was small — 2 subscribers in the last 30 days (both already backfilled to premium out-of-band). This PR closes the gap so it can't recur.

## What

- `SubscriptionCreated` now resolves the user via `stripe_customer_id`, falling back to `subscription.metadata[:user_id]` — mirroring `CheckoutCompleted`.
- When resolved via metadata, it backfills `stripe_customer_id` so downstream `subscription.updated` / `subscription.deleted` webhooks can find the user by customer id.
- Tests: metadata-fallback path, customer-lookup-wins precedence, and the no-user no-op.

## Not included

- The two affected users were fixed directly against production (idempotent `SyncSubscriptionToUser` path, with welcome email/badge).
- The Stripe endpoint briefly showing `status=disabled` is being reviewed separately via the Stripe workbench delivery logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)