### PR TITLE
Add mailshot segment for users who reached level 8 (Digital Clock)

### DIFF
--- a/app/models/mailshot.rb
+++ b/app/models/mailshot.rb
@@ -17,7 +17,11 @@ class Mailshot < ApplicationRecord
     "all_users" => -> { User.all },
     "premium_users" => -> { User.joins(:data).merge(User::Data.where(membership_type: "premium")) },
     "free_users" => -> { User.joins(:data).merge(User::Data.where(membership_type: "standard")) },
-    "admin_users" => -> { User.where(admin: true) }
+    "admin_users" => -> { User.where(admin: true) },
+    "completed_digital_clock" => lambda {
+      level = Level.find_by!(slug: "conditionals")
+      User.joins(:user_levels).merge(UserLevel.where(level:).where.not(completed_at: nil))
+    }
   }.freeze
 
   def ready_to_send? = body_markdown.present?

--- a/test/commands/mailshot/send_to_segment_test.rb
+++ b/test/commands/mailshot/send_to_segment_test.rb
@@ -35,6 +35,21 @@ class Mailshot::SendToSegmentTest < ActiveSupport::TestCase
     Mailshot::SendToSegment.(mailshot, "premium_users")
   end
 
+  test "only targets users who have completed Digital Clock (level 7, reaching level 8+)" do
+    level = create(:level, slug: "conditionals")
+    completed_user = create(:user)
+    create(:user_level, user: completed_user, level:, completed_at: Time.current)
+    incomplete_user = create(:user)
+    create(:user_level, user: incomplete_user, level:)
+    create(:user) # never started — must be excluded
+    mailshot = create(:mailshot)
+
+    User::Mailshot::Send.expects(:call).with(completed_user, mailshot).once
+    Mailshot::SendToSegment.stubs(:defer)
+
+    Mailshot::SendToSegment.(mailshot, "completed_digital_clock")
+  end
+
   test "stops without rescheduling when the batch is empty" do
     user = create(:user)
     mailshot = create(:mailshot)


### PR DESCRIPTION
## Summary
- Add a `completed_digital_clock` audience segment to `Mailshot::SEGMENTS`, targeting users who have completed the Conditionals level (level 7, whose final lesson is Digital Clock) and are therefore on level 8 or above.

## Test plan
- [x] `bin/rails test test/commands/mailshot/ test/models/mailshot_test.rb test/controllers/admin/mailshots_controller_test.rb`
- [x] Full pre-commit suite (tests, rubocop, brakeman)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNqdhA3hf6AajSHcHHqcnK