### PR TITLE
Add a CI guard that production locales are complete

### DIFF
--- a/.github/workflows/locale-completeness.yml
+++ b/.github/workflows/locale-completeness.yml
@@ -1,0 +1,35 @@
+name: Locale completeness
+
+# A locale in PRODUCTION_LOCALES is being served to users, so every key English
+# has must be present and non-empty in it. The i18n parity test reports the same
+# drift for work-in-progress locales, but only as a warning - deliberately, since
+# a half-translated WIP locale must not block anyone. This is the hard gate, and
+# it arms the moment a locale is promoted.
+on:
+  pull_request:
+    paths:
+      - 'config/locales/**'
+      - 'config/initializers/i18n.rb'
+      - 'lib/locale_completeness_check.rb'
+      - '.github/workflows/locale-completeness.yml'
+  push:
+    branches: [ main ]
+
+jobs:
+  verify_locales:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout API
+        uses: actions/checkout@v7
+
+      # The check is plain Ruby against the locale YAML, so it needs no bundle,
+      # no database and none of the app's native dependencies.
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: false
+
+      - name: Verify every production locale is complete
+        run: ruby lib/locale_completeness_check.rb

--- a/lib/locale_completeness_check.rb
+++ b/lib/locale_completeness_check.rb
@@ -1,0 +1,111 @@
+# Verifies that every production locale is complete: every key English has,
+# present and non-empty.
+#
+# This is the gate that arms on promotion. `test/i18n_parity_test.rb` reports
+# the same drift for work-in-progress locales, but only as a warning, because a
+# half-translated WIP locale is a normal state that must not block anyone. The
+# moment a locale enters PRODUCTION_LOCALES it is being served to users, and a
+# missing key renders as an English fallback while an empty one renders as
+# nothing at all - neither of which anything currently fails on.
+#
+# Presence is not translation: a value copied verbatim from English passes here,
+# because no mechanical check can tell a deliberate loanword from an untranslated
+# string. This answers "is anything blank or absent", which is the failure that
+# reaches users as visibly broken output.
+#
+# Deliberately plain Ruby with no Rails, matching lib/curriculum_content_check.rb:
+# it reads the YAML straight off disk, so CI needs no bundle, no database and
+# none of the app's native dependencies.
+#
+#   ruby lib/locale_completeness_check.rb
+require 'yaml'
+
+module LocaleCompletenessCheck
+  ROOT = File.expand_path('..', __dir__)
+  LOCALES_DIR = File.join(ROOT, 'config', 'locales')
+  INITIALIZER = File.join(ROOT, 'config', 'initializers', 'i18n.rb')
+  REFERENCE_LOCALE = 'en'.freeze
+
+  module_function
+
+  def call
+    locales = production_locales
+    return [1, 'Could not read PRODUCTION_LOCALES from config/initializers/i18n.rb'] if locales.empty?
+
+    reference = reference_catalogs
+    return [1, "No #{REFERENCE_LOCALE} catalogs found under config/locales"] if reference.empty?
+
+    problems = locales.flat_map { |locale| problems_for(locale, reference) }
+    checked = locales.size * reference.values.sum(&:size)
+
+    return [1, report(problems, checked)] if problems.any?
+
+    [0, "✓ All #{checked} keys present and non-empty across #{locales.size} production " \
+        "locale(s): #{locales.join(', ')}"]
+  end
+
+  # The single source of truth is the initializer, read rather than duplicated so
+  # promoting a locale there arms this check with no second edit. It cannot be
+  # required: the initializer touches Jiki.env and I18n at load time.
+  def production_locales
+    match = File.read(INITIALIZER)[/PRODUCTION_LOCALES\s*=\s*%w\[(.*?)\]/m]
+    match ? Regexp.last_match(1).split : []
+  end
+
+  # catalog id (path minus the .en.yml suffix) => { dotted key => value }
+  def reference_catalogs
+    Dir.glob(File.join(LOCALES_DIR, '**', "*.#{REFERENCE_LOCALE}.yml")).sort.to_h do |path|
+      [catalog_id(path), flatten(load_tree(path, REFERENCE_LOCALE))]
+    end
+  end
+
+  def problems_for(locale, reference)
+    reference.flat_map do |catalog, reference_keys|
+      path = File.join(LOCALES_DIR, "#{catalog}.#{locale}.yml")
+      next [[catalog, locale, 'catalog file is missing']] unless File.exist?(path)
+
+      keys = flatten(load_tree(path, locale))
+
+      missing = (reference_keys.keys - keys.keys).map { |key| [catalog, locale, "missing key '#{key}'"] }
+      blank = keys.select { |_, value| value.to_s.strip.empty? }.
+        map { |key, _| [catalog, locale, "empty value for '#{key}'"] }
+
+      missing + blank
+    end
+  end
+
+  def report(problems, checked)
+    lines = problems.group_by { |_, locale, _| locale }.map do |locale, entries|
+      ["\n#{entries.size} problem(s) in production locale '#{locale}':",
+       *entries.map { |catalog, _, message| "  #{catalog}: #{message}" }]
+    end
+
+    [*lines.flatten,
+     "\n#{problems.size} of #{checked} checked keys are missing or empty."].join("\n")
+  end
+
+  def catalog_id(path)
+    path.sub("#{LOCALES_DIR}/", '').sub(/\.#{REFERENCE_LOCALE}\.yml\z/, '')
+  end
+
+  def load_tree(path, locale)
+    (YAML.load_file(path) || {})[locale] || {}
+  end
+
+  # Flatten a nested translation hash into { "a.b.c" => value }.
+  def flatten(tree, prefix = nil, acc = {})
+    tree.each do |key, value|
+      full_key = [prefix, key].compact.join('.')
+      value.is_a?(Hash) ? flatten(value, full_key, acc) : acc[full_key] = value
+    end
+    acc
+  end
+end
+
+# Command-line entrypoint: this runs as a bare script outside the Rails app, so
+# stdout and a real exit status are the interface CI reads.
+if $PROGRAM_NAME == __FILE__
+  status, message = LocaleCompletenessCheck.()
+  puts message # rubocop:disable Rails/Output
+  exit status # rubocop:disable Rails/Exit
+end


### PR DESCRIPTION
A locale in `PRODUCTION_LOCALES` is being served to users, so every key English has must be present and non-empty in it.

Nothing enforced that. `test/i18n_parity_test.rb` reports the same drift, but hard-fails only for production locales — and production is `en`-only — so in practice **no locale catalog could fail the build however broken it was**. The first real check happened at promotion time, which is the worst moment to discover it.

## What it checks

For each locale in `PRODUCTION_LOCALES`, against every `*.en.yml` catalog:

- the catalog file exists
- every key English has is present
- no value is empty or whitespace-only

Exit 0 with a summary, exit 1 with a per-locale report of what's missing.

**Presence is not translation.** A value copied verbatim from English passes, because no mechanical check distinguishes a deliberate loanword from an untranslated string. This catches the failure that reaches users as visibly broken output: a key that is absent (renders as English) or empty (renders as nothing).

## Design

Plain Ruby with no Rails, matching `lib/curriculum_content_check.rb`, so CI needs no bundle, no database and none of the app's native dependencies. `PRODUCTION_LOCALES` is read out of `config/initializers/i18n.rb` rather than duplicated, so promoting a locale arms the check with no second edit. The initializer can't be `require`d — it touches `Jiki.env` and `I18n` at load time — so it's parsed.

## Verified

Today it passes with real work to do, checking English against itself:

```
✓ All 102 keys present and non-empty across 1 production locale(s): en
```

Both failure modes confirmed by simulation:

```
# PRODUCTION_LOCALES = %w[en hu]
1 problem(s) in production locale 'hu':
  devise: catalog file is missing        # exit 1

# an emptied value in shared.en.yml
1 problem(s) in production locale 'en':
  mailers/shared: empty value for 'mailers.shared.footer.unsubscribe'   # exit 1
```