### PR TITLE
Make the live locale list a one-line edit

### DIFF
--- a/app/commands/badge/translation/translate_to_all_locales.rb
+++ b/app/commands/badge/translation/translate_to_all_locales.rb
@@ -15,10 +15,5 @@ class Badge::Translation::TranslateToAllLocales
 
   private
   memoize
-  def target_locales = supported_locales - ["en"]
-
-  memoize
-  def supported_locales
-    (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s).uniq
-  end
+  def target_locales = I18n::ALL_LOCALES - ["en"]
 end

--- a/app/commands/badge/translation/translate_to_locale.rb
+++ b/app/commands/badge/translation/translate_to_locale.rb
@@ -32,12 +32,7 @@ class Badge::Translation::TranslateToLocale
   private
   def validate!
     raise ArgumentError, "Target locale cannot be English (en)" if target_locale == "en"
-    raise ArgumentError, "Target locale not supported" unless supported_locales.include?(target_locale)
-  end
-
-  memoize
-  def supported_locales
-    (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s).uniq
+    raise ArgumentError, "Target locale not supported" unless I18n::ALL_LOCALES.include?(target_locale)
   end
 
   memoize

--- a/app/commands/level/translation/translate_to_all_locales.rb
+++ b/app/commands/level/translation/translate_to_all_locales.rb
@@ -15,10 +15,5 @@ class Level::Translation::TranslateToAllLocales
 
   private
   memoize
-  def target_locales = supported_locales - ["en"]
-
-  memoize
-  def supported_locales
-    (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s).uniq
-  end
+  def target_locales = I18n::ALL_LOCALES - ["en"]
 end

--- a/app/commands/level/translation/translate_to_locale.rb
+++ b/app/commands/level/translation/translate_to_locale.rb
@@ -32,12 +32,7 @@ class Level::Translation::TranslateToLocale
   private
   def validate!
     raise ArgumentError, "Target locale cannot be English (en)" if target_locale == "en"
-    raise ArgumentError, "Target locale not supported" unless supported_locales.include?(target_locale)
-  end
-
-  memoize
-  def supported_locales
-    (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s).uniq
+    raise ArgumentError, "Target locale not supported" unless I18n::ALL_LOCALES.include?(target_locale)
   end
 
   memoize

--- a/app/commands/user/determine_locales.rb
+++ b/app/commands/user/determine_locales.rb
@@ -4,8 +4,7 @@ class User::DetermineLocales
   initialize_with :tags
 
   # Returns every distinct locale the user's Accept-Language preferences
-  # resolve to, live or draft (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES),
-  # in preference order. Unlike User::DetermineLocale this isn't gated on
+  # resolve to, live or draft (I18n::ALL_LOCALES), in preference order. Unlike User::DetermineLocale this isn't gated on
   # production-live status - the FE decides which of these to surface.
-  def call = User::NormalizeLocaleTags.(tags, I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES)
+  def call = User::NormalizeLocaleTags.(tags, I18n::ALL_LOCALES)
 end

--- a/app/models/badge/translation.rb
+++ b/app/models/badge/translation.rb
@@ -7,7 +7,7 @@ class Badge::Translation < ApplicationRecord
   validates :locale, uniqueness: { scope: :badge_id }
   validates :locale, exclusion: { in: ['en'], message: "English content belongs on Badge model" }
   validates :locale, inclusion: {
-    in: ->(_) { (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s) - ['en'] },
+    in: ->(_) { I18n::ALL_LOCALES.map(&:to_s) - ['en'] },
     message: "is not a supported locale"
   }
 

--- a/app/models/level/translation.rb
+++ b/app/models/level/translation.rb
@@ -7,7 +7,7 @@ class Level::Translation < ApplicationRecord
   validates :locale, uniqueness: { scope: :level_id }
   validates :locale, exclusion: { in: ['en'], message: "English content belongs on Level model" }
   validates :locale, inclusion: {
-    in: ->(_) { (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s) - ['en'] },
+    in: ->(_) { I18n::ALL_LOCALES.map(&:to_s) - ['en'] },
     message: "is not a supported locale"
   }
 

--- a/app/models/user/data.rb
+++ b/app/models/user/data.rb
@@ -16,7 +16,7 @@ class User::Data < ApplicationRecord
   # and we hold that choice until it does. Resolved lazily (rather than at
   # class-load) so the locale sets can be swapped in tests.
   validates :explicit_locale,
-    inclusion: { in: ->(_) { I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES } },
+    inclusion: { in: ->(_) { I18n::ALL_LOCALES } },
     allow_nil: true
 
   # Locale is derived, never stored directly: an explicit user choice wins
@@ -40,7 +40,7 @@ class User::Data < ApplicationRecord
   # though it were never set, rather than surfaced as a selection the user can't
   # act on.
   def selected_locale
-    return nil unless (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).include?(explicit_locale)
+    return nil unless I18n::ALL_LOCALES.include?(explicit_locale)
 
     explicit_locale
   end

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,42 +1,44 @@
 # I18n Configuration
-# Defines supported and work-in-progress locales for the application
+# Defines every locale the application knows about, and which of them are live.
 
 module I18n
-  # Locales that ship to production. The locale-parity guard test hard-fails
-  # on any of these that drifts from en.
-  PRODUCTION_LOCALES = %w[en hu].freeze
-
-  # Locales that are being worked on but are not yet production-ready.
-  # Translation generation targets these everywhere (so content can be
-  # pre-generated before a locale is promoted), but users can only select
-  # them outside production.
+  # Every locale the application knows about, in canonical BCP-47 casing.
   #
-  # Mirrors the front end's ALL_LOCALES (app/lib/locales.ts), in canonical
-  # BCP-47 casing. The two must stay in step: the front end offers a locale
-  # switcher over its list, and anything missing here is rejected by the
-  # explicit_locale validation, so a locale present there but absent here
-  # shows up in the UI and then 422s when picked.
-  WIP_LOCALES = %w[
-    ar bn ca de el
+  # Mirrors the front end's ALL_LOCALES (app/lib/locales.ts). The two must stay
+  # in step: the front end offers a locale switcher over its list, and anything
+  # missing here is rejected by the explicit_locale validation, so a locale
+  # present there but absent here shows up in the UI and then 422s when picked.
+  #
+  # Promoting a locale is a one-line edit to PRODUCTION_LOCALES below - this
+  # list never changes when a locale goes live.
+  ALL_LOCALES = %w[
+    ar bn ca de el en
     es-ES es-419
-    fa fr hi id it ja ko nl pl
+    fa fr hi hu id it ja ko nl pl
     pt-PT pt-BR
     ro ru sr sv sw tr uk ur vi
     zh-CN zh-TW
   ].freeze
 
-  # Locales users can actually select. Production ships PRODUCTION_LOCALES
-  # only; other environments include the WIP set so translation work can
-  # be exercised in dev/test.
-  SUPPORTED_LOCALES = (
-    Jiki.env.production? ? PRODUCTION_LOCALES : PRODUCTION_LOCALES + WIP_LOCALES
-  ).freeze
+  # The live set: locales that ship to production. The locale-parity guard test
+  # hard-fails on any of these that drifts from en.
+  PRODUCTION_LOCALES = %w[en hu].freeze
+
+  # The draft set: everything not yet live. Translation generation targets every
+  # locale (so content can be pre-generated before a locale is promoted), but
+  # users can only select drafts outside production.
+  WIP_LOCALES = (ALL_LOCALES - PRODUCTION_LOCALES).freeze
+
+  # Locales users can actually select. Production ships the live set only;
+  # other environments serve everything so translation work can be exercised
+  # in dev/test.
+  SUPPORTED_LOCALES = (Jiki.env.production? ? PRODUCTION_LOCALES : ALL_LOCALES).freeze
 end
 
 # Constrain the locales I18n knows about to the set users can select.
 # rails-i18n and devise-i18n ship translations for ~100 locales; without this
 # they would all land in I18n.available_locales (and, in production, bloat the
 # loaded translation set). Nothing in the app keys off available_locales - our
-# own I18n::SUPPORTED_LOCALES / WIP_LOCALES constants drive locale logic - so
+# own I18n::ALL_LOCALES / SUPPORTED_LOCALES constants drive locale logic - so
 # this only trims the gem-provided noise.
-I18n.available_locales = I18n::SUPPORTED_LOCALES.map(&:to_sym).uniq
+I18n.available_locales = I18n::SUPPORTED_LOCALES.map(&:to_sym)

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -106,9 +106,12 @@ part of `bin/rails test` too.
 
 `User::Data#locale` resolves an explicit user choice, falling back to a
 locale derived from stored `Accept-Language` preferences, falling back to
-`I18n.default_locale`. `I18n::SUPPORTED_LOCALES` / `WIP_LOCALES` /
-`PRODUCTION_LOCALES` (`config/initializers/i18n.rb`) gate which locales are
-selectable where - production currently ships `en` and `hu`. Mailers render inside
+`I18n.default_locale`. `config/initializers/i18n.rb` holds every locale the
+app knows about in `I18n::ALL_LOCALES` (mirroring the front end's list) and
+the live subset in `I18n::PRODUCTION_LOCALES`; `WIP_LOCALES` (the drafts) and
+`SUPPORTED_LOCALES` (what's selectable in this environment) are derived from
+those two, so promoting a locale is a one-line edit to `PRODUCTION_LOCALES`
+and nothing else. Mailers render inside
 `I18n.with_locale(user.locale)` (`app/mailers/application_mailer.rb`); the
 per-request locale is set from the URL/user in
 `ApplicationController#set_locale`.

--- a/test/commands/badge/translation/translate_to_all_locales_test.rb
+++ b/test/commands/badge/translation/translate_to_all_locales_test.rb
@@ -5,7 +5,7 @@ class Badge::Translation::TranslateToAllLocalesTest < ActiveSupport::TestCase
     badge = create(:member_badge)
 
     # Get all supported locales (excluding English)
-    expected_locales = (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s).uniq - ["en"]
+    expected_locales = I18n::ALL_LOCALES - ["en"]
 
     # Expect .defer to be called for each target locale
     expected_locales.each do |locale|
@@ -31,15 +31,14 @@ class Badge::Translation::TranslateToAllLocalesTest < ActiveSupport::TestCase
     refute_includes result, "en"
   end
 
-  test "includes both SUPPORTED_LOCALES and WIP_LOCALES" do
+  test "targets draft locales as well as live ones" do
     badge = create(:member_badge)
 
-    # Verify the command uses both
     Badge::Translation::TranslateToLocale.stubs(:defer)
-    result = Badge::Translation::TranslateToAllLocales.(badge)
 
-    assert_includes result, "hu" # From SUPPORTED_LOCALES
-    assert_includes result, "es-ES" # From WIP_LOCALES
+    with_locales(live: %w[en xx], draft: %w[yy]) do
+      assert_equal %w[xx yy], Badge::Translation::TranslateToAllLocales.(badge)
+    end
   end
 
   test "uses .defer() for background job execution" do

--- a/test/commands/level/translation/translate_to_all_locales_test.rb
+++ b/test/commands/level/translation/translate_to_all_locales_test.rb
@@ -4,8 +4,7 @@ class Level::Translation::TranslateToAllLocalesTest < ActiveSupport::TestCase
   test "enqueues background jobs for all non-English locales" do
     level = create(:level)
 
-    # Get all supported locales (excluding English)
-    expected_locales = (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s).uniq - ["en"]
+    expected_locales = I18n::ALL_LOCALES - ["en"]
 
     # Expect .defer to be called for each target locale
     expected_locales.each do |locale|
@@ -31,32 +30,18 @@ class Level::Translation::TranslateToAllLocalesTest < ActiveSupport::TestCase
     refute_includes result, "en"
   end
 
-  test "includes both SUPPORTED_LOCALES and WIP_LOCALES" do
+  test "targets draft locales as well as live ones" do
     level = create(:level)
 
-    # Get all non-English locales from both constants
-    (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s).uniq
-
-    # Should include at least one from each constant
-    # WIP_LOCALES carries every non-production locale, so we expect them
-    # all in the target locales
-    assert_includes I18n::SUPPORTED_LOCALES.map(&:to_s), "en"
-    assert_includes I18n::SUPPORTED_LOCALES.map(&:to_s), "hu"
-    assert_includes I18n::WIP_LOCALES.map(&:to_s), "fr"
-
-    # Verify the command uses both
     Level::Translation::TranslateToLocale.stubs(:defer)
-    result = Level::Translation::TranslateToAllLocales.(level)
 
-    assert_includes result, "hu" # From SUPPORTED_LOCALES
-    assert_includes result, "es-ES" # From WIP_LOCALES
+    with_locales(live: %w[en xx], draft: %w[yy]) do
+      assert_equal %w[xx yy], Level::Translation::TranslateToAllLocales.(level)
+    end
   end
 
   test "uses .defer() for background job execution" do
     level = create(:level)
-
-    # Get first non-English locale
-    (I18n::SUPPORTED_LOCALES + I18n::WIP_LOCALES).map(&:to_s).find { |l| l != "en" }
 
     # Verify .defer is called (not .call)
     Level::Translation::TranslateToLocale.expects(:defer).at_least_once

--- a/test/commands/user/determine_locale_test.rb
+++ b/test/commands/user/determine_locale_test.rb
@@ -31,7 +31,7 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
     %w[xx-YY] => nil                      # nothing matches -> nil, caller applies the default
   }.each do |tags, expected|
     test "#{tags.join(', ')} negotiates to #{expected || 'nil'} against the full set" do
-      with_supported_locales(FULL_SET) do
+      with_locales(live: FULL_SET) do
         result = User::DetermineLocale.(tags)
         expected.nil? ? assert_nil(result) : assert_equal(expected, result)
       end
@@ -42,19 +42,19 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
   # subset. A tag that would collapse to a not-yet-live variant must fall
   # through rather than return it.
   test "pt-MZ, en falls through to en when pt-PT is not live" do
-    with_supported_locales(%w[en hu]) do
+    with_locales(live: %w[en hu]) do
       assert_equal "en", User::DetermineLocale.(%w[pt-MZ en])
     end
   end
 
   test "pt-BR returns nil (caller defaults) when pt-BR is not live" do
-    with_supported_locales(%w[en hu]) do
+    with_locales(live: %w[en hu]) do
       assert_nil User::DetermineLocale.(%w[pt-BR])
     end
   end
 
   test "hu-HU, en negotiates to hu when hu is live" do
-    with_supported_locales(%w[en hu]) do
+    with_locales(live: %w[en hu]) do
       assert_equal "hu", User::DetermineLocale.(%w[hu-HU en])
     end
   end
@@ -71,14 +71,14 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
     %w[zh-US] => "zh-CN"        # diaspora region -> Simplified
   }.each do |tags, expected|
     test "#{tags.join(', ')} negotiates to #{expected}" do
-      with_supported_locales(%w[en zh-CN zh-TW]) do
+      with_locales(live: %w[en zh-CN zh-TW]) do
         assert_equal expected, User::DetermineLocale.(tags)
       end
     end
   end
 
   test "zh-HK falls through when zh-TW is not live" do
-    with_supported_locales(%w[en zh-CN]) do
+    with_locales(live: %w[en zh-CN]) do
       # Must not silently serve Simplified to a Traditional reader.
       assert_equal "en", User::DetermineLocale.(%w[zh-HK en])
     end
@@ -86,19 +86,19 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
 
   # Edge cases.
   test "empty list returns nil" do
-    with_supported_locales(FULL_SET) do
+    with_locales(live: FULL_SET) do
       assert_nil User::DetermineLocale.([])
     end
   end
 
   test "blank and malformed tags are skipped" do
-    with_supported_locales(FULL_SET) do
+    with_locales(live: FULL_SET) do
       assert_equal "fr", User::DetermineLocale.(["", "  ", "-", "fr"])
     end
   end
 
   test "mixed-case tags are normalised for exact matching" do
-    with_supported_locales(FULL_SET) do
+    with_locales(live: FULL_SET) do
       assert_equal "pt-BR", User::DetermineLocale.(%w[PT-br])
       assert_equal "es-419", User::DetermineLocale.(%w[ES-419])
       assert_equal "es-ES", User::DetermineLocale.(%w[es-es]) # lowercase region normalises to canonical es-ES
@@ -108,27 +108,27 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
   end
 
   test "mixed-case region collapses correctly" do
-    with_supported_locales(FULL_SET) do
+    with_locales(live: FULL_SET) do
       assert_equal "es-419", User::DetermineLocale.(%w[es-ar])
       assert_equal "pt-PT", User::DetermineLocale.(%w[pt-mz])
     end
   end
 
   test "duplicate tags are harmless" do
-    with_supported_locales(FULL_SET) do
+    with_locales(live: FULL_SET) do
       assert_equal "de", User::DetermineLocale.(%w[de-CH de-CH de])
     end
   end
 
   test "order determines the winner across supported languages" do
-    with_supported_locales(FULL_SET) do
+    with_locales(live: FULL_SET) do
       assert_equal "de", User::DetermineLocale.(%w[de fr])
       assert_equal "fr", User::DetermineLocale.(%w[fr de])
     end
   end
 
   test "exact es-419 beats an earlier es region rule only when listed first" do
-    with_supported_locales(FULL_SET) do
+    with_locales(live: FULL_SET) do
       # es-ES matches exactly (Peninsular) and wins because it appears first,
       # before es-MX (which would collapse to es-419) is reached.
       assert_equal "es-ES", User::DetermineLocale.(%w[es-ES es-MX])
@@ -136,7 +136,7 @@ class User::DetermineLocaleTest < ActiveSupport::TestCase
   end
 
   test "script subtags don't derail base-language collapse" do
-    with_supported_locales(FULL_SET) do
+    with_locales(live: FULL_SET) do
       # zh-Hant-TW is unsupported; ja is next.
       assert_equal "ja", User::DetermineLocale.(%w[zh-Hant-TW ja])
     end

--- a/test/commands/user/determine_locales_test.rb
+++ b/test/commands/user/determine_locales_test.rb
@@ -2,27 +2,25 @@ require "test_helper"
 
 class User::DetermineLocalesTest < ActiveSupport::TestCase
   test "returns every matching locale, live and draft, in preference order" do
-    with_wip_locales(%w[xx es-ES]) do
-      with_supported_locales(%w[en]) do
-        assert_equal %w[xx es-ES en], User::DetermineLocales.(%w[xx es-ES en])
-      end
+    with_locales(live: %w[en], draft: %w[xx es-ES]) do
+      assert_equal %w[xx es-ES en], User::DetermineLocales.(%w[xx es-ES en])
     end
   end
 
   test "collapses region variants against the full live + draft set" do
-    with_supported_locales(%w[en]) do
+    with_locales(live: %w[en], draft: %w[pt-PT pt-BR]) do
       assert_equal %w[pt-PT], User::DetermineLocales.(%w[pt-MZ])
     end
   end
 
   test "dedupes repeated resolutions" do
-    with_supported_locales(%w[en]) do
+    with_locales(live: %w[en]) do
       assert_equal %w[en], User::DetermineLocales.(%w[en en-GB])
     end
   end
 
   test "returns an empty array when nothing matches" do
-    with_supported_locales(%w[en]) do
+    with_locales(live: %w[en]) do
       assert_equal [], User::DetermineLocales.(%w[xx-YY])
     end
   end

--- a/test/controllers/internal/settings_controller_test.rb
+++ b/test/controllers/internal/settings_controller_test.rb
@@ -120,14 +120,12 @@ class Internal::SettingsControllerTest < ApplicationControllerTest
   end
 
   test "PATCH locale accepts a draft locale, which is recorded but not yet served" do
-    with_wip_locales(%w[xx]) do
-      with_supported_locales(%w[en]) do
-        patch locale_internal_settings_path, params: { value: "xx" }, as: :json
+    with_locales(live: %w[en], draft: %w[xx]) do
+      patch locale_internal_settings_path, params: { value: "xx" }, as: :json
 
-        assert_response :success
-        assert_equal "xx", @user.reload.data.explicit_locale
-        assert_equal "en", @user.reload.locale
-      end
+      assert_response :success
+      assert_equal "xx", @user.reload.data.explicit_locale
+      assert_equal "en", @user.reload.locale
     end
   end
 

--- a/test/i18n_locales_test.rb
+++ b/test/i18n_locales_test.rb
@@ -6,10 +6,17 @@ require "test_helper"
 # explicit_locale validation and the tag negotiation both match exactly, so
 # "zh-cn" would be advertised by the front end and then 422 on selection.
 class I18nLocalesTest < ActiveSupport::TestCase
-  ALL = (I18n::PRODUCTION_LOCALES + I18n::WIP_LOCALES).freeze
+  ALL = I18n::ALL_LOCALES
 
-  test "locales are unique across the production and WIP sets" do
+  test "locales are unique" do
     assert_equal ALL.uniq, ALL, "duplicate locale(s): #{ALL.tally.select { |_, n| n > 1 }.keys.inspect}"
+  end
+
+  test "every live locale is a known locale" do
+    # Promotion is a one-line edit to PRODUCTION_LOCALES, so a typo there is the
+    # likely failure: it would ship a locale nothing else in the app knows about.
+    unknown = I18n::PRODUCTION_LOCALES - ALL
+    assert_empty unknown, "in PRODUCTION_LOCALES but not in ALL_LOCALES: #{unknown.inspect}"
   end
 
   test "locales use canonical BCP-47 casing" do

--- a/test/models/badge/translation_test.rb
+++ b/test/models/badge/translation_test.rb
@@ -45,7 +45,7 @@ class Badge::TranslationTest < ActiveSupport::TestCase
   end
 
   test "accepts supported locales" do
-    I18n::WIP_LOCALES.each do |locale|
+    (I18n::ALL_LOCALES - ["en"]).each do |locale|
       translation = build(:badge_translation, locale:)
       assert translation.valid?, "Expected #{locale} to be valid"
     end

--- a/test/models/level/translation_test.rb
+++ b/test/models/level/translation_test.rb
@@ -59,7 +59,7 @@ class Level::TranslationTest < ActiveSupport::TestCase
   end
 
   test "accepts supported locales" do
-    I18n::WIP_LOCALES.each do |locale|
+    (I18n::ALL_LOCALES - ["en"]).each do |locale|
       translation = build(:level_translation, locale:)
       assert translation.valid?, "Expected #{locale} to be valid"
     end

--- a/test/models/user/data_test.rb
+++ b/test/models/user/data_test.rb
@@ -198,37 +198,31 @@ class User::DataTest < ActiveSupport::TestCase
   test "locale ignores an explicit choice that isn't live yet" do
     user = create(:user)
 
-    with_wip_locales(%w[xx]) do
+    with_locales(live: %w[en], draft: %w[xx]) do
       user.data.update!(explicit_locale: "xx", locales: %w[en])
 
       # xx is a draft locale here, so it must not drive what we serve.
-      with_supported_locales(%w[en]) do
-        assert_equal "en", user.data.locale
-      end
+      assert_equal "en", user.data.locale
     end
   end
 
   test "locale honours the explicit choice once it goes live" do
     user = create(:user)
 
-    with_wip_locales(%w[xx]) do
+    with_locales(live: %w[en xx]) do
       user.data.update!(explicit_locale: "xx", locales: %w[en])
 
-      with_supported_locales(%w[en xx]) do
-        assert_equal "xx", user.data.locale
-      end
+      assert_equal "xx", user.data.locale
     end
   end
 
   test "selected_locale keeps a draft choice" do
     user = create(:user)
 
-    with_wip_locales(%w[xx]) do
+    with_locales(live: %w[en], draft: %w[xx]) do
       user.data.update!(explicit_locale: "xx")
 
-      with_supported_locales(%w[en]) do
-        assert_equal "xx", user.data.selected_locale
-      end
+      assert_equal "xx", user.data.selected_locale
     end
   end
 
@@ -249,25 +243,21 @@ class User::DataTest < ActiveSupport::TestCase
   test "available_locales leads with the explicit choice, then the served locale" do
     user = create(:user)
 
-    with_wip_locales(%w[xx fr]) do
+    with_locales(live: %w[en], draft: %w[xx fr]) do
       user.data.update!(explicit_locale: "xx", locales: %w[fr en])
 
-      with_supported_locales(%w[en]) do
-        # xx is chosen but not live, so en is served — both appear, choice first.
-        assert_equal %w[xx en fr], user.data.available_locales
-      end
+      # xx is chosen but not live, so en is served — both appear, choice first.
+      assert_equal %w[xx en fr], user.data.available_locales
     end
   end
 
   test "available_locales dedupes when the explicit choice is also the served locale" do
     user = create(:user)
 
-    with_wip_locales(%w[xx]) do
+    with_locales(live: %w[en xx]) do
       user.data.update!(explicit_locale: "xx", locales: %w[xx en])
 
-      with_supported_locales(%w[en xx]) do
-        assert_equal %w[xx en], user.data.available_locales
-      end
+      assert_equal %w[xx en], user.data.available_locales
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -81,19 +81,19 @@ class UserTest < ActiveSupport::TestCase
 
   test "locale skips preferences that aren't live" do
     user = create(:user)
-    user.data.update!(locales: %w[fr de hu])
+    with_locales(live: %w[en yy], draft: %w[xx]) do
+      user.data.update!(locales: %w[xx yy])
 
-    # fr and de are known locales but not live here, so hu wins.
-    with_supported_locales(%w[en hu]) do
-      assert_equal "hu", user.locale
+      # xx is a known locale but not live here, so yy wins.
+      assert_equal "yy", user.locale
     end
   end
 
   test "locale falls back to en when no preference is live" do
     user = create(:user)
-    user.data.update!(locales: %w[fr de])
+    with_locales(live: %w[en], draft: %w[xx]) do
+      user.data.update!(locales: %w[xx])
 
-    with_supported_locales(%w[en hu]) do
       assert_equal "en", user.locale
     end
   end
@@ -121,8 +121,8 @@ class UserTest < ActiveSupport::TestCase
   test "explicit_locale accepts a draft locale that isn't live yet" do
     # The test env ships the draft set as live, so narrow it to prove the
     # validation really does span live + draft rather than just live.
-    with_supported_locales(%w[en]) do
-      assert build(:user, locale: "fr").valid?
+    with_locales(live: %w[en], draft: %w[xx]) do
+      assert build(:user, locale: "xx").valid?
       refute build(:user, locale: "kl").valid?
     end
   end

--- a/test/serializers/serialize_user_test.rb
+++ b/test/serializers/serialize_user_test.rb
@@ -184,18 +184,16 @@ class SerializeUserTest < ActiveSupport::TestCase
   end
 
   test "serializes explicit_locale and leads locales with it" do
-    with_wip_locales(%w[xx fr]) do
+    with_locales(live: %w[en], draft: %w[xx fr]) do
       user = create(:user, locale: "xx")
       user.data.update!(locales: %w[fr en])
 
-      with_supported_locales(%w[en]) do
-        result = SerializeUser.(user)
+      result = SerializeUser.(user)
 
-        # xx is chosen but not live: en is still served, xx still leads the list.
-        assert_equal "xx", result[:explicit_locale]
-        assert_equal "en", result[:locale]
-        assert_equal %w[xx en fr], result[:locales]
-      end
+      # xx is chosen but not live: en is still served, xx still leads the list.
+      assert_equal "xx", result[:explicit_locale]
+      assert_equal "en", result[:locale]
+      assert_equal %w[xx en fr], result[:locales]
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -103,31 +103,30 @@ module ActiveSupport
       assert_equal result_one, result_two
     end
 
-    # Temporarily override the live locale set. I18n::SUPPORTED_LOCALES is
-    # environment-gated (en-only in production, en/hu elsewhere), so locale
-    # logic has to be exercised against the eventual content set as well.
-    def with_supported_locales(locales)
-      original = I18n::SUPPORTED_LOCALES
-      I18n.send(:remove_const, :SUPPORTED_LOCALES)
-      I18n.const_set(:SUPPORTED_LOCALES, locales.freeze)
+    # Temporarily override the locale sets, keeping the three constants
+    # consistent with each other exactly as the initializer derives them.
+    #
+    # Locale behaviour splits on live vs draft, so tests that exercise it need
+    # to pin both sides. Use synthetic locales ("xx", "yy") rather than real
+    # ones: which real locale is live changes every time one is promoted, and a
+    # test pinned to a real name silently changes meaning when it does.
+    #
+    #   with_locales(live: %w[en], draft: %w[xx])
+    def with_locales(live:, draft: [])
+      originals = LOCALE_CONSTANTS.index_with { |name| I18n.const_get(name) }
+      override_locale_constants(SUPPORTED_LOCALES: live, WIP_LOCALES: draft, ALL_LOCALES: live + draft)
       yield
     ensure
-      I18n.send(:remove_const, :SUPPORTED_LOCALES)
-      I18n.const_set(:SUPPORTED_LOCALES, original)
+      override_locale_constants(originals)
     end
 
-    # Temporarily override the draft locale set, for tests that exercise
-    # draft-locale behaviour (chosen but not yet live) against a synthetic
-    # locale ("xx") rather than a real WIP locale, which would otherwise
-    # drift out from under the test whenever a locale is promoted.
-    def with_wip_locales(locales)
-      original = I18n::WIP_LOCALES
-      I18n.send(:remove_const, :WIP_LOCALES)
-      I18n.const_set(:WIP_LOCALES, locales.freeze)
-      yield
-    ensure
-      I18n.send(:remove_const, :WIP_LOCALES)
-      I18n.const_set(:WIP_LOCALES, original)
+    LOCALE_CONSTANTS = %i[SUPPORTED_LOCALES WIP_LOCALES ALL_LOCALES].freeze
+
+    def override_locale_constants(values)
+      values.each do |name, locales|
+        I18n.send(:remove_const, name)
+        I18n.const_set(name, locales.freeze)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Follows #625, where promoting a single locale (`hu`) touched 10 files. Almost none of that was the promotion.

Which locales are live was spread across **two** hand-maintained lists that had to be kept complementary — promoting meant adding to `PRODUCTION_LOCALES` *and* deleting from `WIP_LOCALES`. Meanwhile the full set of known locales (the thing that mirrors the front end's `ALL_LOCALES`) was never written down; it only existed as `SUPPORTED_LOCALES + WIP_LOCALES`, reconstructed at ten call sites.

Inverted:

```ruby
ALL_LOCALES = %w[ar bn ca de el en ...]   # hand-maintained; never changes on promotion
PRODUCTION_LOCALES = %w[en hu]            # the live subset — the only thing you edit
WIP_LOCALES = (ALL_LOCALES - PRODUCTION_LOCALES).freeze
SUPPORTED_LOCALES = (Jiki.env.production? ? PRODUCTION_LOCALES : ALL_LOCALES).freeze
```

- Union call sites now use `I18n::ALL_LOCALES`, retiring the `supported_locales` memoized method each of the four translation commands carried a copy of.
- `with_supported_locales` / `with_wip_locales` collapse into one `with_locales(live:, draft:)` that keeps the constants mutually consistent, killing the nested-block pairs #625 introduced.
- Tests that needed "a draft locale" were grabbing whichever real locale happened not to be live yet (`hu`, then `fr`) — they now use synthetic `xx`/`yy`, so promoting a real locale can't quietly change what they assert. Two tests iterating `WIP_LOCALES` meant "every non-English locale"; they now say that.
- New guard: every `PRODUCTION_LOCALES` entry must be in `ALL_LOCALES`, since a typo in the one-line edit is now the likely failure mode.

No behaviour change — the derived sets are identical to the old literals.

The stacked PR is the proof: promoting `it` and `uk` on top of this is a one-line diff.

## Test plan
- [x] `bin/rails test` — full suite green
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmuyHo8ENa5ZjGvseYQUpz