### PR TITLE
Remove video from Type Conversion concept

### DIFF
--- a/db/seeds/concepts.json
+++ b/db/seeds/concepts.json
@@ -305,6 +305,6 @@
     "slug": "type-conversion",
     "title": "Type Conversion",
     "description": "Convert values between types, like turning a string of digits into a number with Number().",
-    "unlocked_by_lesson_slug": "for-while-loops"
+    "unlocked_by_lesson_slug": "isbn-verifier"
   }
 ]


### PR DESCRIPTION
The `type-conversion` concept was seeded with `unlocked_by_lesson_slug: for-while-loops`. Since `video_data` is derived from the unlocking lesson, the concept page showed the for/while/break/continue video as its recap, which doesn't cover type conversion at all.

There's no video for this concept, so it should show none. Repointed the unlock to the `isbn-verifier` exercise lesson (the first lesson whose exercise lists `type-conversion` in its concepts), which is a sensible unlock point and carries no video data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrBvE3ba8EAfLQUyypoy9m