### PR TITLE
Split level_translations seed into one file per locale

### DIFF
--- a/app/commands/level/translation/create_all_from_json.rb
+++ b/app/commands/level/translation/create_all_from_json.rb
@@ -1,10 +1,13 @@
 class Level::Translation::CreateAllFromJson
   include Mandate
 
+  # One file per locale, named after the locale it holds (e.g. hu.json). The
+  # locale isn't repeated in every entry - it's derived from the filename.
   initialize_with :file_path
 
   def call
     validate_file_exists!
+    validate_locale!
     validate_json!
 
     parsed_data.each do |entry|
@@ -13,7 +16,7 @@ class Level::Translation::CreateAllFromJson
       level = Level.find_by(uuid: entry["level_uuid"])
       raise InvalidJsonError, "Level not found for uuid: #{entry['level_uuid']}" unless level
 
-      translation = Level::Translation.find_or_initialize_by(level:, locale: entry["locale"])
+      translation = Level::Translation.find_or_initialize_by(level:, locale:)
       translation.update!(
         milestone_email_subject: entry["milestone_email_subject"],
         milestone_email_content_markdown: entry["milestone_email_content_markdown"]
@@ -26,15 +29,22 @@ class Level::Translation::CreateAllFromJson
     raise InvalidJsonError, "File not found: #{file_path}" unless File.exist?(file_path)
   end
 
+  def validate_locale!
+    raise InvalidJsonError, "Could not derive locale from filename: #{file_path}" if locale.blank?
+  end
+
   def validate_json!
     raise InvalidJsonError, "Invalid JSON structure: expected an array" unless parsed_data.is_a?(Array)
   end
 
   def validate_entry!(entry)
-    %w[level_uuid locale milestone_email_subject milestone_email_content_markdown].each do |key|
+    %w[level_uuid milestone_email_subject milestone_email_content_markdown].each do |key|
       raise InvalidJsonError, "Translation entry missing required '#{key}' field" if entry[key].blank?
     end
   end
+
+  memoize
+  def locale = File.basename(file_path, ".json")
 
   memoize
   def parsed_data

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,9 +36,12 @@ if sync_result[:orphaned_levels].any? || sync_result[:orphaned_lessons].any?
 end
 
 # == Level milestone email translations ==
-# Synced from level_translations.json, matched by level uuid + locale. See
-# docs/i18n.md for where this fits alongside the rest of the app's i18n content.
-Level::Translation::CreateAllFromJson.(Rails.root.join("db", "seeds", "level_translations.json").to_s)
+# One file per locale under level_translations/ (e.g. hu.json), matched by
+# level uuid. See docs/i18n.md for where this fits alongside the rest of the
+# app's i18n content.
+Dir.glob(Rails.root.join("db", "seeds", "level_translations", "*.json")).sort.each do |file_path|
+  Level::Translation::CreateAllFromJson.(file_path)
+end
 puts "✓ Level translations: #{Level::Translation.count}"
 
 # == Concepts ==

--- a/db/seeds/level_translations/hu.json
+++ b/db/seeds/level_translations/hu.json
@@ -1,115 +1,96 @@
 [
   {
     "level_uuid": "7963a7e0-0386-46fa-bf47-c19eaa1eb555",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Congratulations on hitting the first Milestone",
     "milestone_email_content_markdown": "[HU TBD] Great work on completing the first level of Jiki's Coding Fundamentals course.\n\nIt might not feel like you're doing much \"real\" coding yet, but you've just picked up one of the most important skills in programming. You'll be using functions hundreds of times a day from here on, so this really is the foundation for everything else.\n\nNext we'll look at using colours to draw, and then we'll start mixing some logic into the process. Have fun!"
   },
   {
     "level_uuid": "de4de3c1-d2ee-4af5-9df6-857a9f1df478",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Enjoyed Drawing?",
     "milestone_email_content_markdown": "[HU TBD] Great work on this level, and on your first proper bit of drawing.\n\nYou've now added strings and colours to your toolkit, which means your programs can start handling text and producing things that actually look good on screen.\n\nOver the next few lessons we'll start bringing in some logic, so you can move beyond linear instructions and add some variety and intelligence into your programs. Have fun!"
   },
   {
     "level_uuid": "8eafc890-d96f-4143-9556-fafd58f90735",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Feeling Loopy after all that Looping?",
     "milestone_email_content_markdown": "[HU TBD] Great work on this level. Loops are a fundamental building block of programming, and hopefully they're starting to feel pretty comfortable.\n\nThere are other types of loops we'll look at later in the course, but the repeat loop will be your companion for the next few lessons.\n\nNext up are variables, which is the idea of storing and retrieving values as your program runs. Have fun!"
   },
   {
     "level_uuid": "a47b33c1-fecd-4f15-a025-f95b878e31b7",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Variables in the bag",
     "milestone_email_content_markdown": "[HU TBD] Great work on getting variables under your belt.\n\nVariables are one of those ideas that's pretty simple on the surface, but they're going to underpin almost everything you write from now on. The ability to store a value, give it a name, and use it later is what turns code from a fixed list of instructions into something genuinely flexible.\n\nNext we'll look at how variables change over time, which is what programmers call \"state\". Have fun!"
   },
   {
     "level_uuid": "f74c506c-144e-4287-83eb-356568ffc234",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] State of play",
     "milestone_email_content_markdown": "[HU TBD] Great work on this one. You can now track values that change as your program runs, which is a real step up from where you were a couple of levels ago.\n\nThis idea of state is going to keep coming back throughout the course, and it gets more interesting every time we combine it with something new.\n\nNext is a meaty level. We'll look at functions that return values, and then explore colours, randomness, animation, scope, and nested loops along the way. Have fun!"
   },
   {
     "level_uuid": "e3933253-d25e-4b35-a442-4cd96ead2188",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Quite the haul",
     "milestone_email_content_markdown": "[HU TBD] Brilliant work on a packed level. Functions that return values, HSL and RGB colours, animation, random numbers, scope, scenarios, and loops within loops. That's a lot of new ideas to add to your toolkit in one go.\n\nDon't worry if some of them still feel a bit hazy. They'll all come back in different contexts later in the course, and each time they'll get more familiar.\n\nNext we'll start making decisions in code using if statements. This is where your programs really start to feel intelligent. Have fun!"
   },
   {
     "level_uuid": "2977da36-d6e7-4e94-b654-f029f8fd55dd",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] If, then, what?",
     "milestone_email_content_markdown": "[HU TBD] Nice work on the conditionals level. Hopefully if and else are starting to feel pretty natural.\n\nConditionals are one of the most important ideas in programming. Almost every interesting program needs to make decisions based on what's true at the time, and you've now got the basic tools to do that.\n\nNext we'll look at more powerful ways of writing conditions, combining them together with and/or, plus a few related ideas like modulo. Have fun!"
   },
   {
     "level_uuid": "fcd15968-fc9e-49e7-b6dc-d29da3ecf711",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Logical next steps",
     "milestone_email_content_markdown": "[HU TBD] Great work on a tricky level. You've now got and/or, modulo, and looping without a count under your belt.\n\nThese are the kinds of tools that let you write conditions that actually match real-world logic, rather than having to break everything down into tiny separate checks.\n\nNext we'll combine conditionals with state, which is where your programs start being able to respond to what's happening as they run. Have fun!"
   },
   {
     "level_uuid": "f8e8a86f-8802-4cdb-863c-6f8187785cfd",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Programs that respond",
     "milestone_email_content_markdown": "[HU TBD] Great work. Combining conditionals with state is where your programs really start to feel alive, responding to what's happening rather than just following a fixed script.\n\nThis is roughly the level of complexity you'll be writing at for the rest of the course, so everything you've practised here will keep coming back.\n\nNext up is a big one: writing your own functions. Up until now you've been using functions someone else wrote. From here on, you'll be writing your own. Have fun!"
   },
   {
     "level_uuid": "d45d91fe-f790-4f47-b072-9e7d8c453aa4",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Now you're in charge",
     "milestone_email_content_markdown": "[HU TBD] Brilliant work. Writing your own functions is a real shift. You're no longer just using the tools on the shelf, you're building new ones.\n\nThis is one of the most important skills in all of programming. Good code is mostly about breaking problems down into small, well-named functions, and you've now got everything you need to start doing that.\n\nNext we'll get back to strings and look at how to stick them together and slot values into them. Have fun!"
   },
   {
     "level_uuid": "0dcf7cf5-1b75-450d-aaeb-5246c28c3750",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Strings, attached",
     "milestone_email_content_markdown": "[HU TBD] Nice work on this one. Concatenation and templates are pretty simple ideas, but they come up constantly, especially anywhere you're producing output for a person to read.\n\nYou'll be using these techniques in pretty much every program you write from here on.\n\nNext we'll look at how to dig into strings character by character, and how to loop through their contents. Have fun!"
   },
   {
     "level_uuid": "a6244fe4-bc09-4c54-b244-0599bd419fdf",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Letter by letter",
     "milestone_email_content_markdown": "[HU TBD] Great work. Hopefully indexing and looping through strings is starting to make sense.\n\nBeing able to look at individual characters and walk through text systematically opens up a huge range of problems you can now solve. A lot of real-world programming is about exactly this kind of work.\n\nNext we'll look at how to combine multiple functions together to tackle more complex tasks. Have fun!"
   },
   {
     "level_uuid": "f2d5a243-732a-433d-9e9b-51548c41828c",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Better together",
     "milestone_email_content_markdown": "[HU TBD] Great work on this level. Combining functions to solve bigger problems is what professional programming actually looks like day to day. You break a problem into pieces, write a small function for each piece, and then put them together.\n\nYou're now doing this for real.\n\nNext we'll look at methods and properties, which is a slightly different way of working with values. Have fun!"
   },
   {
     "level_uuid": "37f0b015-986c-4b6a-8d3f-704a0056f994",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Methods to the madness",
     "milestone_email_content_markdown": "[HU TBD] Nice work. Methods and properties are a slightly different style to what you've seen so far. Instead of passing a value into a function, you call a function on the value itself. The idea takes a little getting used to, but it's used everywhere, so it'll start feeling natural pretty quickly.\n\nNext we'll look at some more powerful kinds of loops: for loops, while loops, break, and continue. Have fun!"
   },
   {
     "level_uuid": "86e3939f-3141-4b0e-aedb-249a1da33530",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] More than just repeat",
     "milestone_email_content_markdown": "[HU TBD] Great work. You've now got for loops, while loops, break, and continue under your belt. These are the loops you'll reach for most often outside of this course, so they're well worth the time you've put in.\n\nEach one has a slightly different job, and getting a feel for which to reach for will come with practice.\n\nNext we'll look at arrays, which is how programs store and work with collections of things. Have fun!"
   },
   {
     "level_uuid": "ecea29c5-9e4a-4d1a-a215-c3ea2d13a06d",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Quite the collection",
     "milestone_email_content_markdown": "[HU TBD] Brilliant work. Arrays (or lists, as some people call them) are one of the most useful tools in any language. Pretty much any time you're dealing with more than one of something, you'll reach for an array.\n\nYou've now got a good grasp of how to read from them and work through their contents.\n\nNext, we'll look at building arrays up from scratch, piece by piece. Have fun!"
   },
   {
     "level_uuid": "d65e091d-ea5d-4f7b-b588-d06fa712d91e",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Building things up",
     "milestone_email_content_markdown": "[HU TBD] Nice work! Reading from arrays is handy, but being able to build them up piece by piece is where they really come into their own. Loop over something, collect the bits you care about into a new array, and hand it back — that's a pattern you'll reach for again and again.\n\nNext up: dictionaries. These let you store values against named keys rather than just positions. Have fun!"
   },
   {
     "level_uuid": "4647e76e-e600-43dc-8354-bf30e2dc2537",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] Named for a reason",
     "milestone_email_content_markdown": "[HU TBD] Great stuff. Dictionaries let you store values against named keys rather than just positions, which makes looking things up fast and readable.\n\nNext, and finally, we'll look at changing dictionaries — adding, updating and removing entries as you go. Have fun!"
   },
   {
     "level_uuid": "42cbc5e7-c2eb-4abb-b3e2-724d240f6f9c",
-    "locale": "hu",
     "milestone_email_subject": "[HU TBD] That's a wrap",
     "milestone_email_content_markdown": "[HU TBD] And that's the last level of Coding Fundamentals. Hopefully dictionaries are feeling like a useful tool to add to the mix alongside arrays.\n\nThis is a real achievement. You've now covered every core building block of programming: functions, variables, state, conditionals, loops, strings, arrays, and dictionaries. Everything else from here is combinations and refinements of what you already know.\n\nWe're really proud of you for getting this far. Have fun!"
   }

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -20,7 +20,7 @@ adding, moving, or translating anything locale-related.
   `config/locales/**/*.{locale}.yml`, validated automatically by
   `test/i18n_parity_test.rb`.
 - **One exception: `Level` milestone email copy is DB-backed**, seeded from
-  `db/seeds/level_translations.json`, validated by
+  `db/seeds/level_translations/*.json` (one file per locale), validated by
   `test/db/seeds/level_translations_completeness_test.rb`.
 
 ## Rails I18n YAML catalogs (`config/locales/**`)
@@ -77,26 +77,30 @@ synced via `Level::CreateAllFromJson`). Other locales live in
 `Level::Translation` rows, fetched via `level.content_for_locale(locale)` and
 consumed by `ProgressionMailer#level_completed`.
 
-**Seeding:** `db/seeds/level_translations.json` is an array of
-`{ level_uuid, locale, milestone_email_subject, milestone_email_content_markdown }`
-entries, matched to `Level` by `uuid` (not slug - mirrors how
-`Level::CreateAllFromJson` matches). Loaded by
-`Level::Translation::CreateAllFromJson`, called from `db/seeds.rb` after the
+**Seeding:** `db/seeds/level_translations/` holds one file per locale, named
+after the locale it holds (e.g. `hu.json`) - not one giant file for every
+locale, to keep individual files reviewable. Each file is an array of
+`{ level_uuid, milestone_email_subject, milestone_email_content_markdown }`
+entries (no `locale` key - it's derived from the filename), matched to
+`Level` by `uuid` (not slug - mirrors how `Level::CreateAllFromJson`
+matches). `db/seeds.rb` globs every file in the directory and loads each
+through `Level::Translation::CreateAllFromJson`, called after the
 level/lesson sync. Like everything else in `db/seeds.rb`, this must stay
 idempotent - it's an upsert keyed on `(level, locale)`, never a delete.
 
-The `hu` entries currently in `level_translations.json` are placeholders
-(prefixed `[HU TBD]`), not real translations - this PR built the
-seeding/validation mechanism, not the translation content. Replacing them
-with real copy (by hand or via `Level::Translation::TranslateToLocale` /
-`TranslateToAllLocales`, the existing Gemini-backed commands) is separate
-follow-up work.
+The `hu.json` entries are currently placeholders (prefixed `[HU TBD]`), not
+real translations - this PR built the seeding/validation mechanism, not the
+translation content. Replacing them with real copy (by hand or via
+`Level::Translation::TranslateToLocale` / `TranslateToAllLocales`, the
+existing Gemini-backed commands) is separate follow-up work. Adding a new
+locale means adding a new `{locale}.json` file to the directory - no code
+changes needed.
 
 **Validation:** `test/db/seeds/level_translations_completeness_test.rb`
-checks that every level in `curriculum.json` has a complete entry in
-`level_translations.json` for every locale the file ships, with the same
-production-hard-fail / other-locales-warn severity split as
-`i18n_parity_test.rb`. This runs as part of `bin/rails test` too.
+checks that every level in `curriculum.json` has a complete entry in every
+`level_translations/*.json` file, with the same production-hard-fail /
+other-locales-warn severity split as `i18n_parity_test.rb`. This runs as
+part of `bin/rails test` too.
 
 ## Locale flow
 

--- a/test/commands/level/translation/create_all_from_json_test.rb
+++ b/test/commands/level/translation/create_all_from_json_test.rb
@@ -1,24 +1,24 @@
 require "test_helper"
 
 class Level::Translation::CreateAllFromJsonTest < ActiveSupport::TestCase
-  test "creates translations from valid JSON, matched by level uuid + locale" do
+  test "creates translations from valid JSON, locale derived from filename" do
     level = create(:level, uuid: "level-uuid-1")
 
-    sync!([entry(level_uuid: "level-uuid-1", locale: "hu")])
+    sync!("hu", [entry(level_uuid: "level-uuid-1")])
 
     translation = Level::Translation.find_for(level, "hu")
     assert translation
-    assert_equal "Subject hu", translation.milestone_email_subject
-    assert_equal "Body hu", translation.milestone_email_content_markdown
+    assert_equal "Subject", translation.milestone_email_subject
+    assert_equal "Body", translation.milestone_email_content_markdown
   end
 
   test "is idempotent - running twice keeps the same record, updated in place" do
     level = create(:level, uuid: "level-uuid-1")
 
-    sync!([entry(level_uuid: "level-uuid-1", locale: "hu")])
+    sync!("hu", [entry(level_uuid: "level-uuid-1")])
     translation_id = Level::Translation.find_for(level, "hu").id
 
-    sync!([entry(level_uuid: "level-uuid-1", locale: "hu", subject: "Updated subject")])
+    sync!("hu", [entry(level_uuid: "level-uuid-1", subject: "Updated subject")])
 
     assert_equal 1, Level::Translation.count
     translation = Level::Translation.find_for(level, "hu")
@@ -28,29 +28,29 @@ class Level::Translation::CreateAllFromJsonTest < ActiveSupport::TestCase
 
   test "raises for a level uuid that doesn't exist" do
     error = assert_raises InvalidJsonError do
-      sync!([entry(level_uuid: "missing-uuid", locale: "hu")])
+      sync!("hu", [entry(level_uuid: "missing-uuid")])
     end
 
     assert_match(/Level not found/, error.message)
   end
 
   test "raises for invalid JSON" do
-    file = Tempfile.new(["invalid", ".json"])
-    file.write("{ invalid json")
-    file.close
+    dir = Dir.mktmpdir
+    file_path = File.join(dir, "hu.json")
+    File.write(file_path, "{ invalid json")
 
     error = assert_raises InvalidJsonError do
-      Level::Translation::CreateAllFromJson.(file.path)
+      Level::Translation::CreateAllFromJson.(file_path)
     end
 
     assert_match(/Invalid JSON/, error.message)
   ensure
-    file.unlink
+    FileUtils.remove_entry(dir)
   end
 
   test "raises for a missing file" do
     error = assert_raises InvalidJsonError do
-      Level::Translation::CreateAllFromJson.("/nonexistent/path.json")
+      Level::Translation::CreateAllFromJson.("/nonexistent/hu.json")
     end
 
     assert_match(/File not found/, error.message)
@@ -58,27 +58,26 @@ class Level::Translation::CreateAllFromJsonTest < ActiveSupport::TestCase
 
   test "raises when an entry is missing a required field" do
     error = assert_raises InvalidJsonError do
-      sync!([entry(level_uuid: "level-uuid-1", locale: "hu").except("milestone_email_subject")])
+      sync!("hu", [entry(level_uuid: "level-uuid-1").except("milestone_email_subject")])
     end
 
     assert_match(/missing required 'milestone_email_subject' field/, error.message)
   end
 
   private
-  def sync!(entries)
-    file = Tempfile.new(["level_translations", ".json"])
-    file.write(JSON.generate(entries))
-    file.close
+  def sync!(locale, entries)
+    dir = Dir.mktmpdir
+    file_path = File.join(dir, "#{locale}.json")
+    File.write(file_path, JSON.generate(entries))
 
-    Level::Translation::CreateAllFromJson.(file.path)
+    Level::Translation::CreateAllFromJson.(file_path)
   ensure
-    file.unlink
+    FileUtils.remove_entry(dir)
   end
 
-  def entry(level_uuid:, locale:, subject: "Subject #{locale}", body: "Body #{locale}")
+  def entry(level_uuid:, subject: "Subject", body: "Body")
     {
       "level_uuid" => level_uuid,
-      "locale" => locale,
       "milestone_email_subject" => subject,
       "milestone_email_content_markdown" => body
     }

--- a/test/db/seeds/level_translations_completeness_test.rb
+++ b/test/db/seeds/level_translations_completeness_test.rb
@@ -1,27 +1,25 @@
 require "test_helper"
 
-# Guards db/seeds/level_translations.json against drifting out of sync with
+# Guards db/seeds/level_translations/*.json against drifting out of sync with
 # db/seeds/curriculum.json - the only translated content in this repo that
 # isn't a plain config/locales/**/*.yml catalog (see test/i18n_parity_test.rb
 # for those), so it needs its own completeness check. See docs/i18n.md.
 #
 # Severity mirrors I18nParityTest: hard-fail for I18n::PRODUCTION_LOCALES,
-# warn (non-fatal) for every other locale that ships at least one entry in
-# level_translations.json.
+# warn (non-fatal) for every other locale that ships a level_translations file.
 class LevelTranslationsCompletenessTest < ActiveSupport::TestCase
   CURRICULUM_FILE = Rails.root.join("db", "seeds", "curriculum.json")
-  TRANSLATIONS_FILE = Rails.root.join("db", "seeds", "level_translations.json")
+  TRANSLATIONS_DIR = Rails.root.join("db", "seeds", "level_translations")
   REQUIRED_FIELDS = %w[milestone_email_subject milestone_email_content_markdown].freeze
 
   test "every level has a translation entry for every locale it ships" do
     level_uuids = JSON.parse(File.read(CURRICULUM_FILE))["levels"].pluck("uuid")
-    entries = JSON.parse(File.read(TRANSLATIONS_FILE))
+    entries_by_locale = load_entries_by_locale
 
     failures = []
 
-    locales_shipped(entries).each do |locale|
-      entries_for_locale = entries.select { |e| e["locale"] == locale }
-      problems = problems_for(locale, level_uuids, entries_for_locale)
+    locales_shipped(entries_by_locale).each do |locale|
+      problems = problems_for(level_uuids, entries_by_locale[locale] || [])
       next if problems.empty?
 
       if I18n::PRODUCTION_LOCALES.include?(locale)
@@ -32,18 +30,24 @@ class LevelTranslationsCompletenessTest < ActiveSupport::TestCase
       end
     end
 
-    assert_empty failures, "level_translations.json completeness failures:\n\n#{failures.join("\n\n")}"
+    assert_empty failures, "level_translations completeness failures:\n\n#{failures.join("\n\n")}"
   end
 
   private
-  # Every locale we should check: production locales (there always must be
-  # complete coverage, even if that means zero entries are needed because en
-  # lives on Level itself) plus any locale that ships at least one entry.
-  def locales_shipped(entries)
-    (I18n::PRODUCTION_LOCALES + entries.pluck("locale")).uniq - ["en"]
+  # One entry array per locale, keyed by the file's basename (e.g. "hu").
+  def load_entries_by_locale
+    Dir.glob(TRANSLATIONS_DIR.join("*.json")).index_by { |path| File.basename(path, ".json") }.
+      transform_values { |path| JSON.parse(File.read(path)) }
   end
 
-  def problems_for(_locale, level_uuids, entries_for_locale)
+  # Every locale we should check: production locales (there always must be
+  # complete coverage, even if that means zero entries are needed because en
+  # lives on Level itself) plus any locale that ships a file.
+  def locales_shipped(entries_by_locale)
+    (I18n::PRODUCTION_LOCALES + entries_by_locale.keys).uniq - ["en"]
+  end
+
+  def problems_for(level_uuids, entries_for_locale)
     by_uuid = entries_for_locale.index_by { |e| e["level_uuid"] }
 
     problems = []


### PR DESCRIPTION
## Summary
Follow-up to #605: splits `db/seeds/level_translations.json` (one file holding every locale) into `db/seeds/level_translations/{locale}.json` - one file per locale - so it stays reviewable as more locales are added instead of growing into one giant file.

- `db/seeds/level_translations/hu.json` replaces `level_translations.json`, with `locale` dropped from each entry (implied by the filename now).
- `Level::Translation::CreateAllFromJson` takes a single per-locale file and derives the locale from its basename.
- `db/seeds.rb` globs `db/seeds/level_translations/*.json` and loads every file it finds.
- `test/db/seeds/level_translations_completeness_test.rb` updated to scan the directory instead of one file; same hard-fail/warn severity split as before.
- Adding a new locale going forward is just adding a new `{locale}.json` file - no code changes needed.

## Seed idempotency
Ran the directory-glob loading path twice against a seeded dev DB - `Level::Translation` count identical both times.

## Test plan
- [x] `bin/rails test` - full suite green (2150 runs)
- [x] `bin/rubocop -a`
- [x] `bin/brakeman`

Base branch is `drop-curriculum-copy-columns`, same stack as #604/#605.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01Myc6CcQkJ37DmTwJR7xT2J