### PR TITLE
Fix race condition in UserVideo::SetWatchedPercentage

### DIFF
--- a/app/commands/user_video/set_watched_percentage.rb
+++ b/app/commands/user_video/set_watched_percentage.rb
@@ -18,5 +18,7 @@ class UserVideo::SetWatchedPercentage
   memoize
   def user_video
     UserVideo.find_or_create_by!(user:, uuid:)
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+    UserVideo.find_by!(user:, uuid:)
   end
 end

--- a/test/commands/user_video/set_watched_percentage_test.rb
+++ b/test/commands/user_video/set_watched_percentage_test.rb
@@ -88,6 +88,18 @@ class UserVideo::SetWatchedPercentageTest < ActiveSupport::TestCase
     assert_nil UserVideo.find_by!(user:, uuid:).completed_at
   end
 
+  test "recovers when find_or_create_by! races with a concurrent insert" do
+    user = create(:user)
+    uuid = SecureRandom.uuid
+
+    UserVideo.expects(:find_or_create_by!).with(user:, uuid:).raises(ActiveRecord::RecordInvalid)
+    existing = create(:user_video, user:, uuid:, watched_percentage: 20)
+
+    UserVideo::SetWatchedPercentage.(user, uuid, 50)
+
+    assert_equal 50, existing.reload.watched_percentage
+  end
+
   test "isolates progress between users" do
     user1 = create(:user)
     user2 = create(:user)


### PR DESCRIPTION
Closes #581

## Summary
- `UserVideo::SetWatchedPercentage` used `find_or_create_by!`, which is not atomic (SELECT then INSERT). Concurrent requests for the same new user/video (e.g. rapid watch-progress polling from the video player) could both miss the SELECT and both attempt to create the row, causing the loser to raise `ActiveRecord::RecordInvalid: Uuid has already been taken`.
- Rescue the race and re-fetch the row that won, matching the existing pattern used in `User::Flag::Mark`.

## Test plan
- [x] Added a test simulating the race (stubs `find_or_create_by!` to raise, asserts the command recovers via `find_by!`)
- [x] Full test suite passes (via pre-commit hook)
- [x] Rubocop / Brakeman pass (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014e7jXz2N1n8kRgFHKfVMcf