### PR TITLE
Document video-source metadata contract (durationSeconds + uploadDate)

### DIFF
--- a/app/models/concerns/has_video_data.rb
+++ b/app/models/concerns/has_video_data.rb
@@ -1,3 +1,10 @@
+# Video sources are `{ provider, id, durationSeconds, uploadDate }`.
+#
+# Every source MUST carry `durationSeconds` (integer) and `uploadDate` (ISO 8601
+# date) in addition to `provider` + `id` - not just concept walkthroughs. The
+# front-end relies on them to emit schema.org VideoObject JSON-LD (for Google
+# video indexing) on the public, server-rendered pages that show these videos, so
+# a source missing them is a broken source. Author them on every video source.
 module HasVideoData
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
Follow-up to #559. Documents on the `HasVideoData` concern that **every** video source must carry `durationSeconds` + `uploadDate` (not just concept walkthroughs), since the front-end emits schema.org `VideoObject` JSON-LD from video sources on public SSR pages and needs them for Google video indexing.

Comment-only — no behaviour change. (Happy to add validator enforcement in a follow-up if you want teeth on it.)

## Test plan
- [x] Full pre-commit suite (rubocop + tests + brakeman) green