### PR TITLE
Migrate parked users back onto multiple-functions level

### DIFF
--- a/db/migrate/20260726120000_migrate_users_back_to_multiple_functions.rb
+++ b/db/migrate/20260726120000_migrate_users_back_to_multiple_functions.rb
@@ -14,10 +14,15 @@ class MigrateUsersBackToMultipleFunctions < ActiveRecord::Migration[8.1]
   def up
     mf = Level.find_by(slug: "multiple-functions")
     mp = Level.find_by(slug: "methods-and-properties")
-    return unless mf && mp
-
     pangram = Lesson.find_by(slug: "pangram")
+
+    # Bail unless the curriculum is in the expected post-reseed state: `pangram`
+    # must exist (it's the reason for the pull-back). If this migration ever
+    # runs before the reseed, doing nothing is the safe outcome.
+    return unless mf && mp && pangram
+
     mp_exercise_lesson_ids = mp.lessons.where(type: "exercise").pluck(:id)
+    return unless mp_exercise_lesson_ids.any?
 
     UserCourse.joins(:current_user_level).
       where(user_levels: { level_id: mp.id }).
@@ -29,13 +34,13 @@ class MigrateUsersBackToMultipleFunctions < ActiveRecord::Migration[8.1]
       next unless mf_user_level&.completed_at
 
       # Skip anyone who has already engaged past the parked state.
-      next if pangram && UserLesson.exists?(user_id:, lesson_id: pangram.id)
-      next if mp_exercise_lesson_ids.any? && UserLesson.exists?(user_id:, lesson_id: mp_exercise_lesson_ids)
+      next if UserLesson.exists?(user_id:, lesson_id: pangram.id)
+      next if UserLesson.exists?(user_id:, lesson_id: mp_exercise_lesson_ids)
 
-      transaction do
-        mf_user_level.update!(completed_at: nil, current_user_lesson: nil)
-        user_course.update!(current_user_level: mf_user_level)
-      end
+      # The migration runs in a single transaction, so these two updates are
+      # already atomic together.
+      mf_user_level.update!(completed_at: nil, current_user_lesson: nil)
+      user_course.update!(current_user_level: mf_user_level)
     end
   end
 

--- a/db/migrate/20260726120000_migrate_users_back_to_multiple_functions.rb
+++ b/db/migrate/20260726120000_migrate_users_back_to_multiple_functions.rb
@@ -1,0 +1,47 @@
+class MigrateUsersBackToMultipleFunctions < ActiveRecord::Migration[8.1]
+  # The `pangram` exercise was moved to the end of `multiple-functions` (from
+  # the start of `methods-and-properties`). Some users had already "completed"
+  # `multiple-functions` and been advanced onto `methods-and-properties` as
+  # their active level without starting anything there, so their now-incomplete
+  # `multiple-functions` level (it has the unfinished `pangram` on it) is
+  # unreachable to them.
+  #
+  # Pull those users back onto `multiple-functions` as their active level so
+  # `pangram` becomes their frontier: un-complete the level and repoint the
+  # course's current level at it. Users who have already engaged past the
+  # parked state — started `pangram`, or started any `methods-and-properties`
+  # exercise — are left untouched.
+  def up
+    mf = Level.find_by(slug: "multiple-functions")
+    mp = Level.find_by(slug: "methods-and-properties")
+    return unless mf && mp
+
+    pangram = Lesson.find_by(slug: "pangram")
+    mp_exercise_lesson_ids = mp.lessons.where(type: "exercise").pluck(:id)
+
+    UserCourse.joins(:current_user_level).
+      where(user_levels: { level_id: mp.id }).
+      find_each do |user_course|
+      user_id = user_course.user_id
+
+      # Only users who actually finished multiple-functions.
+      mf_user_level = UserLevel.find_by(user_id:, level_id: mf.id)
+      next unless mf_user_level&.completed_at
+
+      # Skip anyone who has already engaged past the parked state.
+      next if pangram && UserLesson.exists?(user_id:, lesson_id: pangram.id)
+      next if mp_exercise_lesson_ids.any? && UserLesson.exists?(user_id:, lesson_id: mp_exercise_lesson_ids)
+
+      transaction do
+        mf_user_level.update!(completed_at: nil, current_user_lesson: nil)
+        user_course.update!(current_user_level: mf_user_level)
+      end
+    end
+  end
+
+  def down
+    # One-off correction of specific users' active-level pointers. The prior
+    # (broken) state carries no value and can't be reliably distinguished from
+    # legitimate state, so there is nothing safe to reverse.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_10_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_26_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -135,6 +135,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_120000) do
     t.bigint "context_id", null: false
     t.string "context_type", null: false
     t.datetime "created_at", null: false
+    t.jsonb "progression_scores"
     t.datetime "updated_at", null: false
     t.string "uuid", null: false
     t.index ["context_type", "context_id"], name: "index_exercise_submissions_on_context"
@@ -412,9 +413,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_120000) do
   end
 
   create_table "user_challenges", force: :cascade do |t|
+    t.bigint "challenge_id", null: false
     t.datetime "completed_at"
     t.datetime "created_at", null: false
-    t.bigint "challenge_id", null: false
     t.datetime "started_at"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false


### PR DESCRIPTION
## What

Data migration that pulls users back onto `multiple-functions` as their active level after #567 relocated the `pangram` exercise there.

**Affected user** (all must hold):
1. Active level (`user_course.current_user_level.level`) is `methods-and-properties`.
2. Their `multiple-functions` `UserLevel` is completed.
3. They have **not** started `pangram`.
4. They have **not** started any `methods-and-properties` exercise.

**Action per user:** null `completed_at` on their `multiple-functions` `UserLevel`, and repoint `user_course.current_user_level` back to it. `current_user_lesson` is left nil, so the newly-appended `pangram` becomes their frontier. The `methods-and-properties` `UserLevel` is left in place (harmless; `UserLevel::Complete → Start` is idempotent when they re-complete `multiple-functions`).

Naturally idempotent — once repointed, a user no longer matches the population.

## ⚠️ Deploy ordering — depends on #567

This must run **after** #567 is merged, deployed, **and reseeded in prod**, so that `pangram` is actually the last lesson of `multiple-functions` before this migration runs. Sequence:

1. Merge + deploy #567 → trigger admin reseed.
2. Then merge + deploy this PR (the migration runs automatically at deploy).

## Verification

Ran the real migration against constructed scenarios in a rolled-back transaction: an affected user (moved back + level un-completed), plus skip cases for started-pangram, started-a-methods-and-properties-exercise, and multiple-functions-not-completed. All behaved correctly; no records left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ja3ZbLrkfgKG3u3N4kHjB