### PR TITLE
Fix race condition in UserChallenge::Start

### DIFF
--- a/app/commands/user_challenge/start.rb
+++ b/app/commands/user_challenge/start.rb
@@ -6,8 +6,15 @@ class UserChallenge::Start
   def call
     raise ChallengeLockedError, "Challenge is locked" unless UserChallenge::UnlockedForUser.(user, challenge)
 
-    UserChallenge.find_or_create_by!(user:, challenge:).tap do |user_challenge|
-      user_challenge.update!(started_at: Time.current) if user_challenge.started_at.nil?
+    user_challenge.tap do |uc|
+      uc.update!(started_at: Time.current) if uc.started_at.nil?
     end
+  end
+
+  private
+  def user_challenge
+    UserChallenge.find_or_create_by!(user:, challenge:)
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+    UserChallenge.find_by!(user:, challenge:)
   end
 end

--- a/test/commands/user_challenge/start_test.rb
+++ b/test/commands/user_challenge/start_test.rb
@@ -37,6 +37,19 @@ class UserChallenge::StartTest < ActiveSupport::TestCase
     refute_nil result.started_at
   end
 
+  test "recovers when find_or_create_by! races with a concurrent insert" do
+    user = create(:user)
+    challenge = create(:challenge)
+
+    UserChallenge.expects(:find_or_create_by!).with(user:, challenge:).raises(ActiveRecord::RecordInvalid)
+    existing = create(:user_challenge, user:, challenge:, started_at: nil)
+
+    result = UserChallenge::Start.(user, challenge)
+
+    assert_equal existing, result
+    refute_nil result.reload.started_at
+  end
+
   test "raises ChallengeLockedError when challenge is locked for user" do
     user = create(:user)
     lesson = create(:lesson, :exercise)


### PR DESCRIPTION
## Summary
- Same `find_or_create_by!` race as #592, this time in `UserChallenge::Start`: concurrent requests to start the same challenge for the same user could both miss the initial SELECT and both attempt to create the row, raising `ActiveRecord::RecordInvalid` against the unique `(user_id, challenge_id)` index.
- Rescue the race and re-fetch the row that won, matching the fix applied to `UserVideo::SetWatchedPercentage` in #592.

Not tied to a reported issue — found while investigating #581, since it's the same unguarded pattern.

## Test plan
- [x] Added a test simulating the race (stubs `find_or_create_by!` to raise, asserts the command recovers via `find_by!`)
- [x] Full test suite passes (via pre-commit hook)
- [x] Rubocop / Brakeman pass (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014e7jXz2N1n8kRgFHKfVMcf