### PR TITLE
Update brakeman to 8.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     bigdecimal (4.1.2)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)


### PR DESCRIPTION
`bin/brakeman` unshifts `--ensure-latest`, so the release of 8.0.6 made it exit 5 on every run regardless of findings — taking the pre-commit hook (`.husky/pre-commit`) down for everyone.

Lockfile bump only.

## Test plan
- [x] `bin/brakeman` — exit 0, no warnings (was exit 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmuyHo8ENa5ZjGvseYQUpz