### PR TITLE
Allow staging/ngrok origins in checkout return_url validation

### DIFF
--- a/app/commands/utils/verify_frontend_url.rb
+++ b/app/commands/utils/verify_frontend_url.rb
@@ -3,18 +3,29 @@ class Utils::VerifyFrontendUrl
 
   initialize_with :url
 
+  # Additional frontend deployments that talk to this API, beyond the
+  # canonical frontend_base_url. Kept in sync with config/initializers/cors.rb.
+  ADDITIONAL_ALLOWED_ORIGINS = [
+    "https://staging.jiki.io",
+    "https://ihid.ngrok.dev"
+  ].freeze
+
   def call
     return false if url.blank?
 
-    # Parse both URLs
     uri = URI.parse(url)
-    allowed_uri = URI.parse(Jiki.config.frontend_base_url)
-
-    # Check scheme, host, and port match exactly
-    uri.scheme == allowed_uri.scheme &&
-      uri.host == allowed_uri.host &&
-      uri.port == allowed_uri.port
+    allowed_uris.any? do |allowed_uri|
+      uri.scheme == allowed_uri.scheme &&
+        uri.host == allowed_uri.host &&
+        uri.port == allowed_uri.port
+    end
   rescue URI::InvalidURIError
     false
+  end
+
+  private
+  memoize
+  def allowed_uris
+    [Jiki.config.frontend_base_url, *ADDITIONAL_ALLOWED_ORIGINS].map { |u| URI.parse(u) }
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,10 +7,12 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    # staging.jiki.io is a second frontend deployment that talks to this same
-    # (production) API from the browser, so its origin must be allowed alongside
-    # the canonical frontend_base_url (https://jiki.io).
-    origins Jiki.config.frontend_base_url, Jiki.config.admin_base_url, "https://staging.jiki.io", "ihid.ngrok.dev"
+    # staging.jiki.io and the ngrok dev tunnel are additional frontend
+    # deployments that talk to this same (production) API from the browser,
+    # so their origins must be allowed alongside the canonical
+    # frontend_base_url. Kept in sync with Utils::VerifyFrontendUrl.
+    origins Jiki.config.frontend_base_url, Jiki.config.admin_base_url,
+      *Utils::VerifyFrontendUrl::ADDITIONAL_ALLOWED_ORIGINS
 
     resource "*",
       headers: :any,

--- a/test/commands/utils/verify_frontend_url_test.rb
+++ b/test/commands/utils/verify_frontend_url_test.rb
@@ -75,4 +75,12 @@ class Utils::VerifyFrontendUrlTest < ActiveSupport::TestCase
   test "returns false for completely different domain" do
     refute Utils::VerifyFrontendUrl.("https://evil.com/callback")
   end
+
+  test "returns true for staging frontend origin" do
+    assert Utils::VerifyFrontendUrl.("https://staging.jiki.io/dashboard?checkout_return=true")
+  end
+
+  test "returns true for ngrok dev tunnel origin" do
+    assert Utils::VerifyFrontendUrl.("https://ihid.ngrok.dev/callback")
+  end
 end


### PR DESCRIPTION
Closes #591

## Summary
- `Utils::VerifyFrontendUrl` only accepted a `return_url` matching the canonical `Jiki.config.frontend_base_url`, but `config/initializers/cors.rb` already allows `staging.jiki.io` and the ngrok dev tunnel to call this API from the browser.
- Sentry confirmed a production user's checkout was rejected with `return_url: "https://staging.jiki.io/dashboard?checkout_return=true&checkout_session_id={CHECKOUT_SESSION_ID}"` — a legitimate staging request.
- Extended `Utils::VerifyFrontendUrl` with an `ADDITIONAL_ALLOWED_ORIGINS` list (staging + ngrok) alongside `frontend_base_url`, and pointed `cors.rb` at the same constant so the two lists can't drift apart again.

## Test plan
- [x] Added tests for staging and ngrok origins being accepted in `test/commands/utils/verify_frontend_url_test.rb`
- [x] `bin/rails test test/commands/utils/verify_frontend_url_test.rb test/controllers/internal/subscriptions_controller_test.rb` — all passing
- [x] Full test suite, rubocop, and brakeman passed via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hspq1Nbg7nJiCiB1yhgS99