### PR TITLE
Allow selecting draft locales

### DIFF
--- a/app/models/user/data.rb
+++ b/app/models/user/data.rb
@@ -12,23 +12,38 @@ class User::Data < ApplicationRecord
   # Welcome emails are transactional — no preference check.
   def email_communication_preferences_key(_kind = nil) = nil
 
-  validates :explicit_locale, inclusion: { in: I18n::SUPPORTED_LOCALES }, allow_nil: true
+  # Draft locales are selectable: a user can commit to one before it ships,
+  # and we hold that choice until it does. Resolved lazily (rather than at
+  # class-load) so the locale sets can be swapped in tests.
+  validates :explicit_locale,
+    inclusion: { in: ->(_) { I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES } },
+    allow_nil: true
 
-  # Locale is derived, never stored directly: an explicit user choice always
-  # wins, then the best match from the browser's Accept-Language preferences
-  # (stored in locales), then the default. Assigning locale records an
-  # explicit choice.
-  def locale = explicit_locale || locale_from_preferences || I18n.default_locale.to_s
+  # Locale is derived, never stored directly: an explicit user choice wins
+  # while that locale is live, then the best match from the browser's
+  # Accept-Language preferences (stored in locales), then the default.
+  # Assigning locale records an explicit choice.
+  def locale = live_explicit_locale || locale_from_preferences || I18n.default_locale.to_s
 
   def locale=(value)
     self.explicit_locale = value.presence
   end
 
-  # Every locale (live or draft) the user could plausibly want: their
-  # resolved locale first, then the rest of their Accept-Language
-  # preferences normalised into our locale forms. The FE decides which of
-  # these are worth surfacing.
-  def available_locales = ([locale] + User::DetermineLocales.(locales)).uniq
+  # Every locale (live or draft) the user could plausibly want: their explicit
+  # choice first, then the locale they're actually served, then the rest of
+  # their Accept-Language preferences normalised into our locale forms. The FE
+  # decides which of these are worth surfacing.
+  def available_locales = [selected_locale, locale, *User::DetermineLocales.(locales)].compact.uniq
+
+  # The stored choice, but only while it's still a locale we recognise. A value
+  # that has since been dropped from both the live and draft sets is treated as
+  # though it were never set, rather than surfaced as a selection the user can't
+  # act on.
+  def selected_locale
+    return nil unless (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).include?(explicit_locale)
+
+    explicit_locale
+  end
 
   # Notification preference slugs mapped to column names
   NOTIFICATION_SLUGS = {
@@ -100,6 +115,16 @@ class User::Data < ApplicationRecord
   def may_receive_emails? = email_complaint_at.nil?
 
   private
+  # An explicit choice only drives what we serve while that locale is live.
+  # Picking a draft locale records the intent (and keeps surfacing it via
+  # selected_locale) but must not strand the user on content that doesn't
+  # exist yet, so until it ships we fall through to the usual negotiation.
+  def live_explicit_locale
+    return nil unless I18n::SUPPORTED_LOCALES.include?(explicit_locale)
+
+    explicit_locale
+  end
+
   # Negotiate the browser's Accept-Language preferences (stored in locales)
   # down to a single supported content locale, or nil when none maps to a
   # live locale.

--- a/app/serializers/serialize_user.rb
+++ b/app/serializers/serialize_user.rb
@@ -10,6 +10,7 @@ class SerializeUser
       email: user.email,
       name: user.name,
       locale: user.locale,
+      explicit_locale: user.data.selected_locale,
       locales: user.data.available_locales,
       avatar_url: user.avatar_url,
       uses_oauth: user.uses_oauth?,

--- a/test/controllers/internal/settings_controller_test.rb
+++ b/test/controllers/internal/settings_controller_test.rb
@@ -119,6 +119,16 @@ class Internal::SettingsControllerTest < ApplicationControllerTest
     assert_equal "hu", @user.reload.locale
   end
 
+  test "PATCH locale accepts a draft locale, which is recorded but not yet served" do
+    with_supported_locales(%w[en]) do
+      patch locale_internal_settings_path, params: { value: "hu" }, as: :json
+
+      assert_response :success
+      assert_equal "hu", @user.reload.data.explicit_locale
+      assert_equal "en", @user.reload.locale
+    end
+  end
+
   test "PATCH locale fails with invalid locale" do
     patch locale_internal_settings_path, params: { value: "invalid" }, as: :json
 

--- a/test/models/user/data_test.rb
+++ b/test/models/user/data_test.rb
@@ -195,6 +195,67 @@ class User::DataTest < ActiveSupport::TestCase
     assert_equal I18n.default_locale.to_s, user.data.locale
   end
 
+  test "locale ignores an explicit choice that isn't live yet" do
+    user = create(:user)
+    user.data.update!(explicit_locale: "hu", locales: %w[en])
+
+    # hu is a draft locale here, so it must not drive what we serve.
+    with_supported_locales(%w[en]) do
+      assert_equal "en", user.data.locale
+    end
+  end
+
+  test "locale honours the explicit choice once it goes live" do
+    user = create(:user)
+    user.data.update!(explicit_locale: "hu", locales: %w[en])
+
+    with_supported_locales(%w[en hu]) do
+      assert_equal "hu", user.data.locale
+    end
+  end
+
+  test "selected_locale keeps a draft choice" do
+    user = create(:user)
+    user.data.update!(explicit_locale: "hu")
+
+    with_supported_locales(%w[en]) do
+      assert_equal "hu", user.data.selected_locale
+    end
+  end
+
+  test "selected_locale ignores a choice that's in neither the live nor draft set" do
+    user = create(:user)
+    user.data.update_column(:explicit_locale, "kl")
+
+    assert_nil user.data.selected_locale
+  end
+
+  test "selected_locale is nil when no explicit choice" do
+    user = create(:user)
+    user.data.update!(explicit_locale: nil)
+
+    assert_nil user.data.selected_locale
+  end
+
+  test "available_locales leads with the explicit choice, then the served locale" do
+    user = create(:user)
+    user.data.update!(explicit_locale: "hu", locales: %w[fr en])
+
+    with_supported_locales(%w[en]) do
+      # hu is chosen but not live, so en is served — both appear, choice first.
+      assert_equal %w[hu en], user.data.available_locales
+    end
+  end
+
+  test "available_locales dedupes when the explicit choice is also the served locale" do
+    user = create(:user)
+    user.data.update!(explicit_locale: "hu", locales: %w[hu en])
+
+    with_supported_locales(%w[en hu]) do
+      assert_equal %w[hu en], user.data.available_locales
+    end
+  end
+
   test "locale= records an explicit choice, and blanks clear it" do
     user = create(:user)
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -101,7 +101,7 @@ class UserTest < ActiveSupport::TestCase
     assert_nil user.data.reload.explicit_locale
   end
 
-  test "explicit_locale must be a supported locale" do
+  test "explicit_locale must be a live or draft locale" do
     user = build(:user, locale: "fr")
     refute user.valid?
 
@@ -110,6 +110,15 @@ class UserTest < ActiveSupport::TestCase
 
     user.locale = nil
     assert user.valid?
+  end
+
+  test "explicit_locale accepts a draft locale that isn't live yet" do
+    # The test env ships the draft set as live, so narrow it to prove the
+    # validation really does span live + draft rather than just live.
+    with_supported_locales(%w[en]) do
+      assert build(:user, locale: "hu").valid?
+      refute build(:user, locale: "fr").valid?
+    end
   end
 
   test "deleting user cascades to delete user_lessons and user_levels" do

--- a/test/serializers/serialize_user_test.rb
+++ b/test/serializers/serialize_user_test.rb
@@ -12,6 +12,7 @@ class SerializeUserTest < ActiveSupport::TestCase
         email: "test@example.com",
         name: "Test User",
         locale: "en",
+        explicit_locale: nil,
         locales: ["en"],
         avatar_url: "https://example.com/avatar.png",
         uses_oauth: false,
@@ -180,6 +181,26 @@ class SerializeUserTest < ActiveSupport::TestCase
     result = SerializeUser.(user)
 
     assert_equal %w[hu en], result[:locales]
+  end
+
+  test "serializes explicit_locale and leads locales with it" do
+    user = create(:user, locale: "hu")
+    user.data.update!(locales: %w[fr en])
+
+    with_supported_locales(%w[en]) do
+      result = SerializeUser.(user)
+
+      # hu is chosen but not live: en is still served, hu still leads the list.
+      assert_equal "hu", result[:explicit_locale]
+      assert_equal "en", result[:locale]
+      assert_equal %w[hu en], result[:locales]
+    end
+  end
+
+  test "serializes explicit_locale as nil when no choice has been made" do
+    user = create(:user)
+
+    assert_nil SerializeUser.(user)[:explicit_locale]
   end
 
   test "serializes admin: false for regular user" do


### PR DESCRIPTION
Follow-up to #585. That PR advertised draft locales in `locales`, but they were impossible to actually select — `explicit_locale` was validated against the live set only, so the settings endpoint 422’d on every one of them. This closes that gap.

```json
{ "locale": "en", "explicit_locale": "hu", "locales": ["hu", "en"] }
```

A user who picks Hungarian before it ships: the choice is recorded and leads `locales`, but `en` is still served until `hu` goes live — at which point they switch over with no further action.

## Changes

1. **`explicit_locale` on `SerializeUser`** — the stored choice, or `null`.
2. **`locales` leads with the explicit choice**, then the served `locale`, then the remaining Accept-Language preferences.
3. **Writing accepts live + draft** (`SUPPORTED_LOCALES + WIP_LOCALES`), matching what the `*::Translation` models already validate against. Resolved via a lambda rather than at class-load so the sets can be swapped in tests.
4. **Reading ignores a choice that isn’t valid for the context it’s used in:**
   - Not live → ignored by `locale`, so nobody lands on content that doesn’t exist yet. Falls through to the usual negotiation.
   - Not in *either* set (e.g. dropped from WIP after being chosen) → ignored by `selected_locale` too, so the FE never shows a selection the user can’t act on.

## Testing

Full suite green (2202 runs, 0 failures), 11 new tests. Note the test env ships the draft set as live, so the tests that matter narrow it with `with_supported_locales(%w[en])` — otherwise they’d pass without proving anything.

Includes an end-to-end controller test: `PATCH /internal/settings/locale` with a draft locale now succeeds, records `explicit_locale`, and leaves the served locale alone.

## Note

`SerializeSettings` still exposes only `locale`. If the picker lives on the settings screen it likely wants `explicit_locale`/`locales` too — happy to add if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzAzM5mUN2YfFNSWnidJ79