### PR TITLE
Promote el to a production locale

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -22,7 +22,7 @@ module I18n
 
   # The live set: locales that ship to production. The locale-parity guard test
   # hard-fails on any of these that drifts from en.
-  PRODUCTION_LOCALES = %w[en hu it uk].freeze
+  PRODUCTION_LOCALES = %w[el en hu it uk].freeze
 
   # The draft set: everything not yet live. Translation generation targets every
   # locale (so content can be pre-generated before a locale is promoted), but


### PR DESCRIPTION
Greek goes live.

```diff
-  PRODUCTION_LOCALES = %w[en hu it uk].freeze
+  PRODUCTION_LOCALES = %w[el en hu it uk].freeze
```

One line, one file — as #626 intended. `el` already had all 7 mailer catalogs and `db/seeds/level_translations/el.json` on main, so the parity and completeness gates arm clean on promotion.

## Test plan
- [x] `bin/rails test` — full suite green, including `i18n_parity_test` and `level_translations_completeness_test` now hard-failing (rather than warning) for `el`
- [x] `ruby lib/locale_completeness_check.rb` — "All 280 keys present and non-empty across 5 production locale(s): el, en, hu, it, uk"
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmuyHo8ENa5ZjGvseYQUpz