### PR TITLE
Add real Hungarian level milestone emails

### DIFF
--- a/db/seeds/level_translations/hu.json
+++ b/db/seeds/level_translations/hu.json
@@ -1,97 +1,97 @@
 [
   {
     "level_uuid": "7963a7e0-0386-46fa-bf47-c19eaa1eb555",
-    "milestone_email_subject": "[HU TBD] Congratulations on hitting the first Milestone",
-    "milestone_email_content_markdown": "[HU TBD] Great work on completing the first level of Jiki's Coding Fundamentals course.\n\nIt might not feel like you're doing much \"real\" coding yet, but you've just picked up one of the most important skills in programming. You'll be using functions hundreds of times a day from here on, so this really is the foundation for everything else.\n\nNext we'll look at using colours to draw, and then we'll start mixing some logic into the process. Have fun!"
+    "milestone_email_subject": "Elérted az első mérföldkövet!",
+    "milestone_email_content_markdown": "Nagyszerű munka, hogy teljesítetted Jiki Programozási Alapok kurzusának első szintjét.\n\nLehet, hogy még nem érzed úgy, hogy igazi programozást végeznél, de most sajátítottad el a programozás egyik legfontosabb készségét. Innentől kezdve naponta több százszor fogsz függvényeket használni, szóval ez tényleg az alapja minden másnak.\n\nEzután megnézzük, hogyan használhatsz színeket a rajzoláshoz, majd logikát is belekeverünk a folyamatba. Jó szórakozást!"
   },
   {
     "level_uuid": "de4de3c1-d2ee-4af5-9df6-857a9f1df478",
-    "milestone_email_subject": "[HU TBD] Enjoyed Drawing?",
-    "milestone_email_content_markdown": "[HU TBD] Great work on this level, and on your first proper bit of drawing.\n\nYou've now added strings and colours to your toolkit, which means your programs can start handling text and producing things that actually look good on screen.\n\nOver the next few lessons we'll start bringing in some logic, so you can move beyond linear instructions and add some variety and intelligence into your programs. Have fun!"
+    "milestone_email_subject": "Élvezted a rajzolást?",
+    "milestone_email_content_markdown": "Nagyszerű munka ezen a szinten, és az első igazi rajzolásodon.\n\nMost már a stringek és színek is az eszköztárad részei, vagyis a programjaid elkezdhetnek szövegeket kezelni és olyan dolgokat készíteni, amelyek jól is néznek ki a képernyőn.\n\nA következő néhány leckében logikát is beépítünk majd, így továbbléphetsz a lineáris utasításokból, és változatosságot és intelligenciát adhatsz a programjaidhoz. Jó szórakozást!"
   },
   {
     "level_uuid": "8eafc890-d96f-4143-9556-fafd58f90735",
-    "milestone_email_subject": "[HU TBD] Feeling Loopy after all that Looping?",
-    "milestone_email_content_markdown": "[HU TBD] Great work on this level. Loops are a fundamental building block of programming, and hopefully they're starting to feel pretty comfortable.\n\nThere are other types of loops we'll look at later in the course, but the repeat loop will be your companion for the next few lessons.\n\nNext up are variables, which is the idea of storing and retrieving values as your program runs. Have fun!"
+    "milestone_email_subject": "Elkábultál a ciklusoktól?",
+    "milestone_email_content_markdown": "Nagyszerű munka ezen a szinten. A ciklusok a programozás alapvető építőkövei, és remélhetőleg már kezdenek kényelmesen érződni.\n\nA kurzus későbbi részében más fajta ciklusokkal is fogunk találkozni, de a repeat ciklus lesz a társad a következő néhány leckében.\n\nA következő a változók következnek, ami azt jelenti, hogy értékeket tárolhatsz és kérhetsz le a programod futása közben. Jó szórakozást!"
   },
   {
     "level_uuid": "a47b33c1-fecd-4f15-a025-f95b878e31b7",
-    "milestone_email_subject": "[HU TBD] Variables in the bag",
-    "milestone_email_content_markdown": "[HU TBD] Great work on getting variables under your belt.\n\nVariables are one of those ideas that's pretty simple on the surface, but they're going to underpin almost everything you write from now on. The ability to store a value, give it a name, and use it later is what turns code from a fixed list of instructions into something genuinely flexible.\n\nNext we'll look at how variables change over time, which is what programmers call \"state\". Have fun!"
+    "milestone_email_subject": "Megvannak a változók!",
+    "milestone_email_content_markdown": "Nagyszerű munka, hogy a változókat is elsajátítottad.\n\nA változók az az ötlet, ami felszínesen nagyon egyszerűnek tűnik, de innentől kezdve szinte mindenben, amit írsz, jelen lesznek. Az, hogy el tudsz tárolni egy értéket, nevet adsz neki, és később használod, az teszi a kódot egy merev utasításlistából valóban rugalmas dologgá.\n\nEzután megnézzük, hogyan változnak a változók az idő múlásával, amit a programozók „állapotnak” neveznek. Jó szórakozást!"
   },
   {
     "level_uuid": "f74c506c-144e-4287-83eb-356568ffc234",
-    "milestone_email_subject": "[HU TBD] State of play",
-    "milestone_email_content_markdown": "[HU TBD] Great work on this one. You can now track values that change as your program runs, which is a real step up from where you were a couple of levels ago.\n\nThis idea of state is going to keep coming back throughout the course, and it gets more interesting every time we combine it with something new.\n\nNext is a meaty level. We'll look at functions that return values, and then explore colours, randomness, animation, scope, and nested loops along the way. Have fun!"
+    "milestone_email_subject": "Játékállás",
+    "milestone_email_content_markdown": "Nagyszerű munka ezen a szinten. Most már nyomon tudod követni azokat az értékeket, amelyek a programod futása közben változnak, ami egy igazi előrelépés ahhoz képest, ahol néhány szinttel ezelőtt tartottál.\n\nAz állapot gondolata folyamatosan vissza fog térni a kurzus során, és minden alkalommal érdekesebb lesz, amikor valami újjal kombináljuk.\n\nA következő egy tartalmas szint következik. Megnézzük a függvényeket, amelyek visszaadnak értékeket, majd felfedezzük a színeket, a véletlenszerű számokat, az animációt, a hatókört és az egymásba ágyazott ciklusokat. Jó szórakozást!"
   },
   {
     "level_uuid": "e3933253-d25e-4b35-a442-4cd96ead2188",
-    "milestone_email_subject": "[HU TBD] Quite the haul",
-    "milestone_email_content_markdown": "[HU TBD] Brilliant work on a packed level. Functions that return values, HSL and RGB colours, animation, random numbers, scope, scenarios, and loops within loops. That's a lot of new ideas to add to your toolkit in one go.\n\nDon't worry if some of them still feel a bit hazy. They'll all come back in different contexts later in the course, and each time they'll get more familiar.\n\nNext we'll start making decisions in code using if statements. This is where your programs really start to feel intelligent. Have fun!"
+    "milestone_email_subject": "Micsoda fogás!",
+    "milestone_email_content_markdown": "Nagyszerű munka ezen a sűrű szinten. Visszatérő függvények, HSL és RGB színek, animáció, véletlenszerű számok, hatókör, forgatókönyvek és ciklusok a ciklusokban. Ez rengeteg új ötlet, amivel bővült az eszköztárad egy menetben.\n\nNe aggódj, ha néhány közülük még kissé homályosnak tűnik. Mindegyik vissza fog térni később más kontextusban a kurzus során, és minden alkalommal ismerősebbek lesznek.\n\nEzután elkezdünk döntéseket hozni a kódban az elágazások használatával. Itt kezdenek a programjaid igazán intelligensnek érződni. Jó szórakozást!"
   },
   {
     "level_uuid": "2977da36-d6e7-4e94-b654-f029f8fd55dd",
-    "milestone_email_subject": "[HU TBD] If, then, what?",
-    "milestone_email_content_markdown": "[HU TBD] Nice work on the conditionals level. Hopefully if and else are starting to feel pretty natural.\n\nConditionals are one of the most important ideas in programming. Almost every interesting program needs to make decisions based on what's true at the time, and you've now got the basic tools to do that.\n\nNext we'll look at more powerful ways of writing conditions, combining them together with and/or, plus a few related ideas like modulo. Have fun!"
+    "milestone_email_subject": "Ha, akkor, mi?",
+    "milestone_email_content_markdown": "Szép munka az elágazások szintjén. Remélhetőleg az if és az else már kezd természetesnek érződni.\n\nAz elágazások a programozás egyik legfontosabb gondolata. Szinte minden érdekes programnak döntéseket kell hoznia az alapján, hogy éppen mi igaz, és most már megvannak az alapvető eszközeid ehhez.\n\nEzután megnézzük, hogyan írhatsz hatékonyabb feltételeket, hogyan kombinálhatod őket az és/vagy használatával, és néhány kapcsolódó fogalmat is, mint a modulo. Jó szórakozást!"
   },
   {
     "level_uuid": "fcd15968-fc9e-49e7-b6dc-d29da3ecf711",
-    "milestone_email_subject": "[HU TBD] Logical next steps",
-    "milestone_email_content_markdown": "[HU TBD] Great work on a tricky level. You've now got and/or, modulo, and looping without a count under your belt.\n\nThese are the kinds of tools that let you write conditions that actually match real-world logic, rather than having to break everything down into tiny separate checks.\n\nNext we'll combine conditionals with state, which is where your programs start being able to respond to what's happening as they run. Have fun!"
+    "milestone_email_subject": "Logikus következő lépések",
+    "milestone_email_content_markdown": "Nagyszerű munka ezen a nehéz szinten. Most már elsajátítottad az és/vagy, a modulo és a számláló nélküli ciklus használatát.\n\nEzek azok az eszközök, amelyekkel olyan feltételeket írhatsz, amelyek tényleg megfelelnek a valós logikának, ahelyett, hogy mindent apró, különálló ellenőrzésekre kellene bontanod.\n\nEzután az elágazásokat és az állapotot fogjuk kombinálni, amivel a programjaid elkezdenek tudni reagálni arra, ami futás közben történik. Jó szórakozást!"
   },
   {
     "level_uuid": "f8e8a86f-8802-4cdb-863c-6f8187785cfd",
-    "milestone_email_subject": "[HU TBD] Programs that respond",
-    "milestone_email_content_markdown": "[HU TBD] Great work. Combining conditionals with state is where your programs really start to feel alive, responding to what's happening rather than just following a fixed script.\n\nThis is roughly the level of complexity you'll be writing at for the rest of the course, so everything you've practised here will keep coming back.\n\nNext up is a big one: writing your own functions. Up until now you've been using functions someone else wrote. From here on, you'll be writing your own. Have fun!"
+    "milestone_email_subject": "Reagáló programok",
+    "milestone_email_content_markdown": "Nagyszerű munka. Az elágazások és az állapot kombinálásával a programjaid kezdenek igazán életre kelni, reagálni arra, ami történik, ahelyett, hogy csak egy előre megírt szkriptet követnének.\n\nEz nagyjából az a bonyolultsági szint, amin a kurzus hátralévő részében dolgozni fogsz, így minden, amit itt gyakoroltál, vissza fog térni.\n\nA következő egy nagy dobás: saját függvények írása. Eddig olyan függvényeket használtál, amelyeket mások írtak. Mostantól te magad fogod írni őket. Jó szórakozást!"
   },
   {
     "level_uuid": "d45d91fe-f790-4f47-b072-9e7d8c453aa4",
-    "milestone_email_subject": "[HU TBD] Now you're in charge",
-    "milestone_email_content_markdown": "[HU TBD] Brilliant work. Writing your own functions is a real shift. You're no longer just using the tools on the shelf, you're building new ones.\n\nThis is one of the most important skills in all of programming. Good code is mostly about breaking problems down into small, well-named functions, and you've now got everything you need to start doing that.\n\nNext we'll get back to strings and look at how to stick them together and slot values into them. Have fun!"
+    "milestone_email_subject": "Most te irányítasz!",
+    "milestone_email_content_markdown": "Nagyszerű munka. A saját függvények írása igazi váltás. Már nem csak használod a polcon lévő eszközöket, hanem újakat építesz.\n\nEz az egyik legfontosabb készség az egész programozásban. A jó kód leginkább arról szól, hogy a problémákat kis, jól elnevezett függvényekre bontjuk, és most már mindened megvan, hogy ezt elkezdd csinálni.\n\nEzután visszatérünk a stringekhez, és megnézzük, hogyan fűzheted össze őket, és hogyan illeszthetsz értékeket beléjük. Jó szórakozást!"
   },
   {
     "level_uuid": "0dcf7cf5-1b75-450d-aaeb-5246c28c3750",
-    "milestone_email_subject": "[HU TBD] Strings, attached",
-    "milestone_email_content_markdown": "[HU TBD] Nice work on this one. Concatenation and templates are pretty simple ideas, but they come up constantly, especially anywhere you're producing output for a person to read.\n\nYou'll be using these techniques in pretty much every program you write from here on.\n\nNext we'll look at how to dig into strings character by character, and how to loop through their contents. Have fun!"
+    "milestone_email_subject": "Stringek összefűzve",
+    "milestone_email_content_markdown": "Szép munka ezen a szinten. Az összefűzés és a sablonok nagyon egyszerű ötletek, de folyamatosan előkerülnek, különösen ott, ahol emberi olvasásra szánt kimenetet állítasz elő.\n\nEzeket a technikákat szinte minden programban használni fogod, amit innentől írsz.\n\nEzután megnézzük, hogyan áshatsz bele a stringekbe karakterenként, és hogyan lépkedhetsz végig a tartalmukon ciklusokkal. Jó szórakozást!"
   },
   {
     "level_uuid": "a6244fe4-bc09-4c54-b244-0599bd419fdf",
-    "milestone_email_subject": "[HU TBD] Letter by letter",
-    "milestone_email_content_markdown": "[HU TBD] Great work. Hopefully indexing and looping through strings is starting to make sense.\n\nBeing able to look at individual characters and walk through text systematically opens up a huge range of problems you can now solve. A lot of real-world programming is about exactly this kind of work.\n\nNext we'll look at how to combine multiple functions together to tackle more complex tasks. Have fun!"
+    "milestone_email_subject": "Betűről betűre",
+    "milestone_email_content_markdown": "Nagyszerű munka. Remélhetőleg az indexelés és a cikluson keresztüli végigjárás a stringeken kezd érthetővé válni.\n\nAz, hogy képes vagy egyes karaktereket megnézni és szisztematikusan végigjárni a szöveget, rengeteg problémát nyit meg, amit most már meg tudsz oldani. A valós programozás nagy része pontosan ilyen jellegű munkáról szól.\n\nEzután megnézzük, hogyan kombinálhatsz több függvényt összetettebb feladatok megoldásához. Jó szórakozást!"
   },
   {
     "level_uuid": "f2d5a243-732a-433d-9e9b-51548c41828c",
-    "milestone_email_subject": "[HU TBD] Better together",
-    "milestone_email_content_markdown": "[HU TBD] Great work on this level. Combining functions to solve bigger problems is what professional programming actually looks like day to day. You break a problem into pieces, write a small function for each piece, and then put them together.\n\nYou're now doing this for real.\n\nNext we'll look at methods and properties, which is a slightly different way of working with values. Have fun!"
+    "milestone_email_subject": "Együtt jobb!",
+    "milestone_email_content_markdown": "Nagyszerű munka ezen a szinten. A függvények kombinálása nagyobb problémák megoldására az, amit a profi programozás valójában napi szinten csinál. Egy problémát részekre bontasz, minden részhez írsz egy kis függvényt, majd összerakod őket.\n\nMost már te is ezt csinálod igazából.\n\nEzután megnézzük a metódusokat és a tulajdonságokat, ami egy kicsit más módja az értékekkel való munkának. Jó szórakozást!"
   },
   {
     "level_uuid": "37f0b015-986c-4b6a-8d3f-704a0056f994",
-    "milestone_email_subject": "[HU TBD] Methods to the madness",
-    "milestone_email_content_markdown": "[HU TBD] Nice work. Methods and properties are a slightly different style to what you've seen so far. Instead of passing a value into a function, you call a function on the value itself. The idea takes a little getting used to, but it's used everywhere, so it'll start feeling natural pretty quickly.\n\nNext we'll look at some more powerful kinds of loops: for loops, while loops, break, and continue. Have fun!"
+    "milestone_email_subject": "Rendszer a káoszban",
+    "milestone_email_content_markdown": "Szép munka. A metódusok és tulajdonságok egy kicsit más stílust képviselnek, mint amit eddig láttál. Ahelyett, hogy egy értéket átadnál egy függvénynek, a függvényt magán az értéken hívod meg. Ez a gondolat egy kis megszokást igényel, de mindenhol használják, így elég gyorsan természetesnek fog érződni.\n\nEzután megnézünk néhány erőteljesebb fajta ciklust: for ciklusokat, while ciklusokat, a break és a continue utasításokat. Jó szórakozást!"
   },
   {
     "level_uuid": "86e3939f-3141-4b0e-aedb-249a1da33530",
-    "milestone_email_subject": "[HU TBD] More than just repeat",
-    "milestone_email_content_markdown": "[HU TBD] Great work. You've now got for loops, while loops, break, and continue under your belt. These are the loops you'll reach for most often outside of this course, so they're well worth the time you've put in.\n\nEach one has a slightly different job, and getting a feel for which to reach for will come with practice.\n\nNext we'll look at arrays, which is how programs store and work with collections of things. Have fun!"
+    "milestone_email_subject": "Túl a repeat-en",
+    "milestone_email_content_markdown": "Nagyszerű munka. Most már elsajátítottad a for ciklusokat, a while ciklusokat, a break-et és a continue-t is. Ezek azok a ciklusok, amelyeket leggyakrabban fogsz használni ezen a kurzuson kívül is, szóval megérte az időt, amit rájuk szántál.\n\nMindegyiknek egy kicsit más a feladata, és az érzés, hogy mikor melyiket érdemes használni, a gyakorlat során jön majd meg.\n\nEzután megnézzük a tömböket, amivel a programok gyűjteményeket tárolnak és kezelnek. Jó szórakozást!"
   },
   {
     "level_uuid": "ecea29c5-9e4a-4d1a-a215-c3ea2d13a06d",
-    "milestone_email_subject": "[HU TBD] Quite the collection",
-    "milestone_email_content_markdown": "[HU TBD] Brilliant work. Arrays (or lists, as some people call them) are one of the most useful tools in any language. Pretty much any time you're dealing with more than one of something, you'll reach for an array.\n\nYou've now got a good grasp of how to read from them and work through their contents.\n\nNext, we'll look at building arrays up from scratch, piece by piece. Have fun!"
+    "milestone_email_subject": "Szép gyűjtemény!",
+    "milestone_email_content_markdown": "Nagyszerű munka. A tömbök (vagy listák, ahogy néhányan nevezik) az egyik leghasznosabb eszköz bármely programozási nyelvben. Szinte minden alkalommal, amikor több dologgal kell egyszerre dolgoznod, egy tömbhöz nyúlsz.\n\nMost már jól átlátod, hogyan olvashatsz belőlük, és hogyan dolgozhatsz végig a tartalmukon.\n\nEzután megnézzük, hogyan építhetsz tömböket a semmiből, lépésről lépésre. Jó szórakozást!"
   },
   {
     "level_uuid": "d65e091d-ea5d-4f7b-b588-d06fa712d91e",
-    "milestone_email_subject": "[HU TBD] Building things up",
-    "milestone_email_content_markdown": "[HU TBD] Nice work! Reading from arrays is handy, but being able to build them up piece by piece is where they really come into their own. Loop over something, collect the bits you care about into a new array, and hand it back — that's a pattern you'll reach for again and again.\n\nNext up: dictionaries. These let you store values against named keys rather than just positions. Have fun!"
+    "milestone_email_subject": "Tömbépítés",
+    "milestone_email_content_markdown": "Szép munka! A tömbökből való olvasás hasznos, de az, hogy darabonként fel tudod építeni őket, az az, ahol igazán kiteljesednek. Ciklussal végigmész valamin, összegyűjtöd a számodra fontos darabokat egy új tömbbe, és visszaadod – ez egy olyan minta, amit újra és újra használni fogsz.\n\nA következő: szótárak. Ezek lehetővé teszik, hogy értékeket nevesített kulcsokhoz tárolj, ne csak pozíciókhoz. Jó szórakozást!"
   },
   {
     "level_uuid": "4647e76e-e600-43dc-8354-bf30e2dc2537",
-    "milestone_email_subject": "[HU TBD] Named for a reason",
-    "milestone_email_content_markdown": "[HU TBD] Great stuff. Dictionaries let you store values against named keys rather than just positions, which makes looking things up fast and readable.\n\nNext, and finally, we'll look at changing dictionaries — adding, updating and removing entries as you go. Have fun!"
+    "milestone_email_subject": "Nem véletlen a neve",
+    "milestone_email_content_markdown": "Nagyszerű. A szótárak lehetővé teszik, hogy értékeket nevesített kulcsokhoz tárolj, ne csak pozíciókhoz, ami gyorssá és olvashatóvá teszi az adatok keresését.\n\nA következő, és egyben utolsó szinten megnézzük a szótárak módosítását – hozzáadást, frissítést és bejegyzések eltávolítását menet közben. Jó szórakozást!"
   },
   {
     "level_uuid": "42cbc5e7-c2eb-4abb-b3e2-724d240f6f9c",
-    "milestone_email_subject": "[HU TBD] That's a wrap",
-    "milestone_email_content_markdown": "[HU TBD] And that's the last level of Coding Fundamentals. Hopefully dictionaries are feeling like a useful tool to add to the mix alongside arrays.\n\nThis is a real achievement. You've now covered every core building block of programming: functions, variables, state, conditionals, loops, strings, arrays, and dictionaries. Everything else from here is combinations and refinements of what you already know.\n\nWe're really proud of you for getting this far. Have fun!"
+    "milestone_email_subject": "Ennyi volt!",
+    "milestone_email_content_markdown": "És ez volt a Programozási Alapok utolsó szintje. Remélhetőleg a szótárak is hasznos eszköznek érződnek a tömbök mellett.\n\nEz egy igazi teljesítmény. Most már minden alapvető építőelemét lefedted a programozásnak: függvények, változók, állapot, elágazások, ciklusok, stringek, tömbök és szótárak. Innentől kezdve minden más ezek kombinációja és finomítása, amit már ismersz.\n\nNagyon büszkék vagyunk rád, hogy idáig eljutottál. Jó szórakozást!"
   }
 ]


### PR DESCRIPTION
`db/seeds/level_translations/hu.json` on `main` holds 19 `[HU TBD]` placeholders wrapping the English copy. The Hungarian translations for all 19 levels already existed but were never committed. This commits them.

The existing translations were keyed by level `slug`. `Level::Translation::CreateAllFromJson` looks levels up with `Level.find_by(uuid: entry["level_uuid"])` and `validate_entry!` requires `level_uuid`, so they are re-keyed to `level_uuid` using the slug/uuid pairs in `db/seeds/curriculum.json`. All 19 slugs resolve, and the resulting level set and order match the file on `main` exactly. File shape, key order and formatting are unchanged.

No `[HU TBD]` string and no English subject or body remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)