### PR TITLE
Widen WIP_LOCALES to match the front end

### DIFF
--- a/app/commands/user/normalize_locale_tags.rb
+++ b/app/commands/user/normalize_locale_tags.rb
@@ -23,7 +23,17 @@ class User::NormalizeLocaleTags
     # (neutral Latin American). Only the ES region maps to Peninsular; every
     # other region collapses to es-419. A region-less "es" defaults to es-419,
     # since Latin America is the far larger Spanish-speaking audience.
-    "es" => { bare: "es-419", regions: { "ES" => "es-ES" }.freeze, fallback: "es-419" }
+    "es" => { bare: "es-419", regions: { "ES" => "es-ES" }.freeze, fallback: "es-419" },
+
+    # Chinese ships Simplified (zh-CN) and Traditional (zh-TW). The split is by
+    # script, not country, so the Traditional-writing regions are listed
+    # explicitly: Taiwan, Hong Kong and Macau. Everywhere else - and a
+    # region-less "zh" - gets Simplified, which is the far larger audience.
+    "zh" => {
+      bare: "zh-CN",
+      regions: { "TW" => "zh-TW", "HK" => "zh-TW", "MO" => "zh-TW" }.freeze,
+      fallback: "zh-CN"
+    }
   }.freeze
 
   def call

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -10,10 +10,19 @@ module I18n
   # Translation generation targets these everywhere (so content can be
   # pre-generated before a locale is promoted), but users can only select
   # them outside production.
+  #
+  # Mirrors the front end's ALL_LOCALES (app/lib/locales.ts), in canonical
+  # BCP-47 casing. The two must stay in step: the front end offers a locale
+  # switcher over its list, and anything missing here is rejected by the
+  # explicit_locale validation, so a locale present there but absent here
+  # shows up in the UI and then 422s when picked.
   WIP_LOCALES = %w[
-    hu
+    ar bn ca de el
     es-ES es-419
+    fa fr hi hu id it ja ko nl pl
     pt-PT pt-BR
+    ro ru sr sv sw tr uk ur vi
+    zh-CN zh-TW
   ].freeze
 
   # Locales users can actually select. Production ships PRODUCTION_LOCALES

--- a/test/commands/user/determine_locale_test.rb
+++ b/test/commands/user/determine_locale_test.rb
@@ -59,6 +59,31 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
     end
   end
 
+  # Chinese splits by script rather than country, so the Traditional regions
+  # are enumerated and everything else falls to Simplified.
+  {
+    %w[zh-CN] => "zh-CN",       # exact
+    %w[zh-TW] => "zh-TW",       # exact
+    %w[zh] => "zh-CN",          # bare zh -> Simplified (larger audience)
+    %w[zh-HK] => "zh-TW",       # Hong Kong writes Traditional
+    %w[zh-MO] => "zh-TW",       # Macau writes Traditional
+    %w[zh-SG] => "zh-CN",       # Singapore writes Simplified
+    %w[zh-US] => "zh-CN"        # diaspora region -> Simplified
+  }.each do |tags, expected|
+    test "#{tags.join(', ')} negotiates to #{expected}" do
+      with_supported_locales(%w[en zh-CN zh-TW]) do
+        assert_equal expected, User::DetermineLocale.(tags)
+      end
+    end
+  end
+
+  test "zh-HK falls through when zh-TW is not live" do
+    with_supported_locales(%w[en zh-CN]) do
+      # Must not silently serve Simplified to a Traditional reader.
+      assert_equal "en", User::DetermineLocale.(%w[zh-HK en])
+    end
+  end
+
   # Edge cases.
   test "empty list returns nil" do
     with_supported_locales(FULL_SET) do

--- a/test/controllers/auth/registrations_controller_test.rb
+++ b/test/controllers/auth/registrations_controller_test.rb
@@ -191,18 +191,18 @@ class Auth::RegistrationsControllerTest < ApplicationControllerTest
     post user_registration_path,
       params: with_turnstile(
         user: {
-          email: "de@example.com",
+          email: "kl@example.com",
           password: "password123",
           password_confirmation: "password123",
-          name: "DE User",
-          handle: "deuser",
-          locale: "de"
+          name: "KL User",
+          handle: "kluser",
+          locale: "kl"
         }
       ),
       as: :json
 
     assert_response :created
-    assert_nil User.find_by(email: "de@example.com").data.explicit_locale
+    assert_nil User.find_by(email: "kl@example.com").data.explicit_locale
   end
 
   test "POST signup does not call User::Bootstrap on failed registration" do

--- a/test/i18n_locales_test.rb
+++ b/test/i18n_locales_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+# Guards the shape of the locale constants. They're hand-maintained in step with
+# the front end's ALL_LOCALES (app/lib/locales.ts), and a locale that drifts in
+# casing or gets duplicated fails in a way that's hard to trace: the
+# explicit_locale validation and the tag negotiation both match exactly, so
+# "zh-cn" would be advertised by the front end and then 422 on selection.
+class I18nLocalesTest < ActiveSupport::TestCase
+  ALL = (I18n::PRODUCTION_LOCALES + I18n::WIP_LOCALES).freeze
+
+  test "locales are unique across the production and WIP sets" do
+    assert_equal ALL.uniq, ALL, "duplicate locale(s): #{ALL.tally.select { |_, n| n > 1 }.keys.inspect}"
+  end
+
+  test "locales use canonical BCP-47 casing" do
+    # Language lowercase; region either a 2-letter country (uppercase) or a
+    # 3-digit UN M.49 area, e.g. es-419.
+    ALL.each do |locale|
+      assert_match(/\A[a-z]{2,3}(-([A-Z]{2}|\d{3}))?\z/, locale, "#{locale.inspect} isn't canonically cased")
+    end
+  end
+
+  test "every locale with a region variant has a sibling or a collapse rule" do
+    # A region-suffixed locale is only reachable if a tag can resolve to it:
+    # either the browser sends it verbatim, or LANGUAGE_VARIANTS routes the
+    # bare language to it. Without a rule, a bare "zh" would resolve to nothing.
+    ALL.select { |locale| locale.include?("-") }.map { |locale| locale.split("-").first }.uniq.each do |language|
+      assert_includes User::NormalizeLocaleTags::LANGUAGE_VARIANTS.keys, language,
+        "#{language} ships region variants but has no LANGUAGE_VARIANTS rule, so a bare #{language.inspect} resolves to nothing"
+    end
+  end
+
+  test "every LANGUAGE_VARIANTS target is a real locale" do
+    User::NormalizeLocaleTags::LANGUAGE_VARIANTS.each do |language, variant|
+      targets = [variant[:bare], variant[:fallback], *variant[:regions].values].uniq
+      targets.each do |target|
+        assert_includes ALL, target, "#{language} maps to #{target.inspect}, which isn't a known locale"
+      end
+    end
+  end
+end

--- a/test/models/user/data_test.rb
+++ b/test/models/user/data_test.rb
@@ -243,7 +243,7 @@ class User::DataTest < ActiveSupport::TestCase
 
     with_supported_locales(%w[en]) do
       # hu is chosen but not live, so en is served — both appear, choice first.
-      assert_equal %w[hu en], user.data.available_locales
+      assert_equal %w[hu en fr], user.data.available_locales
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -79,18 +79,23 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "hu", user.locale
   end
 
-  test "locale skips unsupported preferences" do
+  test "locale skips preferences that aren't live" do
     user = create(:user)
     user.data.update!(locales: %w[fr de hu])
 
-    assert_equal "hu", user.locale
+    # fr and de are known locales but not live here, so hu wins.
+    with_supported_locales(%w[en hu]) do
+      assert_equal "hu", user.locale
+    end
   end
 
-  test "locale falls back to en when no preference is supported" do
+  test "locale falls back to en when no preference is live" do
     user = create(:user)
     user.data.update!(locales: %w[fr de])
 
-    assert_equal "en", user.locale
+    with_supported_locales(%w[en hu]) do
+      assert_equal "en", user.locale
+    end
   end
 
   test "assigning locale sets explicit_locale" do
@@ -102,7 +107,8 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "explicit_locale must be a live or draft locale" do
-    user = build(:user, locale: "fr")
+    # kl (Greenlandic) is in neither set.
+    user = build(:user, locale: "kl")
     refute user.valid?
 
     user.locale = "hu"
@@ -117,7 +123,7 @@ class UserTest < ActiveSupport::TestCase
     # validation really does span live + draft rather than just live.
     with_supported_locales(%w[en]) do
       assert build(:user, locale: "hu").valid?
-      refute build(:user, locale: "fr").valid?
+      refute build(:user, locale: "kl").valid?
     end
   end
 

--- a/test/serializers/serialize_user_test.rb
+++ b/test/serializers/serialize_user_test.rb
@@ -193,7 +193,7 @@ class SerializeUserTest < ActiveSupport::TestCase
       # hu is chosen but not live: en is still served, hu still leads the list.
       assert_equal "hu", result[:explicit_locale]
       assert_equal "en", result[:locale]
-      assert_equal %w[hu en], result[:locales]
+      assert_equal %w[hu en fr], result[:locales]
     end
   end
 


### PR DESCRIPTION
Fixes changing language only working for `en` and `hu`.

The front end’s `ALL_LOCALES` (`app/lib/locales.ts`) carries **31** locales and its switcher offers all of them. We knew about **6**. The other 25 were offered in the UI and then rejected by the `explicit_locale` validation.

| | |
|---|---|
| **Was accepted (6)** | `en` `hu` `es-ES` `es-419` `pt-BR` `pt-PT` |
| **Was rejected (25)** | `ar` `bn` `ca` `de` `el` `fa` `fr` `hi` `id` `it` `ja` `ko` `nl` `pl` `ro` `ru` `sr` `sv` `sw` `tr` `uk` `ur` `vi` `zh-CN` `zh-TW` |

The two sets are now identical in both directions.

## `zh` needed a collapse rule

Chinese is the third language shipping multiple content variants, and it had no `LANGUAGE_VARIANTS` entry — so a bare `zh` or a `zh-HK` resolved to **nothing at all**, falling through to the default. Unlike `pt`/`es` the split is by script rather than country, so the Traditional-writing regions are enumerated (`TW`, `HK`, `MO`) and everything else gets Simplified.

## Triage against real data

Ran the ~12k-user Accept-Language sample (186 distinct tags) through the actual `NormalizeLocaleTags` path:

```
resolved: 154 tags / 12161 users (99.2%)
dropped:   32 tags /   101 users (0.8%)
```

Spot checks: `en-US`/`en-GB`/`en-IN`/`en-GB-oxendict` → `en`; `fr-FR` → `fr`; `es-US`/`es-MX` → `es-419`; `es-ES` → `es-ES`; `pt-CV` → `pt-PT`; `zh-HK` → `zh-TW`; `zh-SG` → `zh-CN`.

The 0.8% that drop are languages the front end doesn’t ship either (`cs` `da` `nb`/`no` `fi` `sk` `th` `he` `hr` `bg` `sl` and similar) — verified that the dropped set has **zero** overlap with `ALL_LOCALES`, so they fall through to the default exactly as before.

## Guard test

The two lists are kept in step by hand, so `test/i18n_locales_test.rb` guards the failure modes that are hard to trace — a locale that drifts in casing is advertised by the FE and then 422s on selection. It checks: no duplicates, canonical BCP-47 casing, every region-variant language has a collapse rule, and every variant rule points at a locale that exists.

## Note on translation fan-out

`WIP_LOCALES` isn’t only a validation list — `Level`/`Lesson`/`Badge::Translation` validate against it and the `TranslateToAllLocales` commands **iterate** it. This takes those from 6 to 31 targets, so a full translate is now ~5x the Gemini work. Nothing fires automatically from this PR, but worth knowing before the next bulk run. If you want selectable-set and translate-set decoupled, that should be a separate constant.

## Testing

Full suite green (2214 runs, 0 failures). Several tests used `fr`/`de` as their “unsupported” sentinel, which these no longer are; where the test is about what’s *live* they now pin the live set with `with_supported_locales` rather than leaning on the global constant, so a future widening won’t break them again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzAzM5mUN2YfFNSWnidJ79