### PR TITLE
Translate the shared email footer and mailer boilerplate

### DIFF
--- a/config/locales/mailers/notifications_mailer.ar.yml
+++ b/config/locales/mailers/notifications_mailer.ar.yml
@@ -1,0 +1,6 @@
+ar:
+  notifications_mailer:
+    badge_earned:
+      greeting: "مرحبًا،"
+      signoff: "مع التحية،"
+      team: "جيريمي والفريق"

--- a/config/locales/mailers/notifications_mailer.bn.yml
+++ b/config/locales/mailers/notifications_mailer.bn.yml
@@ -1,0 +1,6 @@
+bn:
+  notifications_mailer:
+    badge_earned:
+      greeting: "হ্যালো,"
+      signoff: "শুভেচ্ছান্তে,"
+      team: "জেরেমি ও টিম"

--- a/config/locales/mailers/notifications_mailer.ca.yml
+++ b/config/locales/mailers/notifications_mailer.ca.yml
@@ -1,0 +1,6 @@
+ca:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Hola,"
+      signoff: "Salutacions,"
+      team: "Jeremy i l'equip"

--- a/config/locales/mailers/notifications_mailer.de.yml
+++ b/config/locales/mailers/notifications_mailer.de.yml
@@ -1,0 +1,6 @@
+de:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Hallo,"
+      signoff: "Viele Grüße,"
+      team: "Jeremy & das Team"

--- a/config/locales/mailers/notifications_mailer.el.yml
+++ b/config/locales/mailers/notifications_mailer.el.yml
@@ -1,0 +1,6 @@
+el:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Γεια σου,"
+      signoff: "Με εκτίμηση,"
+      team: "Ο Jeremy και η ομάδα"

--- a/config/locales/mailers/notifications_mailer.es-419.yml
+++ b/config/locales/mailers/notifications_mailer.es-419.yml
@@ -1,0 +1,6 @@
+"es-419":
+  notifications_mailer:
+    badge_earned:
+      greeting: "Hola,"
+      signoff: "Saludos,"
+      team: "Jeremy y el equipo"

--- a/config/locales/mailers/notifications_mailer.es-ES.yml
+++ b/config/locales/mailers/notifications_mailer.es-ES.yml
@@ -1,0 +1,6 @@
+"es-ES":
+  notifications_mailer:
+    badge_earned:
+      greeting: "Hola,"
+      signoff: "Un saludo,"
+      team: "Jeremy y el equipo"

--- a/config/locales/mailers/notifications_mailer.fa.yml
+++ b/config/locales/mailers/notifications_mailer.fa.yml
@@ -1,0 +1,6 @@
+fa:
+  notifications_mailer:
+    badge_earned:
+      greeting: "سلام،"
+      signoff: "با احترام،"
+      team: "جرمی و تیم"

--- a/config/locales/mailers/notifications_mailer.fr.yml
+++ b/config/locales/mailers/notifications_mailer.fr.yml
@@ -1,0 +1,6 @@
+fr:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Salut,"
+      signoff: "À bientôt,"
+      team: "Jeremy et l'équipe"

--- a/config/locales/mailers/notifications_mailer.hi.yml
+++ b/config/locales/mailers/notifications_mailer.hi.yml
@@ -1,0 +1,6 @@
+hi:
+  notifications_mailer:
+    badge_earned:
+      greeting: "नमस्ते,"
+      signoff: "शुभकामनाएँ,"
+      team: "जेरेमी और टीम"

--- a/config/locales/mailers/notifications_mailer.id.yml
+++ b/config/locales/mailers/notifications_mailer.id.yml
@@ -1,0 +1,6 @@
+id:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Halo,"
+      signoff: "Salam,"
+      team: "Jeremy & Tim"

--- a/config/locales/mailers/notifications_mailer.it.yml
+++ b/config/locales/mailers/notifications_mailer.it.yml
@@ -1,0 +1,6 @@
+it:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Ciao,"
+      signoff: "A presto,"
+      team: "Jeremy e il team"

--- a/config/locales/mailers/notifications_mailer.ja.yml
+++ b/config/locales/mailers/notifications_mailer.ja.yml
@@ -1,0 +1,6 @@
+ja:
+  notifications_mailer:
+    badge_earned:
+      greeting: "こんにちは、"
+      signoff: "それでは、"
+      team: "Jeremy とチーム一同"

--- a/config/locales/mailers/notifications_mailer.ko.yml
+++ b/config/locales/mailers/notifications_mailer.ko.yml
@@ -1,0 +1,6 @@
+ko:
+  notifications_mailer:
+    badge_earned:
+      greeting: "안녕하세요,"
+      signoff: "감사합니다,"
+      team: "Jeremy와 팀 일동"

--- a/config/locales/mailers/notifications_mailer.nl.yml
+++ b/config/locales/mailers/notifications_mailer.nl.yml
@@ -1,0 +1,6 @@
+nl:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Hoi,"
+      signoff: "Groeten,"
+      team: "Jeremy & het team"

--- a/config/locales/mailers/notifications_mailer.pl.yml
+++ b/config/locales/mailers/notifications_mailer.pl.yml
@@ -1,0 +1,6 @@
+pl:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Cześć,"
+      signoff: "Pozdrawiamy,"
+      team: "Jeremy i zespół"

--- a/config/locales/mailers/notifications_mailer.pt-BR.yml
+++ b/config/locales/mailers/notifications_mailer.pt-BR.yml
@@ -1,0 +1,6 @@
+"pt-BR":
+  notifications_mailer:
+    badge_earned:
+      greeting: "Olá,"
+      signoff: "Abraços,"
+      team: "Jeremy e equipe"

--- a/config/locales/mailers/notifications_mailer.pt-PT.yml
+++ b/config/locales/mailers/notifications_mailer.pt-PT.yml
@@ -1,0 +1,6 @@
+"pt-PT":
+  notifications_mailer:
+    badge_earned:
+      greeting: "Olá,"
+      signoff: "Cumprimentos,"
+      team: "Jeremy e a equipa"

--- a/config/locales/mailers/notifications_mailer.ro.yml
+++ b/config/locales/mailers/notifications_mailer.ro.yml
@@ -1,0 +1,6 @@
+ro:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Salut,"
+      signoff: "Cu drag,"
+      team: "Jeremy și echipa"

--- a/config/locales/mailers/notifications_mailer.ru.yml
+++ b/config/locales/mailers/notifications_mailer.ru.yml
@@ -1,0 +1,6 @@
+ru:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Здравствуйте,"
+      signoff: "С уважением,"
+      team: "Джереми и команда"

--- a/config/locales/mailers/notifications_mailer.sr.yml
+++ b/config/locales/mailers/notifications_mailer.sr.yml
@@ -1,0 +1,6 @@
+sr:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Zdravo,"
+      signoff: "Pozdrav,"
+      team: "Jeremy i tim"

--- a/config/locales/mailers/notifications_mailer.sv.yml
+++ b/config/locales/mailers/notifications_mailer.sv.yml
@@ -1,0 +1,6 @@
+sv:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Hej,"
+      signoff: "Vänliga hälsningar,"
+      team: "Jeremy & teamet"

--- a/config/locales/mailers/notifications_mailer.sw.yml
+++ b/config/locales/mailers/notifications_mailer.sw.yml
@@ -1,0 +1,6 @@
+sw:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Habari,"
+      signoff: "Asante,"
+      team: "Jeremy na Timu"

--- a/config/locales/mailers/notifications_mailer.tr.yml
+++ b/config/locales/mailers/notifications_mailer.tr.yml
@@ -1,0 +1,6 @@
+tr:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Merhaba,"
+      signoff: "Sevgiler,"
+      team: "Jeremy ve ekibi"

--- a/config/locales/mailers/notifications_mailer.uk.yml
+++ b/config/locales/mailers/notifications_mailer.uk.yml
@@ -1,0 +1,6 @@
+uk:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Вітаємо,"
+      signoff: "З повагою,"
+      team: "Джеремі та команда"

--- a/config/locales/mailers/notifications_mailer.ur.yml
+++ b/config/locales/mailers/notifications_mailer.ur.yml
@@ -1,0 +1,6 @@
+ur:
+  notifications_mailer:
+    badge_earned:
+      greeting: "سلام،"
+      signoff: "نیک تمناؤں کے ساتھ،"
+      team: "جیریمی اور ٹیم"

--- a/config/locales/mailers/notifications_mailer.vi.yml
+++ b/config/locales/mailers/notifications_mailer.vi.yml
@@ -1,0 +1,6 @@
+vi:
+  notifications_mailer:
+    badge_earned:
+      greeting: "Xin chào,"
+      signoff: "Thân mến,"
+      team: "Jeremy và nhóm"

--- a/config/locales/mailers/notifications_mailer.zh-CN.yml
+++ b/config/locales/mailers/notifications_mailer.zh-CN.yml
@@ -1,0 +1,6 @@
+"zh-CN":
+  notifications_mailer:
+    badge_earned:
+      greeting: "您好，"
+      signoff: "祝好，"
+      team: "Jeremy 和团队"

--- a/config/locales/mailers/notifications_mailer.zh-TW.yml
+++ b/config/locales/mailers/notifications_mailer.zh-TW.yml
@@ -1,0 +1,6 @@
+"zh-TW":
+  notifications_mailer:
+    badge_earned:
+      greeting: "您好，"
+      signoff: "祝好，"
+      team: "Jeremy 與團隊"

--- a/config/locales/mailers/progression_mailer.ar.yml
+++ b/config/locales/mailers/progression_mailer.ar.yml
@@ -1,0 +1,6 @@
+ar:
+  progression_mailer:
+    level_completed:
+      greeting: "مرحبًا،"
+      signoff: "مع التحية،"
+      team: "جيريمي والفريق"

--- a/config/locales/mailers/progression_mailer.bn.yml
+++ b/config/locales/mailers/progression_mailer.bn.yml
@@ -1,0 +1,6 @@
+bn:
+  progression_mailer:
+    level_completed:
+      greeting: "হ্যালো,"
+      signoff: "শুভেচ্ছান্তে,"
+      team: "জেরেমি ও টিম"

--- a/config/locales/mailers/progression_mailer.ca.yml
+++ b/config/locales/mailers/progression_mailer.ca.yml
@@ -1,0 +1,6 @@
+ca:
+  progression_mailer:
+    level_completed:
+      greeting: "Hola,"
+      signoff: "Salutacions,"
+      team: "Jeremy i l'equip"

--- a/config/locales/mailers/progression_mailer.de.yml
+++ b/config/locales/mailers/progression_mailer.de.yml
@@ -1,0 +1,6 @@
+de:
+  progression_mailer:
+    level_completed:
+      greeting: "Hallo,"
+      signoff: "Viele Grüße,"
+      team: "Jeremy & das Team"

--- a/config/locales/mailers/progression_mailer.el.yml
+++ b/config/locales/mailers/progression_mailer.el.yml
@@ -1,0 +1,6 @@
+el:
+  progression_mailer:
+    level_completed:
+      greeting: "Γεια σου,"
+      signoff: "Με εκτίμηση,"
+      team: "Ο Jeremy και η ομάδα"

--- a/config/locales/mailers/progression_mailer.es-419.yml
+++ b/config/locales/mailers/progression_mailer.es-419.yml
@@ -1,0 +1,6 @@
+"es-419":
+  progression_mailer:
+    level_completed:
+      greeting: "Hola,"
+      signoff: "Saludos,"
+      team: "Jeremy y el equipo"

--- a/config/locales/mailers/progression_mailer.es-ES.yml
+++ b/config/locales/mailers/progression_mailer.es-ES.yml
@@ -1,0 +1,6 @@
+"es-ES":
+  progression_mailer:
+    level_completed:
+      greeting: "Hola,"
+      signoff: "Un saludo,"
+      team: "Jeremy y el equipo"

--- a/config/locales/mailers/progression_mailer.fa.yml
+++ b/config/locales/mailers/progression_mailer.fa.yml
@@ -1,0 +1,6 @@
+fa:
+  progression_mailer:
+    level_completed:
+      greeting: "سلام،"
+      signoff: "با احترام،"
+      team: "جرمی و تیم"

--- a/config/locales/mailers/progression_mailer.fr.yml
+++ b/config/locales/mailers/progression_mailer.fr.yml
@@ -1,0 +1,6 @@
+fr:
+  progression_mailer:
+    level_completed:
+      greeting: "Salut,"
+      signoff: "À bientôt,"
+      team: "Jeremy et l'équipe"

--- a/config/locales/mailers/progression_mailer.hi.yml
+++ b/config/locales/mailers/progression_mailer.hi.yml
@@ -1,0 +1,6 @@
+hi:
+  progression_mailer:
+    level_completed:
+      greeting: "नमस्ते,"
+      signoff: "शुभकामनाएँ,"
+      team: "जेरेमी और टीम"

--- a/config/locales/mailers/progression_mailer.id.yml
+++ b/config/locales/mailers/progression_mailer.id.yml
@@ -1,0 +1,6 @@
+id:
+  progression_mailer:
+    level_completed:
+      greeting: "Halo,"
+      signoff: "Salam,"
+      team: "Jeremy & Tim"

--- a/config/locales/mailers/progression_mailer.it.yml
+++ b/config/locales/mailers/progression_mailer.it.yml
@@ -1,0 +1,6 @@
+it:
+  progression_mailer:
+    level_completed:
+      greeting: "Ciao,"
+      signoff: "A presto,"
+      team: "Jeremy e il team"

--- a/config/locales/mailers/progression_mailer.ja.yml
+++ b/config/locales/mailers/progression_mailer.ja.yml
@@ -1,0 +1,6 @@
+ja:
+  progression_mailer:
+    level_completed:
+      greeting: "こんにちは、"
+      signoff: "それでは、"
+      team: "Jeremy とチーム一同"

--- a/config/locales/mailers/progression_mailer.ko.yml
+++ b/config/locales/mailers/progression_mailer.ko.yml
@@ -1,0 +1,6 @@
+ko:
+  progression_mailer:
+    level_completed:
+      greeting: "안녕하세요,"
+      signoff: "감사합니다,"
+      team: "Jeremy와 팀 일동"

--- a/config/locales/mailers/progression_mailer.nl.yml
+++ b/config/locales/mailers/progression_mailer.nl.yml
@@ -1,0 +1,6 @@
+nl:
+  progression_mailer:
+    level_completed:
+      greeting: "Hoi,"
+      signoff: "Groeten,"
+      team: "Jeremy & het team"

--- a/config/locales/mailers/progression_mailer.pl.yml
+++ b/config/locales/mailers/progression_mailer.pl.yml
@@ -1,0 +1,6 @@
+pl:
+  progression_mailer:
+    level_completed:
+      greeting: "Cześć,"
+      signoff: "Pozdrawiamy,"
+      team: "Jeremy i zespół"

--- a/config/locales/mailers/progression_mailer.pt-BR.yml
+++ b/config/locales/mailers/progression_mailer.pt-BR.yml
@@ -1,0 +1,6 @@
+"pt-BR":
+  progression_mailer:
+    level_completed:
+      greeting: "Olá,"
+      signoff: "Abraços,"
+      team: "Jeremy e equipe"

--- a/config/locales/mailers/progression_mailer.pt-PT.yml
+++ b/config/locales/mailers/progression_mailer.pt-PT.yml
@@ -1,0 +1,6 @@
+"pt-PT":
+  progression_mailer:
+    level_completed:
+      greeting: "Olá,"
+      signoff: "Cumprimentos,"
+      team: "Jeremy e a equipa"

--- a/config/locales/mailers/progression_mailer.ro.yml
+++ b/config/locales/mailers/progression_mailer.ro.yml
@@ -1,0 +1,6 @@
+ro:
+  progression_mailer:
+    level_completed:
+      greeting: "Salut,"
+      signoff: "Cu drag,"
+      team: "Jeremy și echipa"

--- a/config/locales/mailers/progression_mailer.ru.yml
+++ b/config/locales/mailers/progression_mailer.ru.yml
@@ -1,0 +1,6 @@
+ru:
+  progression_mailer:
+    level_completed:
+      greeting: "Здравствуйте,"
+      signoff: "С уважением,"
+      team: "Джереми и команда"

--- a/config/locales/mailers/progression_mailer.sr.yml
+++ b/config/locales/mailers/progression_mailer.sr.yml
@@ -1,0 +1,6 @@
+sr:
+  progression_mailer:
+    level_completed:
+      greeting: "Zdravo,"
+      signoff: "Pozdrav,"
+      team: "Jeremy i tim"

--- a/config/locales/mailers/progression_mailer.sv.yml
+++ b/config/locales/mailers/progression_mailer.sv.yml
@@ -1,0 +1,6 @@
+sv:
+  progression_mailer:
+    level_completed:
+      greeting: "Hej,"
+      signoff: "Vänliga hälsningar,"
+      team: "Jeremy & teamet"

--- a/config/locales/mailers/progression_mailer.sw.yml
+++ b/config/locales/mailers/progression_mailer.sw.yml
@@ -1,0 +1,6 @@
+sw:
+  progression_mailer:
+    level_completed:
+      greeting: "Habari,"
+      signoff: "Asante,"
+      team: "Jeremy na Timu"

--- a/config/locales/mailers/progression_mailer.tr.yml
+++ b/config/locales/mailers/progression_mailer.tr.yml
@@ -1,0 +1,6 @@
+tr:
+  progression_mailer:
+    level_completed:
+      greeting: "Merhaba,"
+      signoff: "Sevgiler,"
+      team: "Jeremy ve ekibi"

--- a/config/locales/mailers/progression_mailer.uk.yml
+++ b/config/locales/mailers/progression_mailer.uk.yml
@@ -1,0 +1,6 @@
+uk:
+  progression_mailer:
+    level_completed:
+      greeting: "Вітаємо,"
+      signoff: "З повагою,"
+      team: "Джеремі та команда"

--- a/config/locales/mailers/progression_mailer.ur.yml
+++ b/config/locales/mailers/progression_mailer.ur.yml
@@ -1,0 +1,6 @@
+ur:
+  progression_mailer:
+    level_completed:
+      greeting: "سلام،"
+      signoff: "نیک تمناؤں کے ساتھ،"
+      team: "جیریمی اور ٹیم"

--- a/config/locales/mailers/progression_mailer.vi.yml
+++ b/config/locales/mailers/progression_mailer.vi.yml
@@ -1,0 +1,6 @@
+vi:
+  progression_mailer:
+    level_completed:
+      greeting: "Xin chào,"
+      signoff: "Thân mến,"
+      team: "Jeremy và nhóm"

--- a/config/locales/mailers/progression_mailer.zh-CN.yml
+++ b/config/locales/mailers/progression_mailer.zh-CN.yml
@@ -1,0 +1,6 @@
+"zh-CN":
+  progression_mailer:
+    level_completed:
+      greeting: "您好，"
+      signoff: "祝好，"
+      team: "Jeremy 和团队"

--- a/config/locales/mailers/progression_mailer.zh-TW.yml
+++ b/config/locales/mailers/progression_mailer.zh-TW.yml
@@ -1,0 +1,6 @@
+"zh-TW":
+  progression_mailer:
+    level_completed:
+      greeting: "您好，"
+      signoff: "祝好，"
+      team: "Jeremy 與團隊"

--- a/config/locales/mailers/shared.ar.yml
+++ b/config/locales/mailers/shared.ar.yml
@@ -1,0 +1,9 @@
+ar:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "تصلك هذه الرسالة لأن لديك حسابًا على %{jiki_link}."
+        manage_preferences_only_html: "هل تريد تغيير طريقة استلامك لهذه الرسائل؟ يمكنك %{preferences_link}"
+        manage_with_unsubscribe_html: "هل تريد تغيير طريقة استلامك لهذه الرسائل؟ يمكنك %{preferences_link} أو %{unsubscribe_link} من هذه القائمة."
+        update_preferences: "تحديث تفضيلاتك"
+        unsubscribe: "إلغاء الاشتراك"

--- a/config/locales/mailers/shared.bn.yml
+++ b/config/locales/mailers/shared.bn.yml
@@ -1,0 +1,9 @@
+bn:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "আপনি এই ইমেলটি পাচ্ছেন কারণ %{jiki_link}-এ আপনার একটি অ্যাকাউন্ট রয়েছে।"
+        manage_preferences_only_html: "এই ইমেলগুলো কীভাবে পাবেন তা বদলাতে চান? আপনি %{preferences_link}"
+        manage_with_unsubscribe_html: "এই ইমেলগুলো কীভাবে পাবেন তা বদলাতে চান? আপনি %{preferences_link} বা এই তালিকা থেকে %{unsubscribe_link}।"
+        update_preferences: "আপনার পছন্দসমূহ আপডেট করতে পারেন"
+        unsubscribe: "আনসাবস্ক্রাইব করতে পারেন"

--- a/config/locales/mailers/shared.ca.yml
+++ b/config/locales/mailers/shared.ca.yml
@@ -1,0 +1,9 @@
+ca:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Reps aquest correu perquè tens un compte a %{jiki_link}."
+        manage_preferences_only_html: "Vols canviar com reps aquests correus? Pots %{preferences_link}"
+        manage_with_unsubscribe_html: "Vols canviar com reps aquests correus? Pots %{preferences_link} o %{unsubscribe_link} d'aquesta llista."
+        update_preferences: "actualitzar les teves preferències"
+        unsubscribe: "donar-te de baixa"

--- a/config/locales/mailers/shared.de.yml
+++ b/config/locales/mailers/shared.de.yml
@@ -1,0 +1,9 @@
+de:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Du erhältst diese E-Mail, weil du ein Konto bei %{jiki_link} hast."
+        manage_preferences_only_html: "Du möchtest ändern, wie du diese E-Mails erhältst? Du kannst %{preferences_link}"
+        manage_with_unsubscribe_html: "Du möchtest ändern, wie du diese E-Mails erhältst? Du kannst %{preferences_link} oder dich von dieser Liste %{unsubscribe_link}."
+        update_preferences: "deine Einstellungen anpassen"
+        unsubscribe: "abmelden"

--- a/config/locales/mailers/shared.el.yml
+++ b/config/locales/mailers/shared.el.yml
@@ -1,0 +1,9 @@
+el:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Λαμβάνεις αυτό το email επειδή έχεις λογαριασμό στο %{jiki_link}."
+        manage_preferences_only_html: "Θέλεις να αλλάξεις τον τρόπο που λαμβάνεις αυτά τα email; Μπορείς να %{preferences_link}"
+        manage_with_unsubscribe_html: "Θέλεις να αλλάξεις τον τρόπο που λαμβάνεις αυτά τα email; Μπορείς να %{preferences_link} ή να %{unsubscribe_link} από αυτή τη λίστα."
+        update_preferences: "ενημερώσεις τις προτιμήσεις σου"
+        unsubscribe: "διαγραφείς"

--- a/config/locales/mailers/shared.es-419.yml
+++ b/config/locales/mailers/shared.es-419.yml
@@ -1,0 +1,9 @@
+"es-419":
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Recibes este correo porque tienes una cuenta en %{jiki_link}."
+        manage_preferences_only_html: "¿Quieres cambiar cómo recibes estos correos electrónicos? Puedes %{preferences_link}"
+        manage_with_unsubscribe_html: "¿Quieres cambiar cómo recibes estos correos electrónicos? Puedes %{preferences_link} o %{unsubscribe_link} de esta lista."
+        update_preferences: "actualizar tus preferencias"
+        unsubscribe: "cancelar la suscripción"

--- a/config/locales/mailers/shared.es-ES.yml
+++ b/config/locales/mailers/shared.es-ES.yml
@@ -1,0 +1,9 @@
+"es-ES":
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Recibes este correo electrónico porque tienes una cuenta en %{jiki_link}."
+        manage_preferences_only_html: "¿Quieres cambiar cómo recibes estos correos? Puedes %{preferences_link}"
+        manage_with_unsubscribe_html: "¿Quieres cambiar cómo recibes estos correos? Puedes %{preferences_link} o %{unsubscribe_link} de esta lista."
+        update_preferences: "actualizar tus preferencias"
+        unsubscribe: "darte de baja"

--- a/config/locales/mailers/shared.fa.yml
+++ b/config/locales/mailers/shared.fa.yml
@@ -1,0 +1,9 @@
+fa:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "این ایمیل را دریافت می‌کنید چون در %{jiki_link} حساب کاربری دارید."
+        manage_preferences_only_html: "می‌خواهید نحوهٔ دریافت این ایمیل‌ها را تغییر دهید؟ می‌توانید %{preferences_link}"
+        manage_with_unsubscribe_html: "می‌خواهید نحوهٔ دریافت این ایمیل‌ها را تغییر دهید؟ می‌توانید %{preferences_link} یا از این فهرست %{unsubscribe_link}."
+        update_preferences: "تنظیمات خود را به‌روزرسانی کنید"
+        unsubscribe: "اشتراک خود را لغو کنید"

--- a/config/locales/mailers/shared.fr.yml
+++ b/config/locales/mailers/shared.fr.yml
@@ -1,0 +1,9 @@
+fr:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Tu reçois cet e-mail car tu as un compte sur %{jiki_link}."
+        manage_preferences_only_html: "Tu veux changer la façon dont tu reçois ces e-mails ? Tu peux %{preferences_link}"
+        manage_with_unsubscribe_html: "Tu veux changer la façon dont tu reçois ces e-mails ? Tu peux %{preferences_link} ou %{unsubscribe_link} de cette liste."
+        update_preferences: "mettre à jour tes préférences"
+        unsubscribe: "te désabonner"

--- a/config/locales/mailers/shared.hi.yml
+++ b/config/locales/mailers/shared.hi.yml
@@ -1,0 +1,9 @@
+hi:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "आपको यह ईमेल इसलिए मिला है क्योंकि %{jiki_link} पर आपका खाता है।"
+        manage_preferences_only_html: "इन ईमेल को पाने का तरीका बदलना चाहते हैं? आप %{preferences_link}"
+        manage_with_unsubscribe_html: "इन ईमेल को पाने का तरीका बदलना चाहते हैं? आप %{preferences_link} या इस सूची से %{unsubscribe_link}।"
+        update_preferences: "अपनी प्राथमिकताएँ अपडेट कर सकते हैं"
+        unsubscribe: "सदस्यता छोड़ सकते हैं"

--- a/config/locales/mailers/shared.id.yml
+++ b/config/locales/mailers/shared.id.yml
@@ -1,0 +1,9 @@
+id:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Kamu menerima email ini karena kamu memiliki akun di %{jiki_link}."
+        manage_preferences_only_html: "Ingin mengubah cara kamu menerima email ini? Kamu bisa %{preferences_link}"
+        manage_with_unsubscribe_html: "Ingin mengubah cara kamu menerima email ini? Kamu bisa %{preferences_link} atau %{unsubscribe_link} dari daftar ini."
+        update_preferences: "memperbarui preferensimu"
+        unsubscribe: "berhenti berlangganan"

--- a/config/locales/mailers/shared.it.yml
+++ b/config/locales/mailers/shared.it.yml
@@ -1,0 +1,9 @@
+it:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Ricevi questa email perché hai un account su %{jiki_link}."
+        manage_preferences_only_html: "Vuoi cambiare il modo in cui ricevi queste email? Puoi %{preferences_link}"
+        manage_with_unsubscribe_html: "Vuoi cambiare il modo in cui ricevi queste email? Puoi %{preferences_link} o %{unsubscribe_link} da questa lista."
+        update_preferences: "aggiornare le tue preferenze"
+        unsubscribe: "annullare l'iscrizione"

--- a/config/locales/mailers/shared.ja.yml
+++ b/config/locales/mailers/shared.ja.yml
@@ -1,0 +1,9 @@
+ja:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "%{jiki_link} のアカウントをお持ちのため、このメールをお送りしています。"
+        manage_preferences_only_html: "これらのメールの受け取り方を変更しますか？%{preferences_link}ことができます。"
+        manage_with_unsubscribe_html: "これらのメールの受け取り方を変更しますか？%{preferences_link}か、このリストから%{unsubscribe_link}ことができます。"
+        update_preferences: "設定を更新する"
+        unsubscribe: "配信を停止する"

--- a/config/locales/mailers/shared.ko.yml
+++ b/config/locales/mailers/shared.ko.yml
@@ -1,0 +1,9 @@
+ko:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "%{jiki_link}에 계정이 있으셔서 이 이메일을 보내드립니다."
+        manage_preferences_only_html: "이 이메일 수신 방식을 변경하고 싶으신가요? %{preferences_link}."
+        manage_with_unsubscribe_html: "이 이메일 수신 방식을 변경하고 싶으신가요? %{preferences_link} 또는 이 목록에서 %{unsubscribe_link}."
+        update_preferences: "환경설정 업데이트하기"
+        unsubscribe: "수신 거부하기"

--- a/config/locales/mailers/shared.nl.yml
+++ b/config/locales/mailers/shared.nl.yml
@@ -1,0 +1,9 @@
+nl:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Je ontvangt deze e-mail omdat je een account hebt bij %{jiki_link}."
+        manage_preferences_only_html: "Wil je aanpassen hoe je deze e-mails ontvangt? Je kunt %{preferences_link}"
+        manage_with_unsubscribe_html: "Wil je aanpassen hoe je deze e-mails ontvangt? Je kunt %{preferences_link} of %{unsubscribe_link} voor deze lijst."
+        update_preferences: "je voorkeuren aanpassen"
+        unsubscribe: "je afmelden"

--- a/config/locales/mailers/shared.pl.yml
+++ b/config/locales/mailers/shared.pl.yml
@@ -1,0 +1,9 @@
+pl:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Otrzymujesz tę wiadomość, ponieważ masz konto w %{jiki_link}."
+        manage_preferences_only_html: "Chcesz zmienić sposób otrzymywania tych wiadomości? Możesz %{preferences_link}"
+        manage_with_unsubscribe_html: "Chcesz zmienić sposób otrzymywania tych wiadomości? Możesz %{preferences_link} lub %{unsubscribe_link} z tej listy."
+        update_preferences: "zaktualizować swoje preferencje"
+        unsubscribe: "wypisać się"

--- a/config/locales/mailers/shared.pt-BR.yml
+++ b/config/locales/mailers/shared.pt-BR.yml
@@ -1,0 +1,9 @@
+"pt-BR":
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Você está recebendo este e-mail porque tem uma conta no %{jiki_link}."
+        manage_preferences_only_html: "Quer mudar como você recebe estes e-mails? Você pode %{preferences_link}"
+        manage_with_unsubscribe_html: "Quer mudar como você recebe estes e-mails? Você pode %{preferences_link} ou %{unsubscribe_link} desta lista."
+        update_preferences: "atualizar suas preferências"
+        unsubscribe: "cancelar a inscrição"

--- a/config/locales/mailers/shared.pt-PT.yml
+++ b/config/locales/mailers/shared.pt-PT.yml
@@ -1,0 +1,9 @@
+"pt-PT":
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Estás a receber este e-mail porque tens uma conta no %{jiki_link}."
+        manage_preferences_only_html: "Queres mudar a forma como recebes estes e-mails? Podes %{preferences_link}"
+        manage_with_unsubscribe_html: "Queres mudar a forma como recebes estes e-mails? Podes %{preferences_link} ou %{unsubscribe_link} desta lista."
+        update_preferences: "atualizar as tuas preferências"
+        unsubscribe: "cancelar a subscrição"

--- a/config/locales/mailers/shared.ro.yml
+++ b/config/locales/mailers/shared.ro.yml
@@ -1,0 +1,9 @@
+ro:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Primești acest e-mail deoarece ai un cont pe %{jiki_link}."
+        manage_preferences_only_html: "Vrei să schimbi modul în care primești aceste e-mailuri? Poți %{preferences_link}"
+        manage_with_unsubscribe_html: "Vrei să schimbi modul în care primești aceste e-mailuri? Poți %{preferences_link} sau %{unsubscribe_link} de la această listă."
+        update_preferences: "să îți actualizezi preferințele"
+        unsubscribe: "să te dezabonezi"

--- a/config/locales/mailers/shared.ru.yml
+++ b/config/locales/mailers/shared.ru.yml
@@ -1,0 +1,9 @@
+ru:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Вы получили это письмо, потому что у вас есть аккаунт на %{jiki_link}."
+        manage_preferences_only_html: "Хотите изменить, как вы получаете эти письма? Вы можете %{preferences_link}"
+        manage_with_unsubscribe_html: "Хотите изменить, как вы получаете эти письма? Вы можете %{preferences_link} или %{unsubscribe_link} от этой рассылки."
+        update_preferences: "обновить настройки"
+        unsubscribe: "отписаться"

--- a/config/locales/mailers/shared.sr.yml
+++ b/config/locales/mailers/shared.sr.yml
@@ -1,0 +1,9 @@
+sr:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Primaš ovaj imejl jer imaš nalog na %{jiki_link}."
+        manage_preferences_only_html: "Želiš da promeniš način na koji primaš ove imejlove? Možeš %{preferences_link}"
+        manage_with_unsubscribe_html: "Želiš da promeniš način na koji primaš ove imejlove? Možeš %{preferences_link} ili %{unsubscribe_link} sa ove liste."
+        update_preferences: "da ažuriraš svoja podešavanja"
+        unsubscribe: "da se odjaviš"

--- a/config/locales/mailers/shared.sv.yml
+++ b/config/locales/mailers/shared.sv.yml
@@ -1,0 +1,9 @@
+sv:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Du får det här mejlet eftersom du har ett konto på %{jiki_link}."
+        manage_preferences_only_html: "Vill du ändra hur du får de här mejlen? Du kan %{preferences_link}"
+        manage_with_unsubscribe_html: "Vill du ändra hur du får de här mejlen? Du kan %{preferences_link} eller %{unsubscribe_link} från den här listan."
+        update_preferences: "uppdatera dina inställningar"
+        unsubscribe: "avregistrera dig"

--- a/config/locales/mailers/shared.sw.yml
+++ b/config/locales/mailers/shared.sw.yml
@@ -1,0 +1,9 @@
+sw:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Unapokea barua pepe hii kwa sababu una akaunti kwenye %{jiki_link}."
+        manage_preferences_only_html: "Ungependa kubadilisha jinsi unavyopokea barua pepe hizi? Unaweza %{preferences_link}"
+        manage_with_unsubscribe_html: "Ungependa kubadilisha jinsi unavyopokea barua pepe hizi? Unaweza %{preferences_link} au %{unsubscribe_link} kwenye orodha hii."
+        update_preferences: "kusasisha mapendeleo yako"
+        unsubscribe: "kujiondoa"

--- a/config/locales/mailers/shared.tr.yml
+++ b/config/locales/mailers/shared.tr.yml
@@ -1,0 +1,9 @@
+tr:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Bu e-postayı %{jiki_link} üzerinde bir hesabın olduğu için alıyorsun."
+        manage_preferences_only_html: "Bu e-postaları nasıl aldığını değiştirmek ister misin? %{preferences_link}."
+        manage_with_unsubscribe_html: "Bu e-postaları nasıl aldığını değiştirmek ister misin? %{preferences_link} ya da bu listeden %{unsubscribe_link}."
+        update_preferences: "tercihlerini güncelleyebilirsin"
+        unsubscribe: "abonelikten çıkabilirsin"

--- a/config/locales/mailers/shared.uk.yml
+++ b/config/locales/mailers/shared.uk.yml
@@ -1,0 +1,9 @@
+uk:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Ви отримали цей лист, тому що у вас є обліковий запис на %{jiki_link}."
+        manage_preferences_only_html: "Хочете змінити, як ви отримуєте ці листи? Ви можете %{preferences_link}"
+        manage_with_unsubscribe_html: "Хочете змінити, як ви отримуєте ці листи? Ви можете %{preferences_link} або %{unsubscribe_link} від цієї розсилки."
+        update_preferences: "оновити налаштування"
+        unsubscribe: "відписатися"

--- a/config/locales/mailers/shared.ur.yml
+++ b/config/locales/mailers/shared.ur.yml
@@ -1,0 +1,9 @@
+ur:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "آپ کو یہ ای میل اس لیے موصول ہوئی ہے کیونکہ %{jiki_link} پر آپ کا اکاؤنٹ ہے۔"
+        manage_preferences_only_html: "کیا آپ یہ ای میلز موصول کرنے کا طریقہ بدلنا چاہتے ہیں؟ آپ %{preferences_link}"
+        manage_with_unsubscribe_html: "کیا آپ یہ ای میلز موصول کرنے کا طریقہ بدلنا چاہتے ہیں؟ آپ %{preferences_link} یا اس فہرست سے %{unsubscribe_link}۔"
+        update_preferences: "اپنی ترجیحات اپ ڈیٹ کر سکتے ہیں"
+        unsubscribe: "سبسکرپشن منسوخ کر سکتے ہیں"

--- a/config/locales/mailers/shared.vi.yml
+++ b/config/locales/mailers/shared.vi.yml
@@ -1,0 +1,9 @@
+vi:
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "Bạn nhận được email này vì bạn có tài khoản tại %{jiki_link}."
+        manage_preferences_only_html: "Bạn muốn thay đổi cách nhận những email này? Bạn có thể %{preferences_link}"
+        manage_with_unsubscribe_html: "Bạn muốn thay đổi cách nhận những email này? Bạn có thể %{preferences_link} hoặc %{unsubscribe_link} khỏi danh sách này."
+        update_preferences: "cập nhật tùy chọn của bạn"
+        unsubscribe: "hủy đăng ký"

--- a/config/locales/mailers/shared.zh-CN.yml
+++ b/config/locales/mailers/shared.zh-CN.yml
@@ -1,0 +1,9 @@
+"zh-CN":
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "您收到这封邮件，是因为您在 %{jiki_link} 拥有账号。"
+        manage_preferences_only_html: "想更改接收这些邮件的方式吗？您可以%{preferences_link}。"
+        manage_with_unsubscribe_html: "想更改接收这些邮件的方式吗？您可以%{preferences_link}，或%{unsubscribe_link}此列表。"
+        update_preferences: "更新您的偏好设置"
+        unsubscribe: "退订"

--- a/config/locales/mailers/shared.zh-TW.yml
+++ b/config/locales/mailers/shared.zh-TW.yml
@@ -1,0 +1,9 @@
+"zh-TW":
+  mailers:
+    shared:
+      footer:
+        account_notice_html: "您會收到這封郵件，是因為您在 %{jiki_link} 擁有帳號。"
+        manage_preferences_only_html: "想變更接收這些郵件的方式嗎？您可以%{preferences_link}。"
+        manage_with_unsubscribe_html: "想變更接收這些郵件的方式嗎？您可以%{preferences_link}，或%{unsubscribe_link}此清單。"
+        update_preferences: "更新您的偏好設定"
+        unsubscribe: "取消訂閱"


### PR DESCRIPTION
Stacked on #613 — review #612 and #613 first.

Adds `shared`, `notifications_mailer` and `progression_mailer` catalogs for the 29 non-`hu` WIP locales. These are the strings every email carries but no gem provides: the footer's account notice and preference links, plus each mailer's greeting/signoff/team lines.

Before this, a French devise email rendered a French body under an English footer — `translation_missing` in dev/test, and English via fallbacks in production.

`notifications_mailer` and `progression_mailer` contain nothing but boilerplate — their real content is DB-backed badge and level copy — so both are now **fully translated in every supported locale**.

## Scope note

Deliberately excludes `account_mailer`, `premium_mailer` and `onboarding_mailer`. Their short keys could be translated cheaply, but their bodies are 300–500 character original Jiki copy; translating only the subjects would ship a translated subject over an English body, which is worse than leaving them alone. They need a proper translation pass.

## Testing

Full suite green (2153 runs, 0 failures). Every catalog verified to parse, carry all its keys, and preserve the `%{jiki_link}` / `%{preferences_link}` / `%{unsubscribe_link}` placeholders.