### PR TITLE
Fix curriculum content check after front-end path refactor

### DIFF
--- a/lib/curriculum_content_check.rb
+++ b/lib/curriculum_content_check.rb
@@ -64,23 +64,23 @@ module CurriculumContentCheck
     {
       'level' => levels.map { |level| [level[:slug], "levels/#{level[:slug]}.ts"] },
       'exercise' => lessons.select { |l| l[:type] == 'exercise' }.
-        map { |l| [l[:slug], "exercises/#{l[:slug]}/instructions/source.md"] },
+        map { |l| [l[:slug], "exercises/#{l[:slug]}/instructions.md"] },
       'concept' => seeds('concepts.json').map { |c| [c[:slug], "concepts/#{c[:slug]}/source.md"] },
       # Challenges are exercises on the front end, reached via exercise_slug.
       'challenge' => seeds('challenges.json').
-        map { |c| [c[:slug], "exercises/#{c[:exercise_slug]}/instructions/source.md"] }
+        map { |c| [c[:slug], "exercises/#{c[:exercise_slug]}/instructions.md"] }
     }
   end
 
-  # Video lessons and badges are keyed inside a single per-locale JSON file
+  # Video lessons and badges are keyed inside a single English source catalogue
   # rather than getting a file each, so they are checked by key.
   def keyed_expectations
     lessons = seeds('curriculum.json')[:levels].flat_map { |level| level[:lessons] }
 
     {
-      'video lesson' => ['video-lessons/locales/en/translation.json',
+      'video lesson' => ['video-lessons/messages.json',
                          lessons.select { |l| l[:type] == 'video' }.map { |l| l[:slug] }],
-      'badge' => ['badges/locales/en/translation.json', BADGE_SLUGS]
+      'badge' => ['badges/messages.json', BADGE_SLUGS]
     }
   end
 


### PR DESCRIPTION
`verify_content` has been red on every PR, on pushes to main and on the weekly schedule, reporting ~89 exercises (and all video lessons/badges) with no front-end content. Not a false positive in the sense of the content being gone - the front end genuinely moved it:

- exercise instructions: `exercises/<slug>/instructions/source.md` -> `exercises/<slug>/instructions.md` (front-end #1038)
- video lessons: `video-lessons/locales/en/translation.json` -> `video-lessons/messages.json` (front-end #1046, "Flatten the locale directories that hold one file")
- badges: same flattening, `badges/messages.json`

Levels (`levels/<slug>.ts`) and concepts (`concepts/<slug>/source.md`) are unchanged, as is the `curriculum/src` root, so the workflow's sparse-checkout needs no change.

Verified against a current front-end checkout: `✓ All 209 seeded slugs have front-end content` - no real content gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)