### PR TITLE
Add durationSeconds + uploadDate to concept video sources

### DIFF
--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -20,7 +20,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "IpNiHV5Pfz3QpaSbGmtdhUqo519FBcDDyGfb57tF902w"
+                "id": "IpNiHV5Pfz3QpaSbGmtdhUqo519FBcDDyGfb57tF902w",
+                "durationSeconds": 191,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -45,7 +47,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "CO5Cn701GibUya1wuoK01kUU01rw02taIYZEdmvFHZgIjRc"
+                "id": "CO5Cn701GibUya1wuoK01kUU01rw02taIYZEdmvFHZgIjRc",
+                "durationSeconds": 276,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -70,7 +74,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "mHahztg02TYzAve4qxUDkHYLnIrpLP948XMSuqYPqw8A"
+                "id": "mHahztg02TYzAve4qxUDkHYLnIrpLP948XMSuqYPqw8A",
+                "durationSeconds": 248,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -127,7 +133,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "saWa7N5mKY02ZwIjBcP5102bAGABwRJCaA7VacK543xuQ"
+                "id": "saWa7N5mKY02ZwIjBcP5102bAGABwRJCaA7VacK543xuQ",
+                "durationSeconds": 237,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -194,7 +202,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "wD902h8Md3cYuXUoh00P0201ZKDl1p02Lm7GHaMlDsJIoa00U"
+                "id": "wD902h8Md3cYuXUoh00P0201ZKDl1p02Lm7GHaMlDsJIoa00U",
+                "durationSeconds": 267,
+                "uploadDate": "2026-07-10"
               }
             ]
           }
@@ -251,7 +261,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "Y1yaGd5ht6qerPuy58TKkc8ZvF1pToLPkvvI9N5AI1c"
+                "id": "Y1yaGd5ht6qerPuy58TKkc8ZvF1pToLPkvvI9N5AI1c",
+                "durationSeconds": 352,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -286,7 +298,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "x01ttw78cvyX005yob02zuyUCQDTF86gXYjWi6Tz8GVcEk"
+                "id": "x01ttw78cvyX005yob02zuyUCQDTF86gXYjWi6Tz8GVcEk",
+                "durationSeconds": 273,
+                "uploadDate": "2026-06-06"
               }
             ]
           }
@@ -343,7 +357,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "iGgimCTqArVVXR7bYkQKL5Nv00c2S2FMpmWuIxtMBNnE"
+                "id": "iGgimCTqArVVXR7bYkQKL5Nv00c2S2FMpmWuIxtMBNnE",
+                "durationSeconds": 290,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -400,7 +416,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "HqCtx5KALIqtL02wSgOCy83zuqzycMR8oy01BdHCmVSGM"
+                "id": "HqCtx5KALIqtL02wSgOCy83zuqzycMR8oy01BdHCmVSGM",
+                "durationSeconds": 187,
+                "uploadDate": "2026-07-10"
               }
             ]
           }
@@ -435,7 +453,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "5X47O7800XWzyMa9ZUcjKtGzp19obzi5GLvUNS6cElwI"
+                "id": "5X47O7800XWzyMa9ZUcjKtGzp19obzi5GLvUNS6cElwI",
+                "durationSeconds": 402,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -460,7 +480,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "jrj3bpJNuNQ1tQkcHYduxbtSPSNK5D8jpDuahU00xWQ8"
+                "id": "jrj3bpJNuNQ1tQkcHYduxbtSPSNK5D8jpDuahU00xWQ8",
+                "durationSeconds": 194,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -485,7 +507,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "ExAsqyg2trGCVVEy4FQ9GaFRWXuJdlqhv4Om7K2027y8"
+                "id": "ExAsqyg2trGCVVEy4FQ9GaFRWXuJdlqhv4Om7K2027y8",
+                "durationSeconds": 142,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -510,7 +534,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "wKaRbHv02BFW700ExsghQ00vvD9DQrg01444YZsb6fSwvAs"
+                "id": "wKaRbHv02BFW700ExsghQ00vvD9DQrg01444YZsb6fSwvAs",
+                "durationSeconds": 257,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -545,7 +571,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "CJLyjszp2rtBJl8L3kntt602yNA3iVtrITEDF4ivd7ME"
+                "id": "CJLyjszp2rtBJl8L3kntt602yNA3iVtrITEDF4ivd7ME",
+                "durationSeconds": 158,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -590,7 +618,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "01fZExWLXQgcl4nFP1XShPBxtK00idlA00fnDxBzIm9Y02o"
+                "id": "01fZExWLXQgcl4nFP1XShPBxtK00idlA00fnDxBzIm9Y02o",
+                "durationSeconds": 263,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -627,7 +657,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "zcmxSxOKn9opIz1a5T00b8LRBIAoAZ8kxOBBZrxQS6uU"
+                "id": "zcmxSxOKn9opIz1a5T00b8LRBIAoAZ8kxOBBZrxQS6uU",
+                "durationSeconds": 256,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -662,7 +694,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "YtnDfhkfV7CstaiFhLMIaeYknAbWqIJ9FTn9FlMn700c"
+                "id": "YtnDfhkfV7CstaiFhLMIaeYknAbWqIJ9FTn9FlMn700c",
+                "durationSeconds": 256,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -709,7 +743,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "yjZUdaMolP7AvvLBWuyilzEDPwf5UcJVour0122tTWoM"
+                "id": "yjZUdaMolP7AvvLBWuyilzEDPwf5UcJVour0122tTWoM",
+                "durationSeconds": 201,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -754,7 +790,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "Px02iBHwKLMDkhRrMiwgdcjM00fVo6JVY5MgfwT4kU0000k"
+                "id": "Px02iBHwKLMDkhRrMiwgdcjM00fVo6JVY5MgfwT4kU0000k",
+                "durationSeconds": 312,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -789,7 +827,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "00CEptHgeayPLnkov5z7DJven01CbfGcEwAh8s02MLazjU"
+                "id": "00CEptHgeayPLnkov5z7DJven01CbfGcEwAh8s02MLazjU",
+                "durationSeconds": 123,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -826,7 +866,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "GprQMNbd7vE1AITiSyEFAcmiMMD6h200iy4fodZjD1zQ"
+                "id": "GprQMNbd7vE1AITiSyEFAcmiMMD6h200iy4fodZjD1zQ",
+                "durationSeconds": 156,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -873,7 +915,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "wAAkHJrzrZc97iirqkuhy3IGBftP6nMhSd8gyjqF3SA"
+                "id": "wAAkHJrzrZc97iirqkuhy3IGBftP6nMhSd8gyjqF3SA",
+                "durationSeconds": 219,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -908,7 +952,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "Iwn2PLYrpnbXeU5hNXebvbci2WOtuD9w1FhVs8wzgFo"
+                "id": "Iwn2PLYrpnbXeU5hNXebvbci2WOtuD9w1FhVs8wzgFo",
+                "durationSeconds": 213,
+                "uploadDate": "2026-07-10"
               }
             ]
           }
@@ -933,7 +979,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "HQ8t4J78TeM3BGzTMTm5CHiefqTUlv006hzXNg85AlMU"
+                "id": "HQ8t4J78TeM3BGzTMTm5CHiefqTUlv006hzXNg85AlMU",
+                "durationSeconds": 187,
+                "uploadDate": "2026-07-10"
               }
             ]
           }
@@ -1010,7 +1058,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "k895BIVPNi601prsiwe1Md2zaI01pxKlvD01DueWKdH7zA"
+                "id": "k895BIVPNi601prsiwe1Md2zaI01pxKlvD01DueWKdH7zA",
+                "durationSeconds": 213,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -1067,7 +1117,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "vmd93umP4AH1I1zdGR92w93eFC2XYgZVOBpRa5Ml5w4"
+                "id": "vmd93umP4AH1I1zdGR92w93eFC2XYgZVOBpRa5Ml5w4",
+                "durationSeconds": 146,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -1092,7 +1144,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "Sukf8Q003FG2KGq3WgQEhMqnNlieA9N02urIdqcZ8NTx00"
+                "id": "Sukf8Q003FG2KGq3WgQEhMqnNlieA9N02urIdqcZ8NTx00",
+                "durationSeconds": 208,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -1179,7 +1233,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "NgwMPFk02s9kmUe62iuosjWCu9MJ9J9sZKHRoDUd602MU"
+                "id": "NgwMPFk02s9kmUe62iuosjWCu9MJ9J9sZKHRoDUd602MU",
+                "durationSeconds": 298,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -1226,7 +1282,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "AzDWSOAgAsmfHGVXeGUlD01sY6VYlZ8icPvvRxBUqmF8"
+                "id": "AzDWSOAgAsmfHGVXeGUlD01sY6VYlZ8icPvvRxBUqmF8",
+                "durationSeconds": 214,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -1273,7 +1331,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "x001DHMg23ec02lexph9F102XiDD8Qu3LjdOPnie43aDLo"
+                "id": "x001DHMg23ec02lexph9F102XiDD8Qu3LjdOPnie43aDLo",
+                "durationSeconds": 314,
+                "uploadDate": "2026-06-11"
               }
             ]
           }
@@ -1320,7 +1380,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "crld00MTVkFCyPjeLB1oK4iz00BbUSyZLcWTKzCD01Mejs"
+                "id": "crld00MTVkFCyPjeLB1oK4iz00BbUSyZLcWTKzCD01Mejs",
+                "durationSeconds": 275,
+                "uploadDate": "2026-07-13"
               }
             ]
           }
@@ -1385,7 +1447,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "NauVD1prYbb01N9N02LCAHbrSkV8ziUs1AGST02dVM4IZU"
+                "id": "NauVD1prYbb01N9N02LCAHbrSkV8ziUs1AGST02dVM4IZU",
+                "durationSeconds": 92,
+                "uploadDate": "2026-07-12"
               }
             ]
           }
@@ -1482,7 +1546,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "CkkTxQwQH8LwilAQjWaYhJysSL02u3gRa8Ce01BrXGaFI"
+                "id": "CkkTxQwQH8LwilAQjWaYhJysSL02u3gRa8Ce01BrXGaFI",
+                "durationSeconds": 238,
+                "uploadDate": "2026-07-12"
               }
             ]
           }
@@ -1517,7 +1583,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "nneymd6yNj2Sjop1xvhQsIUq7RigZoDyr02OVJxF4lqQ"
+                "id": "nneymd6yNj2Sjop1xvhQsIUq7RigZoDyr02OVJxF4lqQ",
+                "durationSeconds": 170,
+                "uploadDate": "2026-07-13"
               }
             ]
           }

--- a/test/serializers/serialize_concept_test.rb
+++ b/test/serializers/serialize_concept_test.rb
@@ -18,6 +18,16 @@ class SerializeConceptTest < ActiveSupport::TestCase
     assert_equal video_sources, result[:video_data]
   end
 
+  test "video_data passes through duration and upload date when present" do
+    video_sources = [{ provider: "mux", id: "abc123", durationSeconds: 372, uploadDate: "2026-05-15" }]
+    lesson = create(:lesson, :video, data: { sources: video_sources })
+    concept = create(:concept, unlocked_by_lesson: lesson)
+
+    result = SerializeConcept.(concept)
+
+    assert_equal video_sources, result[:video_data]
+  end
+
   test "video_data is nil when no unlocked_by_lesson" do
     concept = create(:concept)
 


### PR DESCRIPTION
## Summary

Adds `durationSeconds` and `uploadDate` to each concept walkthrough video source in `db/seeds/curriculum.json` (34 sources, sourced from Mux).

The front-end wants to emit schema.org `VideoObject` JSON-LD on the external (public, SSR'd) concept pages so episode/concept videos get picked up by Google's video index. `VideoObject` requires `uploadDate` and wants `duration` — neither of which the API exposed.

These fields ride through the **existing** passthrough: `SerializeConcept` returns `concept.unlocked_by_lesson.data[:sources]` verbatim, and neither `validate_video_data!` nor the `has_video_data` concern strips extra keys. So this is a data-only change plus a test that locks in the passthrough — no serializer or schema change.

## Changes
- `db/seeds/curriculum.json` — `durationSeconds` + `uploadDate` on all 34 video sources (matched to Mux by playback id).
- `test/serializers/serialize_concept_test.rb` — asserts the new fields pass through in `video_data`.

## Test plan
- [x] `serialize_concept_test.rb` green (incl. new passthrough test)
- [x] `create_all_from_json_test.rb` green (imports the edited `curriculum.json`)
- [x] Full pre-commit suite (rubocop + tests + brakeman) green
- [ ] After deploy + `rails db:seed` sync, `GET /external/concepts/:slug` returns `video_data` entries with `durationSeconds`/`uploadDate`
