### PR TITLE
Add hu as a production locale alongside en

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -2,9 +2,9 @@
 # Defines supported and work-in-progress locales for the application
 
 module I18n
-  # Locales that ship to production. Production is English-only for now; the
-  # locale-parity guard test hard-fails on any of these that drifts from en.
-  PRODUCTION_LOCALES = %w[en].freeze
+  # Locales that ship to production. The locale-parity guard test hard-fails
+  # on any of these that drifts from en.
+  PRODUCTION_LOCALES = %w[en hu].freeze
 
   # Locales that are being worked on but are not yet production-ready.
   # Translation generation targets these everywhere (so content can be
@@ -19,7 +19,7 @@ module I18n
   WIP_LOCALES = %w[
     ar bn ca de el
     es-ES es-419
-    fa fr hi hu id it ja ko nl pl
+    fa fr hi id it ja ko nl pl
     pt-PT pt-BR
     ro ru sr sv sw tr uk ur vi
     zh-CN zh-TW

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -108,7 +108,7 @@ part of `bin/rails test` too.
 locale derived from stored `Accept-Language` preferences, falling back to
 `I18n.default_locale`. `I18n::SUPPORTED_LOCALES` / `WIP_LOCALES` /
 `PRODUCTION_LOCALES` (`config/initializers/i18n.rb`) gate which locales are
-selectable where - production is `en`-only for now. Mailers render inside
+selectable where - production currently ships `en` and `hu`. Mailers render inside
 `I18n.with_locale(user.locale)` (`app/mailers/application_mailer.rb`); the
 per-request locale is set from the URL/user in
 `ApplicationController#set_locale`.

--- a/test/commands/badge/translation/translate_to_all_locales_test.rb
+++ b/test/commands/badge/translation/translate_to_all_locales_test.rb
@@ -38,7 +38,7 @@ class Badge::Translation::TranslateToAllLocalesTest < ActiveSupport::TestCase
     Badge::Translation::TranslateToLocale.stubs(:defer)
     result = Badge::Translation::TranslateToAllLocales.(badge)
 
-    assert_includes result, "hu" # From WIP_LOCALES (non-production SUPPORTED)
+    assert_includes result, "hu" # From SUPPORTED_LOCALES
     assert_includes result, "es-ES" # From WIP_LOCALES
   end
 

--- a/test/commands/level/translation/translate_to_all_locales_test.rb
+++ b/test/commands/level/translation/translate_to_all_locales_test.rb
@@ -42,13 +42,13 @@ class Level::Translation::TranslateToAllLocalesTest < ActiveSupport::TestCase
     # all in the target locales
     assert_includes I18n::SUPPORTED_LOCALES.map(&:to_s), "en"
     assert_includes I18n::SUPPORTED_LOCALES.map(&:to_s), "hu"
-    assert_includes I18n::WIP_LOCALES.map(&:to_s), "hu"
+    assert_includes I18n::WIP_LOCALES.map(&:to_s), "fr"
 
     # Verify the command uses both
     Level::Translation::TranslateToLocale.stubs(:defer)
     result = Level::Translation::TranslateToAllLocales.(level)
 
-    assert_includes result, "hu" # From WIP_LOCALES (non-production SUPPORTED)
+    assert_includes result, "hu" # From SUPPORTED_LOCALES
     assert_includes result, "es-ES" # From WIP_LOCALES
   end
 

--- a/test/commands/user/determine_locales_test.rb
+++ b/test/commands/user/determine_locales_test.rb
@@ -2,8 +2,10 @@ require "test_helper"
 
 class User::DetermineLocalesTest < ActiveSupport::TestCase
   test "returns every matching locale, live and draft, in preference order" do
-    with_supported_locales(%w[en]) do
-      assert_equal %w[hu es-ES en], User::DetermineLocales.(%w[hu es-ES en])
+    with_wip_locales(%w[xx es-ES]) do
+      with_supported_locales(%w[en]) do
+        assert_equal %w[xx es-ES en], User::DetermineLocales.(%w[xx es-ES en])
+      end
     end
   end
 

--- a/test/controllers/internal/settings_controller_test.rb
+++ b/test/controllers/internal/settings_controller_test.rb
@@ -120,12 +120,14 @@ class Internal::SettingsControllerTest < ApplicationControllerTest
   end
 
   test "PATCH locale accepts a draft locale, which is recorded but not yet served" do
-    with_supported_locales(%w[en]) do
-      patch locale_internal_settings_path, params: { value: "hu" }, as: :json
+    with_wip_locales(%w[xx]) do
+      with_supported_locales(%w[en]) do
+        patch locale_internal_settings_path, params: { value: "xx" }, as: :json
 
-      assert_response :success
-      assert_equal "hu", @user.reload.data.explicit_locale
-      assert_equal "en", @user.reload.locale
+        assert_response :success
+        assert_equal "xx", @user.reload.data.explicit_locale
+        assert_equal "en", @user.reload.locale
+      end
     end
   end
 

--- a/test/models/user/data_test.rb
+++ b/test/models/user/data_test.rb
@@ -197,29 +197,38 @@ class User::DataTest < ActiveSupport::TestCase
 
   test "locale ignores an explicit choice that isn't live yet" do
     user = create(:user)
-    user.data.update!(explicit_locale: "hu", locales: %w[en])
 
-    # hu is a draft locale here, so it must not drive what we serve.
-    with_supported_locales(%w[en]) do
-      assert_equal "en", user.data.locale
+    with_wip_locales(%w[xx]) do
+      user.data.update!(explicit_locale: "xx", locales: %w[en])
+
+      # xx is a draft locale here, so it must not drive what we serve.
+      with_supported_locales(%w[en]) do
+        assert_equal "en", user.data.locale
+      end
     end
   end
 
   test "locale honours the explicit choice once it goes live" do
     user = create(:user)
-    user.data.update!(explicit_locale: "hu", locales: %w[en])
 
-    with_supported_locales(%w[en hu]) do
-      assert_equal "hu", user.data.locale
+    with_wip_locales(%w[xx]) do
+      user.data.update!(explicit_locale: "xx", locales: %w[en])
+
+      with_supported_locales(%w[en xx]) do
+        assert_equal "xx", user.data.locale
+      end
     end
   end
 
   test "selected_locale keeps a draft choice" do
     user = create(:user)
-    user.data.update!(explicit_locale: "hu")
 
-    with_supported_locales(%w[en]) do
-      assert_equal "hu", user.data.selected_locale
+    with_wip_locales(%w[xx]) do
+      user.data.update!(explicit_locale: "xx")
+
+      with_supported_locales(%w[en]) do
+        assert_equal "xx", user.data.selected_locale
+      end
     end
   end
 
@@ -239,20 +248,26 @@ class User::DataTest < ActiveSupport::TestCase
 
   test "available_locales leads with the explicit choice, then the served locale" do
     user = create(:user)
-    user.data.update!(explicit_locale: "hu", locales: %w[fr en])
 
-    with_supported_locales(%w[en]) do
-      # hu is chosen but not live, so en is served — both appear, choice first.
-      assert_equal %w[hu en fr], user.data.available_locales
+    with_wip_locales(%w[xx fr]) do
+      user.data.update!(explicit_locale: "xx", locales: %w[fr en])
+
+      with_supported_locales(%w[en]) do
+        # xx is chosen but not live, so en is served — both appear, choice first.
+        assert_equal %w[xx en fr], user.data.available_locales
+      end
     end
   end
 
   test "available_locales dedupes when the explicit choice is also the served locale" do
     user = create(:user)
-    user.data.update!(explicit_locale: "hu", locales: %w[hu en])
 
-    with_supported_locales(%w[en hu]) do
-      assert_equal %w[hu en], user.data.available_locales
+    with_wip_locales(%w[xx]) do
+      user.data.update!(explicit_locale: "xx", locales: %w[xx en])
+
+      with_supported_locales(%w[en xx]) do
+        assert_equal %w[xx en], user.data.available_locales
+      end
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -122,7 +122,7 @@ class UserTest < ActiveSupport::TestCase
     # The test env ships the draft set as live, so narrow it to prove the
     # validation really does span live + draft rather than just live.
     with_supported_locales(%w[en]) do
-      assert build(:user, locale: "hu").valid?
+      assert build(:user, locale: "fr").valid?
       refute build(:user, locale: "kl").valid?
     end
   end

--- a/test/serializers/serialize_user_test.rb
+++ b/test/serializers/serialize_user_test.rb
@@ -184,16 +184,18 @@ class SerializeUserTest < ActiveSupport::TestCase
   end
 
   test "serializes explicit_locale and leads locales with it" do
-    user = create(:user, locale: "hu")
-    user.data.update!(locales: %w[fr en])
+    with_wip_locales(%w[xx fr]) do
+      user = create(:user, locale: "xx")
+      user.data.update!(locales: %w[fr en])
 
-    with_supported_locales(%w[en]) do
-      result = SerializeUser.(user)
+      with_supported_locales(%w[en]) do
+        result = SerializeUser.(user)
 
-      # hu is chosen but not live: en is still served, hu still leads the list.
-      assert_equal "hu", result[:explicit_locale]
-      assert_equal "en", result[:locale]
-      assert_equal %w[hu en fr], result[:locales]
+        # xx is chosen but not live: en is still served, xx still leads the list.
+        assert_equal "xx", result[:explicit_locale]
+        assert_equal "en", result[:locale]
+        assert_equal %w[xx en fr], result[:locales]
+      end
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -115,6 +115,20 @@ module ActiveSupport
       I18n.send(:remove_const, :SUPPORTED_LOCALES)
       I18n.const_set(:SUPPORTED_LOCALES, original)
     end
+
+    # Temporarily override the draft locale set, for tests that exercise
+    # draft-locale behaviour (chosen but not yet live) against a synthetic
+    # locale ("xx") rather than a real WIP locale, which would otherwise
+    # drift out from under the test whenever a locale is promoted.
+    def with_wip_locales(locales)
+      original = I18n::WIP_LOCALES
+      I18n.send(:remove_const, :WIP_LOCALES)
+      I18n.const_set(:WIP_LOCALES, locales.freeze)
+      yield
+    ensure
+      I18n.send(:remove_const, :WIP_LOCALES)
+      I18n.const_set(:WIP_LOCALES, original)
+    end
   end
 end
 


### PR DESCRIPTION
## Summary
- Stacked on #624 (test infra) — moves `hu` from `I18n::WIP_LOCALES` to `PRODUCTION_LOCALES` in `config/initializers/i18n.rb`, making it a fully live, user-selectable locale in production alongside `en`.
- This upgrades `hu`'s i18n parity (`test/i18n_parity_test.rb`) and level-milestone-email completeness (`test/db/seeds/level_translations_completeness_test.rb`) checks from warnings to hard failures — both currently pass, since real Hungarian mailer/level-milestone content already landed in #613, #617, #618.
- Updated `docs/i18n.md`'s "production is en-only for now" note accordingly.

## Test plan
- [x] `bin/rails test` — full suite green
- [x] `bin/rubocop -a` — no offenses
- [x] `bin/brakeman` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZVsJx8YpMLjMKHM21sb6b