### PR TITLE
Promote it and uk to production locales

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -22,7 +22,7 @@ module I18n
 
   # The live set: locales that ship to production. The locale-parity guard test
   # hard-fails on any of these that drifts from en.
-  PRODUCTION_LOCALES = %w[en hu].freeze
+  PRODUCTION_LOCALES = %w[en hu it uk].freeze
 
   # The draft set: everything not yet live. Translation generation targets every
   # locale (so content can be pre-generated before a locale is promoted), but


### PR DESCRIPTION
Stacked on #626. The proof that PR does what it says:

```diff
-  PRODUCTION_LOCALES = %w[en hu].freeze
+  PRODUCTION_LOCALES = %w[en hu it uk].freeze
```

One line, one file. Compare #625, where promoting `hu` alone touched ten.

## Draft: blocked on content, not code

CI fails here **by design** — the gates are refusing to ship half-translated locales:

| | `it` | `uk` |
|---|---|---|
| `mailers/account_mailer.<l>.yml` | missing | missing |
| `mailers/onboarding_mailer.<l>.yml` | missing | missing |
| `mailers/premium_mailer.<l>.yml` | missing | missing |
| `db/seeds/level_translations/<l>.json` | ✅ | missing |

(`en` and `hu` are the only locales with all 7 mailer catalogs today.)

Nothing further is needed in code — land that content and this one-line diff goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmuyHo8ENa5ZjGvseYQUpz