### PR TITLE
Make mailshot inline images responsive with max-width:100%

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -85,9 +85,13 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   private
-  # Convert markdown to HTML for email templates
+  # Convert markdown to HTML for email templates.
+  # Inline max-width is required because email clients ignore stylesheets,
+  # and markdown images (unlike mj-image) aren't made responsive by MJML.
   def markdown_to_html(markdown)
-    Commonmarker.to_html(markdown).html_safe
+    fragment = Nokogiri::HTML::DocumentFragment.parse(Commonmarker.to_html(markdown))
+    fragment.css('img').each { |img| img['style'] = 'max-width:100%;height:auto' }
+    fragment.to_html.html_safe
   end
 
   # Convert markdown to plain text for email templates

--- a/test/mailers/mailshot_mailer_test.rb
+++ b/test/mailers/mailshot_mailer_test.rb
@@ -15,6 +15,15 @@ class MailshotMailerTest < ActionMailer::TestCase
     assert_match "Heading", mail.text_part.body.to_s
   end
 
+  test "adds max-width:100% style to inline images in the body" do
+    user = create(:user)
+    mailshot = create(:mailshot, body_markdown: "![alt text](https://assets.jiki.io/static/emails/example.webp)")
+
+    html = MailshotMailer.send_mailshot(user, mailshot).html_part.body.to_s
+
+    assert_match '<img src="https://assets.jiki.io/static/emails/example.webp" alt="alt text" style="max-width:100%;height:auto" />', html
+  end
+
   test "uses preview_text as the preheader" do
     user = create(:user)
     mailshot = create(:mailshot, subject: "Monthly news", preview_text: "Three new exercises inside")


### PR DESCRIPTION
## Summary
- Mailshot bodies are user-authored markdown rendered to raw HTML via `markdown_to_html`. Unlike the fixed header/badge images (which use MJML's `mj-image`), these `<img>` tags weren't made responsive, so they could overflow narrow email clients.
- `markdown_to_html` now post-processes the rendered HTML with Nokogiri, adding `style="max-width:100%;height:auto"` to every `<img>` tag.
- The admin dashboard's mailshot preview reuses `MailshotMailer.send_mailshot` (via `Mailshot::RenderPreview`), so it picks up this fix automatically — no changes needed there.

## Test plan
- [x] Added a test in `test/mailers/mailshot_mailer_test.rb` asserting the style attribute is added to inline images
- [x] Full test suite, rubocop, and brakeman passed via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ur7t2Q3f51ypm6xzEcDbcv