### PR TITLE
Install libvips in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,12 +36,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      # Boots the app on the runner, outside the image, so it needs libvips
+      # here as well as in the Dockerfile.
       - name: Run Zeitwerk test
         run: bundle exec rails test:zeitwerk
 


### PR DESCRIPTION
Fixes the failing deploy on main: https://github.com/jiki-education/api/actions/runs/30672645095/job/91293409311

```
LoadError: Could not open library 'vips.so.42' ... (ruby-vips-2.3.0/lib/vips.rb:48)
```

Same root cause as the CI fix in #585. The deploy job runs `bundle exec rails test:zeitwerk` on the bare runner *before* building the image, so it boots the app and needs libvips there too. I added it to `ci.yml` when introducing `ruby-vips` but missed this second call site.

**The built image was never affected** — the Dockerfile has installed libvips all along, so the running containers are fine. Only the pre-build boot check on the runner fails, which blocks the deploy from proceeding.

`test:zeitwerk` in this job is now the only place left that boots the app outside Docker; I grepped the other workflows to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzAzM5mUN2YfFNSWnidJ79