### PR TITLE
Update Mux playback IDs for reworked loops & functions videos

### DIFF
--- a/db/seeds/curriculum.json
+++ b/db/seeds/curriculum.json
@@ -1233,9 +1233,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "PwqulcLfS2oF9uvfSkB4lwBMAuwjug4UjqnNrnIyUho",
+                "id": "HqGxmSUhkGy5zF8nkKvCd3itMLgtOpV02CimiwgdCWDE",
                 "durationSeconds": 174,
-                "uploadDate": "2026-07-26"
+                "uploadDate": "2026-07-28"
               }
             ]
           }
@@ -1341,9 +1341,9 @@
             "sources": [
               {
                 "provider": "mux",
-                "id": "x001DHMg23ec02lexph9F102XiDD8Qu3LjdOPnie43aDLo",
+                "id": "ghCnw2FiEgPSf34NKSMYzH00UODStmO8jYEveiPpvX02Y",
                 "durationSeconds": 314,
-                "uploadDate": "2026-06-11"
+                "uploadDate": "2026-07-28"
               }
             ]
           }


### PR DESCRIPTION
## What

Re-published two lesson videos to Mux after fixing on-screen code bugs, and point the curriculum seed at the new playback IDs.

### Videos affected
- **for-while-loops** (`Advanced Loops`) — fixed the trace walkthrough: `i < 5` → `i < 2` in the syntax card (matches the narration "less than two"), and `i = i + 2` → `i = i + 1` in the second iteration card.
- **using-multiple-functions-together** — converted `+= 1` shorthand to longhand `x = x + 1` in both code cards.

### Seed changes (`db/seeds/curriculum.json`)
| Lesson | New Mux playback ID | uploadDate |
|---|---|---|
| for-while-loops | `ghCnw2FiEgPSf34NKSMYzH00UODStmO8jYEveiPpvX02Y` | 2026-07-28 |
| using-multiple-functions-together | `HqGxmSUhkGy5zF8nkKvCd3itMLgtOpV02CimiwgdCWDE` | 2026-07-28 |

`durationSeconds` unchanged (edits were text-only, no timing change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)