### PR TITLE
Rescue invalid Discourse SSO signatures instead of raising 500

### DIFF
--- a/app/controllers/auth/discourse_controller.rb
+++ b/app/controllers/auth/discourse_controller.rb
@@ -21,5 +21,7 @@ class Auth::DiscourseController < ApplicationController
     AwardBadgeJob.perform_later(current_user, 'townsfolk')
 
     redirect_to sso.to_url("#{FORUM_URL}/session/sso_login"), allow_other_host: true
+  rescue DiscourseApi::SingleSignOn::ParseError
+    render_400(:invalid_signature)
   end
 end

--- a/test/controllers/auth/discourse_controller_test.rb
+++ b/test/controllers/auth/discourse_controller_test.rb
@@ -80,6 +80,16 @@ class Auth::DiscourseControllerTest < ApplicationControllerTest
     assert_equal nonce, decoded_payload["nonce"]
   end
 
+  test "GET sso renders 400 for authenticated user when signature is invalid" do
+    Jiki.secrets.stubs(:discourse_sso_secret).returns(@secret)
+    sign_in_user(@user)
+
+    get auth_discourse_sso_path, params: { sso: "not-valid-base64!!!", sig: "bogus" }
+
+    assert_response :bad_request
+    assert_json_response({ error: { type: "invalid_signature", message: I18n.t("api_errors.invalid_signature") } })
+  end
+
   test "GET sso preserves original SSO params in return_to URL for unauthenticated users" do
     Jiki.config.stubs(:frontend_base_url).returns("https://app.jiki.io")
 


### PR DESCRIPTION
Closes #586

## Summary
- Requests hitting `Auth::DiscourseController#sso` with a missing/invalid `sig` (bots, stale links, direct hits without going through Discourse) raised an unhandled `DiscourseApi::SingleSignOn::ParseError`, resulting in a 500 and a Sentry alert.
- Rescue the error and return a 400 with the existing `invalid_signature` error type instead of crashing.

## Test plan
- [x] Added a controller test covering a request with an invalid signature, asserting a 400 response
- [x] Full test suite passes (`bin/rails test`)
- [x] Rubocop and Brakeman pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)