### PR TITLE
Advance current_user_level even when next UserLevel already exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,15 @@ If you need to add a new config key, include a PR to the config gem (`../config`
 - **Never** use `RAILS_ENV=test` to run any database commands. If you encounter test database issues, ask the user what to do.
 - Rails handles the test DB automatically when running tests.
 
+### Curriculum changes
+
+Editing the lessons on a level that existing users have progressed through can wedge them (a `UserLevel` whose lessons are all complete but which `current_user_level` still points at → `level_not_completed` 422s on the next lesson). Never hand-roll the user reconciliation in a migration — use the tested `Curriculum::` commands, which handle every affected population safely:
+
+- `Curriculum::AppendLesson.(level, attrs, reopen_completed:)` — add a lesson (always appended at the end; mid-level inserts scramble ordering).
+- `Curriculum::MoveLesson.(lesson, to_level, reopen_completed:)` — move a lesson to another level (appended at the end).
+
+`reopen_completed:` (default false) re-opens the level for users who already completed it so the new/moved lesson resurfaces — a completed level never advertises a next lesson, so it's otherwise invisible to them.
+
 ### Exceptions
 
 Any exceptions that are referenced outside of the file in which they're raised, should be defined in `config/initializers/exceptions.rb`. This allows exceptions to be shared across multiple commands and accessed throughout the application.

--- a/app/commands/curriculum/append_lesson.rb
+++ b/app/commands/curriculum/append_lesson.rb
@@ -1,0 +1,41 @@
+# Safely add a lesson to a level, reconciling existing users.
+#
+# ALWAYS appends at the end of the level: inserting mid-level would retroactively
+# change which lessons count as "earlier" for the position-based ordering guard
+# in UserLesson::Start, scrambling in-flight users. Call this from a migration
+# rather than hand-rolling the user reconciliation.
+#
+# Users still working through (or yet to reach) the level need no reconciliation
+# - the new lesson slots into their ordering naturally. The only affected group
+# is users who had ALREADY completed the level: SerializeUserLevels never
+# advertises a next lesson on a completed level, so the new lesson is invisible
+# to them. Pass reopen_completed: true to resurface it (see below).
+class Curriculum::AppendLesson
+  include Mandate
+
+  initialize_with :level, :lesson_attributes, reopen_completed: false
+
+  def call
+    ActiveRecord::Base.transaction do
+      create_lesson!.tap do
+        reopen_for_completed_users! if reopen_completed
+      end
+    end
+  end
+
+  private
+  # Lesson#set_position assigns the next position at the end of the level.
+  def create_lesson! = level.lessons.create!(**lesson_attributes)
+
+  def reopen_for_completed_users!
+    # Un-complete the level for everyone who had finished it, so the new lesson
+    # resurfaces as their frontier. We deliberately do NOT touch
+    # current_user_level: users whose frontier has moved past this level stay
+    # put, and finishing the new lesson won't yank them backwards because
+    # UserLevel::Complete only advances the frontier when completing the level
+    # the user is currently on.
+    UserLevel.where(level:).where.not(completed_at: nil).find_each do |user_level|
+      user_level.update!(completed_at: nil)
+    end
+  end
+end

--- a/app/commands/curriculum/move_lesson.rb
+++ b/app/commands/curriculum/move_lesson.rb
@@ -1,0 +1,81 @@
+# Safely move a lesson from one level to another, reconciling existing users.
+#
+# ALWAYS appends at the end of the destination level (see Curriculum::AppendLesson
+# for why mid-level inserts are unsafe). The Lesson row keeps its id, so users'
+# UserLesson records travel with it. Call this from a migration rather than
+# hand-rolling the reconciliation - there are three user populations to fix up,
+# and missing any of them wedges people (this is the class of bug behind the
+# pangram move, Sentry JIKI-API-X):
+#
+#   1. Users on the SOURCE level whose only-remaining lesson was the one moving
+#      away are now silently "all done" on that level, but nothing marked the
+#      level complete or advanced them - so their next start 422s. We complete
+#      the source level for them (which advances the frontier correctly).
+#   2. Users who progressed on the lesson while it lived on the source level
+#      hold a UserLesson but may have no UserLevel for the DESTINATION, so
+#      SerializeUserLevels (which joins user_levels -> lessons) can't show their
+#      progress. We backfill an incomplete UserLevel.
+#   3. Users who had already completed the DESTINATION level can't see the newly
+#      arrived lesson (completed levels never advertise a next lesson). Pass
+#      reopen_completed: true to resurface it for them.
+#
+# No current_user_level pointer is ever moved backwards.
+class Curriculum::MoveLesson
+  include Mandate
+
+  initialize_with :lesson, :to_level, reopen_completed: false
+
+  def call
+    ActiveRecord::Base.transaction do
+      move_lesson!
+      complete_source_level_where_now_finished!
+      backfill_destination_user_levels!
+      reopen_destination_for_completed_users! if reopen_completed
+    end
+  end
+
+  private
+  memoize
+  def source_level = lesson.level
+
+  def move_lesson!
+    # Capture the source before reassigning; append at the end of the destination.
+    source_level
+    next_position = (to_level.lessons.where.not(id: lesson.id).maximum(:position) || 0) + 1
+    lesson.update!(level: to_level, position: next_position)
+  end
+
+  def complete_source_level_where_now_finished!
+    remaining_lesson_ids = source_level.lessons.where.not(id: lesson.id).pluck(:id)
+
+    # An empty source level can't be "complete" in any meaningful way - leave it.
+    return if remaining_lesson_ids.empty?
+
+    UserLevel.where(level: source_level, completed_at: nil).find_each do |user_level|
+      completed_count = UserLesson.where(user_id: user_level.user_id, lesson_id: remaining_lesson_ids).
+        where.not(completed_at: nil).count
+
+      next unless completed_count == remaining_lesson_ids.count
+
+      # Every remaining source lesson is done, so the level is legitimately
+      # finished now. UserLevel::Complete marks it complete, clears the (possibly
+      # dangling) current_user_lesson, and advances the frontier if this is the
+      # user's current level.
+      UserLevel::Complete.(user_level)
+    end
+  end
+
+  def backfill_destination_user_levels!
+    UserLesson.where(lesson:).distinct.pluck(:user_id).each do |user_id|
+      next if UserLevel.exists?(user_id:, level: to_level)
+
+      UserLevel.create!(user_id:, level: to_level)
+    end
+  end
+
+  def reopen_destination_for_completed_users!
+    UserLevel.where(level: to_level).where.not(completed_at: nil).find_each do |user_level|
+      user_level.update!(completed_at: nil)
+    end
+  end
+end

--- a/app/commands/user_level/complete.rb
+++ b/app/commands/user_level/complete.rb
@@ -33,13 +33,23 @@ class UserLevel::Complete
     return unless next_level
 
     next_user_level = UserLevel::Start.(user, next_level)
+    advance_frontier!(next_user_level)
+  end
 
+  def advance_frontier!(next_user_level)
     # UserLevel::Start only repoints the course's current level when it CREATES
     # the UserLevel. If the user was previously advanced onto next_level and
     # later pulled back (e.g. a curriculum change that reopened this level),
     # that UserLevel already exists, so the pointer would be stranded on the
     # now-completed level and every start on next_level would 422
-    # (level_not_completed). Repoint explicitly so completion always advances.
+    # (level_not_completed). Repoint explicitly to cover that case.
+    #
+    # Only advance when this level IS the user's current frontier, though:
+    # completing an older, reopened level (while the frontier is further ahead)
+    # must not yank current_user_level backwards onto that old level's successor.
+    return unless user_course.current_user_level_id.nil? ||
+                  user_course.current_user_level_id == user_level.id
+
     user_course.update!(current_user_level: next_user_level)
   end
 

--- a/app/commands/user_level/complete.rb
+++ b/app/commands/user_level/complete.rb
@@ -25,11 +25,22 @@ class UserLevel::Complete
   private
   delegate :user, :level, to: :user_level
 
+  memoize
+  def user_course = user.user_courses.find_by!(course: level.course)
+
   def create_next_user_level!
     next_level = Level::FindNext.(level)
     return unless next_level
 
-    UserLevel::Start.(user, next_level)
+    next_user_level = UserLevel::Start.(user, next_level)
+
+    # UserLevel::Start only repoints the course's current level when it CREATES
+    # the UserLevel. If the user was previously advanced onto next_level and
+    # later pulled back (e.g. a curriculum change that reopened this level),
+    # that UserLevel already exists, so the pointer would be stranded on the
+    # now-completed level and every start on next_level would 422
+    # (level_not_completed). Repoint explicitly so completion always advances.
+    user_course.update!(current_user_level: next_user_level)
   end
 
   def send_completion_email!

--- a/test/commands/curriculum/append_lesson_test.rb
+++ b/test/commands/curriculum/append_lesson_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class Curriculum::AppendLessonTest < ActiveSupport::TestCase
+  ATTRS = {
+    slug: "brand-new-exercise",
+    title: "Brand New Exercise",
+    description: "A freshly added exercise.",
+    type: "exercise",
+    data: { slug: "brand-new-exercise" }
+  }.freeze
+
+  test "appends the lesson at the end of the level" do
+    level = create(:level)
+    create(:lesson, :video, level:, position: 1)
+    create(:lesson, :exercise, level:, position: 2)
+
+    lesson = Curriculum::AppendLesson.(level, ATTRS)
+
+    assert_equal level, lesson.level
+    assert_equal 3, lesson.position
+    assert_equal "brand-new-exercise", lesson.slug
+  end
+
+  test "does not reopen completed levels by default" do
+    level = create(:level)
+    create(:lesson, :exercise, level:)
+    completed = create(:user_level, level:, completed_at: Time.current)
+
+    Curriculum::AppendLesson.(level, ATTRS)
+
+    assert completed.reload.completed_at.present?
+  end
+
+  test "reopens completed levels when reopen_completed is true" do
+    level = create(:level)
+    create(:lesson, :exercise, level:)
+    completed = create(:user_level, level:, completed_at: Time.current)
+
+    Curriculum::AppendLesson.(level, ATTRS, reopen_completed: true)
+
+    assert_nil completed.reload.completed_at
+  end
+
+  test "reopening does not touch levels that were not completed" do
+    level = create(:level)
+    create(:lesson, :exercise, level:)
+    in_progress = create(:user_level, level:, completed_at: nil)
+
+    Curriculum::AppendLesson.(level, ATTRS, reopen_completed: true)
+
+    assert_nil in_progress.reload.completed_at
+  end
+
+  test "reopening never moves current_user_level" do
+    level = create(:level)
+    next_level = create(:level, course: level.course, position: 99)
+    create(:lesson, :exercise, level:)
+    user = create(:user)
+    user_course = create(:user_course, user:, course: level.course)
+    create(:user_level, user:, level:, completed_at: Time.current)
+    frontier = create(:user_level, user:, level: next_level)
+    user_course.update!(current_user_level: frontier)
+
+    Curriculum::AppendLesson.(level, ATTRS, reopen_completed: true)
+
+    assert_equal frontier, user_course.reload.current_user_level
+  end
+end

--- a/test/commands/curriculum/move_lesson_test.rb
+++ b/test/commands/curriculum/move_lesson_test.rb
@@ -1,0 +1,124 @@
+require "test_helper"
+
+class Curriculum::MoveLessonTest < ActiveSupport::TestCase
+  test "moves the lesson to the end of the destination level" do
+    source = create(:level, position: 1)
+    destination = create(:level, course: source.course, position: 2)
+    create(:lesson, :video, level: destination, position: 1)
+    lesson = create(:lesson, :exercise, level: source, position: 1)
+
+    Curriculum::MoveLesson.(lesson, destination)
+
+    lesson.reload
+    assert_equal destination, lesson.level
+    assert_equal 2, lesson.position
+  end
+
+  test "completes the source level for users whose remaining lessons are now all done" do
+    source = create(:level, position: 1)
+    destination = create(:level, course: source.course, position: 2)
+    keeper = create(:lesson, :exercise, level: source, position: 1)
+    mover = create(:lesson, :exercise, level: source, position: 2)
+    user = create(:user)
+    user_course = create(:user_course, user:, course: source.course)
+    source_ul = create(:user_level, user:, level: source)
+    user_course.update!(current_user_level: source_ul)
+    create(:user_lesson, user:, lesson: keeper, completed_at: Time.current)
+
+    Curriculum::MoveLesson.(mover, destination)
+
+    assert source_ul.reload.completed_at.present?
+    destination_ul = UserLevel.find_by(user:, level: destination)
+    assert_equal destination_ul, user_course.reload.current_user_level
+  end
+
+  test "does not complete the source level when remaining lessons are still outstanding" do
+    source = create(:level, position: 1)
+    destination = create(:level, course: source.course, position: 2)
+    create(:lesson, :exercise, level: source, position: 1) # keeper, not completed
+    mover = create(:lesson, :exercise, level: source, position: 2)
+    user = create(:user)
+    create(:user_course, user:, course: source.course)
+    source_ul = create(:user_level, user:, level: source)
+
+    Curriculum::MoveLesson.(mover, destination)
+
+    assert_nil source_ul.reload.completed_at
+  end
+
+  test "does not move current_user_level backwards when completing the source level" do
+    source = create(:level, position: 1)
+    mid = create(:level, course: source.course, position: 2)
+    keeper = create(:lesson, :exercise, level: source, position: 1)
+    mover = create(:lesson, :exercise, level: source, position: 2)
+    user = create(:user)
+    user_course = create(:user_course, user:, course: source.course)
+    source_ul = create(:user_level, user:, level: source)
+    frontier = create(:user_level, user:, level: mid)
+    user_course.update!(current_user_level: frontier)
+    create(:user_lesson, user:, lesson: keeper, completed_at: Time.current)
+
+    Curriculum::MoveLesson.(mover, mid)
+
+    assert source_ul.reload.completed_at.present?
+    assert_equal frontier, user_course.reload.current_user_level
+  end
+
+  test "backfills a destination user_level for users who progressed on the moved lesson" do
+    source = create(:level, position: 1)
+    destination = create(:level, course: source.course, position: 2)
+    create(:lesson, :exercise, level: source, position: 2) # keeper, keeps source non-empty & incomplete
+    mover = create(:lesson, :exercise, level: source, position: 1)
+    user = create(:user)
+    create(:user_course, user:, course: source.course)
+    create(:user_lesson, user:, lesson: mover, completed_at: Time.current)
+    refute UserLevel.exists?(user:, level: destination)
+
+    Curriculum::MoveLesson.(mover, destination)
+
+    destination_ul = UserLevel.find_by(user:, level: destination)
+    refute_nil destination_ul
+    assert_nil destination_ul.completed_at
+  end
+
+  test "does not duplicate an existing destination user_level" do
+    source = create(:level, position: 1)
+    destination = create(:level, course: source.course, position: 2)
+    create(:lesson, :exercise, level: source, position: 2) # keeper
+    mover = create(:lesson, :exercise, level: source, position: 1)
+    user = create(:user)
+    create(:user_course, user:, course: source.course)
+    existing = create(:user_level, user:, level: destination)
+    create(:user_lesson, user:, lesson: mover, completed_at: Time.current)
+
+    Curriculum::MoveLesson.(mover, destination)
+
+    assert_equal [existing], UserLevel.where(user:, level: destination).to_a
+  end
+
+  test "does not reopen a completed destination by default" do
+    source = create(:level, position: 1)
+    destination = create(:level, course: source.course, position: 2)
+    mover = create(:lesson, :exercise, level: source, position: 1)
+    user = create(:user)
+    create(:user_course, user:, course: source.course)
+    destination_ul = create(:user_level, user:, level: destination, completed_at: Time.current)
+
+    Curriculum::MoveLesson.(mover, destination)
+
+    assert destination_ul.reload.completed_at.present?
+  end
+
+  test "reopens a completed destination when reopen_completed is true" do
+    source = create(:level, position: 1)
+    destination = create(:level, course: source.course, position: 2)
+    mover = create(:lesson, :exercise, level: source, position: 1)
+    user = create(:user)
+    create(:user_course, user:, course: source.course)
+    destination_ul = create(:user_level, user:, level: destination, completed_at: Time.current)
+
+    Curriculum::MoveLesson.(mover, destination, reopen_completed: true)
+
+    assert_nil destination_ul.reload.completed_at
+  end
+end

--- a/test/commands/user_level/complete_test.rb
+++ b/test/commands/user_level/complete_test.rb
@@ -41,6 +41,42 @@ class UserLevel::CompleteTest < ActiveSupport::TestCase
     assert_nil next_user_level.completed_at
   end
 
+  test "advances current_user_level onto the next level" do
+    user_course = create(:user_course)
+    level1 = create(:level, course: user_course.course, position: 1)
+    level2 = create(:level, course: user_course.course, position: 2)
+    lesson = create(:lesson, :exercise, level: level1)
+    user_level = create(:user_level, user: user_course.user, level: level1)
+    user_course.update!(current_user_level: user_level)
+    create(:user_lesson, user: user_course.user, lesson:, completed_at: Time.current)
+
+    UserLevel::Complete.(user_level)
+
+    next_user_level = UserLevel.find_by(user: user_course.user, level: level2)
+    assert_equal next_user_level, user_course.reload.current_user_level
+  end
+
+  # Regression: a user previously advanced onto the next level, then pulled back
+  # (e.g. a curriculum change reopened this level), already has the next
+  # UserLevel. UserLevel::Start won't repoint the course pointer in that case,
+  # so completion must repoint it explicitly - otherwise the user is stranded on
+  # the completed level and every start on the next level 422s (level_not_completed).
+  test "advances current_user_level even when the next user_level already exists" do
+    user_course = create(:user_course)
+    level1 = create(:level, course: user_course.course, position: 1)
+    level2 = create(:level, course: user_course.course, position: 2)
+    lesson = create(:lesson, :exercise, level: level1)
+    user_level = create(:user_level, user: user_course.user, level: level1)
+    existing_next = create(:user_level, user: user_course.user, level: level2)
+    user_course.update!(current_user_level: user_level)
+    create(:user_lesson, user: user_course.user, lesson:, completed_at: Time.current)
+
+    UserLevel::Complete.(user_level)
+
+    assert_equal existing_next, user_course.reload.current_user_level
+    assert_nil existing_next.reload.completed_at
+  end
+
   test "does not create next user_level when no next level exists" do
     user_lesson = create(:user_lesson, :completed)
     user_level = UserLevel.find_by(user: user_lesson.user, level: user_lesson.lesson.level)

--- a/test/commands/user_level/complete_test.rb
+++ b/test/commands/user_level/complete_test.rb
@@ -77,6 +77,26 @@ class UserLevel::CompleteTest < ActiveSupport::TestCase
     assert_nil existing_next.reload.completed_at
   end
 
+  # Guard against the fix above yanking users backwards: completing an OLD,
+  # reopened level (while the frontier is further ahead) must not move
+  # current_user_level back onto that old level's successor.
+  test "does not move current_user_level when completing a non-frontier level" do
+    user_course = create(:user_course)
+    level1 = create(:level, course: user_course.course, position: 1)
+    level2 = create(:level, course: user_course.course, position: 2)
+    level3 = create(:level, course: user_course.course, position: 3)
+    lesson = create(:lesson, :exercise, level: level1)
+    old_user_level = create(:user_level, user: user_course.user, level: level1)
+    create(:user_level, user: user_course.user, level: level2)
+    frontier = create(:user_level, user: user_course.user, level: level3)
+    user_course.update!(current_user_level: frontier)
+    create(:user_lesson, user: user_course.user, lesson:, completed_at: Time.current)
+
+    UserLevel::Complete.(old_user_level)
+
+    assert_equal frontier, user_course.reload.current_user_level
+  end
+
   test "does not create next user_level when no next level exists" do
     user_lesson = create(:user_lesson, :completed)
     user_level = UserLevel.find_by(user: user_lesson.user, level: user_lesson.lesson.level)


### PR DESCRIPTION
## Problem

Users reported `methods-and-strings` / `methodic-pangram` lessons failing to load — a 422 `level_not_completed` on `internal/user_lessons#start` (Sentry JIKI-API-X, #569). Affected users were stranded: their `current_user_level` pointed at a **completed** level, so the client could neither resume it nor start the next level.

## Root cause

`UserLevel::Complete#create_next_user_level!` relied on `UserLevel::Start` to move the course's `current_user_level` forward. But `UserLevel::Start` only repoints the pointer when it **creates** the UserLevel (`if user_level.just_created?`).

The "migrate parked users back onto multiple-functions" migration pulled a cohort back onto `multiple-functions` while leaving their pre-existing `methods-and-properties` UserLevel in place. When they re-completed `multiple-functions`, `UserLevel::Start` found the next UserLevel already existed, skipped the repoint, and left the pointer stranded on the now-completed level → every subsequent start on the next level 422'd.

The 3 affected production users were unwedged via a one-off data fix (repointing `current_user_level` to their existing `methods-and-properties` UserLevel). This PR fixes the underlying behaviour and adds tooling so the whole class of curriculum-edit bug can't recur.

## Changes

**1. `UserLevel::Complete` advances the frontier explicitly** — repoints `current_user_level` to the next level's UserLevel whether or not it already existed. Guarded to only advance when completing the user's *current* level, so re-completing an older reopened level can't yank the pointer backwards.

**2. `Curriculum::AppendLesson`** — safely add a lesson to a level. Always appends at the end (mid-level inserts scramble the position-based ordering guard). `reopen_completed:` resurfaces the lesson for users who'd already completed the level (a completed level never advertises a next lesson) without moving `current_user_level`.

**3. `Curriculum::MoveLesson`** — safely move a lesson to another level (append at end). Fixes the three populations a naive move wedges:
- source-level users whose only-remaining lesson moved away → complete + advance them;
- users who progressed on the moved lesson → backfill a destination UserLevel so their progress stays visible;
- `reopen_completed:` handles an already-completed destination.

Never moves `current_user_level` backwards.

Migrations now call these commands instead of hand-rolling user reconciliation. Full command test coverage for every population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)