### PR TITLE
Return Stripe's decline_code, not its English message

### DIFF
--- a/app/commands/stripe/verify_checkout_session.rb
+++ b/app/commands/stripe/verify_checkout_session.rb
@@ -7,11 +7,11 @@ class Stripe::VerifyCheckoutSession
     verify_ownership!
 
     # An incomplete session is an expected outcome (declined/abandoned/expired payment),
-    # not a bug. Surface the decline reason and the attempted plan (interval + currency,
+    # not a bug. Surface the decline code and the attempted plan (interval + currency,
     # which Jiki prices vary by) so the UI can offer a precise "retry" CTA.
     unless session.status == "complete"
       raise StripeCheckoutSessionIncompleteError.new(
-        decline_reason:, interval: attempted_interval, currency: session.currency
+        decline_code:, interval: attempted_interval, currency: session.currency
       )
     end
     raise ArgumentError, "Checkout session has no subscription" unless session.subscription.present?
@@ -35,7 +35,7 @@ class Stripe::VerifyCheckoutSession
       interval: interval,
       payment_status: session.payment_status,
       payment_state: payment_state,
-      decline_reason: payment_state == "failed" ? first_invoice_payment_intent&.last_payment_error&.message : nil,
+      decline_code: payment_state == "failed" ? decline_code_for(first_invoice_payment_intent) : nil,
       subscription_status: status
     }
   end
@@ -119,11 +119,29 @@ class Stripe::VerifyCheckoutSession
   # Best-effort customer-facing decline reason for an incomplete (status != complete)
   # checkout. Returns nil for abandoned/expired sessions with no payment attempt, and
   # never raises - a missing reason degrades to the generic "payment wasn't completed".
-  def decline_reason
-    declined_payment_intent&.last_payment_error&.message
+  def decline_code
+    decline_code_for(declined_payment_intent)
   rescue ::Stripe::StripeError => e
     Rails.logger.warn("Could not determine checkout decline reason for #{session_id}: #{e.message}")
     nil
+  end
+
+  # Stripe's own English message text is never returned to the client - only the
+  # stable decline_code/code, so the front-end can map it to localized copy (see
+  # https://docs.stripe.com/declines/codes). A handful of codes are collapsed to
+  # the generic "card_declined" per Stripe's own guidance: don't tell a customer
+  # their card was reported fraudulent/stolen/lost, since that tips off an
+  # attacker who's testing stolen numbers to try a different card instead.
+  SENSITIVE_DECLINE_CODES = %w[fraudulent stolen_card lost_card merchant_blacklist pickup_card restricted_card].freeze
+
+  def decline_code_for(payment_intent)
+    error = payment_intent&.last_payment_error
+    return nil unless error
+
+    code = error.decline_code.presence || error.code
+    return nil if code.blank?
+
+    SENSITIVE_DECLINE_CODES.include?(code) ? "card_declined" : code
   end
 
   def declined_payment_intent

--- a/app/controllers/internal/subscriptions_controller.rb
+++ b/app/controllers/internal/subscriptions_controller.rb
@@ -99,7 +99,7 @@ class Internal::SubscriptionsController < Internal::BaseController
       interval: result[:interval],
       payment_status: result[:payment_status],
       payment_state: result[:payment_state],
-      decline_reason: result[:decline_reason],
+      decline_code: result[:decline_code],
       subscription_status: result[:subscription_status]
     }
   rescue SecurityError => e
@@ -109,11 +109,11 @@ class Internal::SubscriptionsController < Internal::BaseController
   rescue StripeCheckoutSessionIncompleteError => e
     # Expected user-driven outcome (declined/abandoned payment), not a bug -
     # log only, don't report to Sentry.
-    Rails.logger.info("Checkout session incomplete: #{e.decline_reason || 'no reason given'}")
+    Rails.logger.info("Checkout session incomplete: #{e.decline_code || 'no reason given'}")
     render json: {
       error: {
         type: "checkout_payment_incomplete",
-        decline_reason: e.decline_reason,
+        decline_code: e.decline_code,
         interval: e.interval,
         currency: e.currency
       }

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -101,12 +101,12 @@ class MailshotUnknownSegmentError < RuntimeError; end
 class MailshotBlankBodyError < RuntimeError; end
 
 class StripeCheckoutSessionIncompleteError < RuntimeError
-  attr_reader :decline_reason, :interval, :currency
+  attr_reader :decline_code, :interval, :currency
 
-  def initialize(decline_reason: nil, interval: nil, currency: nil)
-    @decline_reason = decline_reason
+  def initialize(decline_code: nil, interval: nil, currency: nil)
+    @decline_code = decline_code
     @interval = interval
     @currency = currency
-    super(decline_reason || "Checkout session is not complete")
+    super(decline_code || "Checkout session is not complete")
   end
 end

--- a/docs/api_error_types.md
+++ b/docs/api_error_types.md
@@ -118,7 +118,7 @@ copy included as a starting point for the front-end catalogue.
 - `cancel_failed` - "Cancellation failed"
 - `not_cancelling` - "Subscription is not scheduled for cancellation"
 - `reactivate_failed` - "Reactivation failed"
-- `checkout_payment_incomplete` - was "Your payment wasn't completed. Please try again." (extra: `decline_reason`, `interval`, `currency`)
+- `checkout_payment_incomplete` - was "Your payment wasn't completed. Please try again." (extra: `decline_code`, `interval`, `currency`). `decline_code` is a stable key (e.g. `insufficient_funds`, `expired_card`, `card_declined`), not free text - map it to your own localized copy rather than displaying it directly, same pattern as `error.type` elsewhere in the API.
 - `unauthorized` (subscriptions-specific) - was "Checkout session does not belong to current user"
 
 ### External services

--- a/test/commands/stripe/verify_checkout_session_test.rb
+++ b/test/commands/stripe/verify_checkout_session_test.rb
@@ -18,7 +18,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     assert_equal "monthly", result[:interval]
     assert_equal "paid", result[:payment_status]
     assert_equal "paid", result[:payment_state]
-    assert_nil result[:decline_reason]
+    assert_nil result[:decline_code]
     assert_equal "active", result[:subscription_status]
 
     user.data.reload
@@ -77,7 +77,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     stripe_session.stubs(:currency).returns("gbp")
     ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
 
-    payment_intent = stub(last_payment_error: stub(message: "Your card has insufficient funds."))
+    payment_intent = stub(last_payment_error: stub(code: "insufficient_funds", decline_code: nil))
     detailed = stub(payment_intent:)
     ::Stripe::Checkout::Session.expects(:retrieve).
       with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
@@ -86,9 +86,32 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     error = assert_raises(StripeCheckoutSessionIncompleteError) do
       Stripe::VerifyCheckoutSession.(user, "cs_test_123")
     end
-    assert_equal "Your card has insufficient funds.", error.decline_reason
+    assert_equal "insufficient_funds", error.decline_code
     assert_equal "monthly", error.interval
     assert_equal "gbp", error.currency
+  end
+
+  test "collapses sensitive decline codes to the generic card_declined rather than exposing the real reason" do
+    user = create(:user)
+    user.data.update!(stripe_customer_id: "cus_123")
+
+    stripe_session = mock
+    stripe_session.stubs(:metadata).returns("price_id" => Jiki.config.stripe_premium_monthly_price_id)
+    stripe_session.stubs(:customer).returns("cus_123")
+    stripe_session.stubs(:status).returns("open")
+    stripe_session.stubs(:currency).returns("gbp")
+    ::Stripe::Checkout::Session.expects(:retrieve).with("cs_test_123").returns(stripe_session)
+
+    payment_intent = stub(last_payment_error: stub(decline_code: "stolen_card"))
+    detailed = stub(payment_intent:)
+    ::Stripe::Checkout::Session.expects(:retrieve).
+      with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
+      returns(detailed)
+
+    error = assert_raises(StripeCheckoutSessionIncompleteError) do
+      Stripe::VerifyCheckoutSession.(user, "cs_test_123")
+    end
+    assert_equal "card_declined", error.decline_code
   end
 
   test "derives the decline reason from the subscription invoice in subscription mode" do
@@ -109,13 +132,13 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
       with(id: "cs_test_123", expand: ["payment_intent", "subscription.latest_invoice.payments"]).
       returns(detailed)
 
-    payment_intent = stub(last_payment_error: stub(message: "Your card was declined."))
+    payment_intent = stub(last_payment_error: stub(decline_code: "generic_decline"))
     ::Stripe::PaymentIntent.expects(:retrieve).with("pi_1").returns(payment_intent)
 
     error = assert_raises(StripeCheckoutSessionIncompleteError) do
       Stripe::VerifyCheckoutSession.(user, "cs_test_123")
     end
-    assert_equal "Your card was declined.", error.decline_reason
+    assert_equal "generic_decline", error.decline_code
   end
 
   test "raises StripeCheckoutSessionIncompleteError with nil reason when no payment was attempted" do
@@ -137,7 +160,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     error = assert_raises(StripeCheckoutSessionIncompleteError) do
       Stripe::VerifyCheckoutSession.(user, "cs_test_123")
     end
-    assert_nil error.decline_reason
+    assert_nil error.decline_code
   end
 
   test "swallows Stripe errors while fetching the decline reason" do
@@ -157,7 +180,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     error = assert_raises(StripeCheckoutSessionIncompleteError) do
       Stripe::VerifyCheckoutSession.(user, "cs_test_123")
     end
-    assert_nil error.decline_reason
+    assert_nil error.decline_code
   end
 
   test "does not adopt the customer id when the checkout is incomplete" do
@@ -287,7 +310,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     assert_equal "monthly", result[:interval]
     assert_equal "unpaid", result[:payment_status]
     assert_equal "processing", result[:payment_state]
-    assert_nil result[:decline_reason]
+    assert_nil result[:decline_code]
     assert_equal "incomplete", result[:subscription_status]
 
     user.data.reload
@@ -313,7 +336,7 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     result = Stripe::VerifyCheckoutSession.(user, "cs_test_123")
 
     assert_equal "processing", result[:payment_state]
-    assert_nil result[:decline_reason]
+    assert_nil result[:decline_code]
   end
 
   test "reports payment_state failed with the decline reason when the first payment is declined" do
@@ -334,14 +357,14 @@ class Stripe::VerifyCheckoutSessionTest < ActiveSupport::TestCase
     ::Stripe::Invoice.expects(:retrieve).with(id: "in_1", expand: ["payments"]).returns(invoice)
     payment_intent = stub(
       status: "requires_payment_method",
-      last_payment_error: stub(message: "Your card has insufficient funds.")
+      last_payment_error: stub(code: "insufficient_funds", decline_code: nil)
     )
     ::Stripe::PaymentIntent.expects(:retrieve).with("pi_1").returns(payment_intent)
 
     result = Stripe::VerifyCheckoutSession.(user, "cs_test_123")
 
     assert_equal "failed", result[:payment_state]
-    assert_equal "Your card has insufficient funds.", result[:decline_reason]
+    assert_equal "insufficient_funds", result[:decline_code]
   end
 
   private

--- a/test/controllers/internal/subscriptions_controller_test.rb
+++ b/test/controllers/internal/subscriptions_controller_test.rb
@@ -250,7 +250,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
       interval: "monthly",
       payment_status: "paid",
       payment_state: "paid",
-      decline_reason: nil,
+      decline_code: nil,
       subscription_status: "active"
     })
 
@@ -264,11 +264,11 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert_equal "monthly", json["interval"]
     assert_equal "paid", json["payment_status"]
     assert_equal "paid", json["payment_state"]
-    assert_nil json["decline_reason"]
+    assert_nil json["decline_code"]
     assert_equal "active", json["subscription_status"]
   end
 
-  test "POST verify_checkout passes through payment_state and decline_reason for a failed async payment" do
+  test "POST verify_checkout passes through payment_state and decline_code for a failed async payment" do
     session_id = "cs_test_123"
 
     Stripe::VerifyCheckoutSession.expects(:call).with(@user, session_id).returns({
@@ -276,7 +276,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
       interval: "monthly",
       payment_status: "unpaid",
       payment_state: "failed",
-      decline_reason: "Your card has insufficient funds.",
+      decline_code: "insufficient_funds",
       subscription_status: "incomplete"
     })
 
@@ -287,7 +287,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert_response :success
     json = response.parsed_body
     assert_equal "failed", json["payment_state"]
-    assert_equal "Your card has insufficient funds.", json["decline_reason"]
+    assert_equal "insufficient_funds", json["decline_code"]
   end
 
   test "POST verify_checkout returns incomplete status for async payments" do
@@ -298,7 +298,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
       interval: "monthly",
       payment_status: "unpaid",
       payment_state: "processing",
-      decline_reason: nil,
+      decline_code: nil,
       subscription_status: "incomplete"
     })
 
@@ -357,13 +357,13 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert_equal "invalid_session", json["error"]["type"]
   end
 
-  test "POST verify_checkout returns checkout_payment_incomplete with decline reason and attempted plan" do
+  test "POST verify_checkout returns checkout_payment_incomplete with decline code and attempted plan" do
     session_id = "cs_test_123"
 
     Stripe::VerifyCheckoutSession.expects(:call).
       with(@user, session_id).
       raises(StripeCheckoutSessionIncompleteError.new(
-        decline_reason: "Your card has insufficient funds.", interval: "monthly", currency: "gbp"
+        decline_code: "insufficient_funds", interval: "monthly", currency: "gbp"
       ))
 
     post internal_subscriptions_verify_checkout_path,
@@ -373,7 +373,7 @@ class Internal::SubscriptionsControllerTest < ApplicationControllerTest
     assert_response :unprocessable_entity
     json = response.parsed_body
     assert_equal "checkout_payment_incomplete", json["error"]["type"]
-    assert_equal "Your card has insufficient funds.", json["error"]["decline_reason"]
+    assert_equal "insufficient_funds", json["error"]["decline_code"]
     assert_equal "monthly", json["error"]["interval"]
     assert_equal "gbp", json["error"]["currency"]
   end


### PR DESCRIPTION
## Summary
Follow-up to #604: the checkout-verification flow (`Stripe::VerifyCheckoutSession`, `Internal::SubscriptionsController#verify_checkout`) was the one remaining place in the API returning raw English text - Stripe's own `last_payment_error.message` (e.g. "Your card was declined."), verbatim, in a `decline_reason` field. Everything else #604 touched went through the type/structured-data pattern; this one slipped through because it's third-party text, not our own copy.

- `decline_reason` -> `decline_code` everywhere (command return value, `StripeCheckoutSessionIncompleteError`, controller responses for both the 200 success-with-failed-payment path and the 422 `checkout_payment_incomplete` error path).
- Uses Stripe's own stable `decline_code` (falling back to the broader `code` when `decline_code` isn't populated) instead of `.message` - this is what [Stripe's own docs](https://docs.stripe.com/declines/codes) recommend building UI off, precisely so integrators can map it to their own localized copy rather than displaying Stripe's English text.
- Per Stripe's own guidance, a handful of codes that would tip off an attacker (`fraudulent`, `stolen_card`, `lost_card`, `merchant_blacklist`, `pickup_card`, `restricted_card`) are collapsed to the generic `card_declined` before ever leaving the API - don't tell a customer their card was flagged stolen, since that's exactly the kind of signal someone testing stolen card numbers would want.
- `docs/api_error_types.md` updated with a short brief for the front-end: `decline_code` is a stable key, not free text, to be mapped to localized copy same as `error.type`.

## Test plan
- [x] `bin/rails test` - full suite green (2144 runs)
- [x] `bin/rubocop -a`
- [x] `bin/brakeman`
- [x] Added a test covering the sensitive-code collapsing behavior

Base branch is `remove-fe-ignored-api-error-messages` (#604), same stack.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Myc6CcQkJ37DmTwJR7xT2J