### PR TITLE
Make French servable, with mailer and level milestone copy

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -22,7 +22,7 @@ module I18n
 
   # The live set: locales that ship to production. The locale-parity guard test
   # hard-fails on any of these that drifts from en.
-  PRODUCTION_LOCALES = %w[el en hu it uk].freeze
+  PRODUCTION_LOCALES = %w[el en fr hu it uk].freeze
 
   # The draft set: everything not yet live. Translation generation targets every
   # locale (so content can be pre-generated before a locale is promoted), but

--- a/config/locales/mailers/account_mailer.fr.yml
+++ b/config/locales/mailers/account_mailer.fr.yml
@@ -1,0 +1,27 @@
+fr:
+  account_mailer:
+    welcome:
+      subject: "Bienvenue sur Jiki !"
+      greeting: "Salut,"
+      body_markdown: |
+        Bienvenue sur [Jiki](https://jiki.io) ! On est vraiment ravis de t'accueillir.
+
+        Jiki a été conçu pour t'accompagner de tes tout premiers pas jusqu'au moment où tu coderas avec assurance. Tu vas travailler sur des projets amusants et résoudre des problèmes intéressants, en avançant petit à petit et en apprenant énormément de choses en chemin.
+
+        Si jamais tu bloques ou que tu as des questions, n'hésite pas à nous écrire. Apprendre à coder peut sembler intimidant au début, mais tu vas y arriver !
+
+        Amuse-toi bien, et profite de l'aventure !
+
+        À bientôt,  
+        Jeremy et l'équipe
+    account_deletion_confirmation:
+      subject: "Confirme la suppression de ton compte"
+      preview: "Merci de confirmer que tu veux supprimer définitivement ton compte Jiki"
+      greeting: "Salut,"
+      body_markdown: |
+        On a reçu une demande de suppression de ton compte Jiki.
+
+        Si cette demande vient bien de toi, clique sur le bouton ci-dessous pour la confirmer. Cette action est définitive et ne peut pas être annulée : toute ta progression et toutes tes données seront supprimées.
+
+        Si tu n'es pas à l'origine de cette demande, tu peux ignorer cet e-mail sans crainte : ton compte restera inchangé.
+      cta: "Supprimer mon compte"

--- a/config/locales/mailers/onboarding_mailer.fr.yml
+++ b/config/locales/mailers/onboarding_mailer.fr.yml
@@ -1,0 +1,96 @@
+fr:
+  onboarding_mailer:
+    overview:
+      subject: "Devenir développeur en 2026 : les deux moitiés"
+      preview: "Depuis quelques années, j'apprends le japonais tout doucement."
+      greeting: "Salut,"
+      body_markdown: |
+        Depuis quelques années, **j'apprends le japonais tout doucement**. Je vais régulièrement au Japon et j'essaie de m'immerger dans la langue, mais c'est difficile, parce qu'aujourd'hui, avec l'aide de Google Traduction, il est plutôt facile de passer du temps au Japon sans dire un mot de japonais. **Mon cerveau peut donc se permettre d'être paresseux**, et je m'en sors très bien.
+
+        La programmation a récemment commencé à suivre le même chemin. Pendant trente ans, si tu voulais faire quoi que ce soit avec la technologie, **il fallait apprendre à coder**. C'était le seul moyen de communiquer avec un ordinateur. Mais depuis deux ans, avec l'essor de la programmation agentique, les choses ont changé. Tu peux désormais utiliser ta langue maternelle pour dire à un agent IA ce que tu veux qu'il fasse, et **il écrira le code à ta place**, en traduisant tes instructions pour l'ordinateur.
+
+        Tout comme je n'ai pas besoin d'attendre de parler couramment japonais pour explorer le Japon, **ça n'a plus aucun sens de passer des années à devenir bon en programmation** avant de commencer à créer des choses.
+
+        Mais si je veux vraiment entrer dans la culture japonaise et me faire des amis japonais, j'ai besoin d'apprendre le japonais. Et si tu veux entrer dans la tech, tu dois toujours apprendre à coder. Le code n'est plus le gardien de la porte, mais c'est **la différence entre « se débrouiller » et vraiment s'épanouir**.
+
+        Pour progresser vite, divise ton temps d'apprentissage en deux parties :
+        1. **Apprends à coder.** Suis le cours Fondamentaux de la programmation de Jiki et tu auras d'excellentes bases.
+        2. **Crée des choses.** Suis « Apprendre à créer », mets les mains dans le cambouis et crée des produits que les gens peuvent vraiment utiliser !
+
+        Si tu veux en savoir plus sur ma vision de **comment entrer dans la tech en 2026**, lis [cet article de blog](https://jiki.io/blog/how-to-get-into-tech-in-2026).
+
+        Dans les prochains jours, je te parlerai un peu plus des deux côtés, la programmation et la création, et de la façon dont tu peux tirer le meilleur parti de [Jiki](https://jiki.io). En attendant, **lance-toi et amuse-toi bien !**
+
+        Merci de m'avoir lu !
+        Jeremy
+    coding:
+      subject: "Construis des bases solides en programmation"
+      preview: "Apprendre à coder a la réputation d'être technique et difficile."
+      greeting: "Salut, c'est encore moi,"
+      body_markdown: |
+        Apprendre à coder a la réputation d'être technique et difficile. Quand j'ai commencé à apprendre à coder, j'étais un gamin de 8 ans qui ne connaissait rien à la programmation, à part que **je pouvais soudain créer des trucs géniaux**. Je ne savais pas que c'était censé être difficile. Je savais juste que j'avais tout à coup un nouvel exutoire pour ma créativité.
+
+        Pendant que tu apprends à coder, **je ne veux pas que tu voies ça comme une discipline technique à maîtriser**. Je veux que tu y voies un endroit où libérer **ta** créativité, où tu peux **t'amuser à créer des choses** et à résoudre des casse-tête. Parce que c'est vraiment ça, la programmation : résoudre des problèmes.
+
+        Peu importe [quel langage de programmation tu apprends](https://jiki.io/blog/just-learn-to-code), ce qui compte, c'est que tu construises une très bonne compréhension de **comment fonctionne la programmation**.
+
+        Au fil de ta progression, il y aura des moments où la programmation te semblera difficile et frustrante. Mais ce n'est pas parce que _la programmation_ est difficile, c'est parce qu'**apprendre est difficile**. Si tu veux devenir bon dans quoi que ce soit, tu dois traverser des phases où le défi paraît trop grand, mais il faut persévérer.
+
+        Si tu n'es pas sûr que la partie programmation vaille l'effort, lis [cet article de blog](https://jiki.io/blog/should-i-still-learn-to-code-in-2026) qui explique pourquoi il faut encore apprendre à coder en 2026.
+
+        Merci de m'avoir lu !
+        Jeremy
+    building:
+      subject: "La meilleure façon d'apprendre, c'est de créer !"
+      preview: "Je crois vraiment que c'est le meilleur moment pour entrer dans la tech."
+      greeting: "Salut,"
+      body_markdown: |
+        Je crois vraiment qu'**il n'y a jamais eu meilleur moment pour entrer dans la tech**. Il n'a jamais été aussi facile d'apprendre les bases et de pouvoir rapidement créer des choses.
+
+        Mais (et c'est un gros mais !) là où beaucoup de gens se trompent, c'est qu'ils confient entièrement les rênes à un agent IA sans vraiment apprendre. Et c'est très agréable pendant un moment, tu peux faire apparaître plein de choses comme par magie, mais si tout ce que tu fais c'est dire à Claude ou à ChatGPT quoi faire, tu n'apprends rien du tout !
+
+        C'est pourquoi je prépare des **projets pas à pas** sur lesquels tu peux travailler, et où je _VEUX_ que tu utilises des agents IA pour faire une grande partie du travail à ta place. Mais où je veux aussi que tu t'assures de **bien comprendre ce qui se passe** à chaque étape.
+
+        Le but de ces projets, c'est de pouvoir apprendre **toutes les différentes facettes de la création de logiciels**. Tu peux me rejoindre pendant que je construis des choses, je t'expliquerai exactement ce que je fais et pourquoi, puis tu pourras travailler avec un agent IA pour appliquer ces mêmes idées à tes projets.
+
+        Mais surtout, **ne deviens pas accro aux shots de dopamine** que procure l'agent IA qui fait le travail à ta place. Prends bien le temps de comprendre ce qui se passe !
+
+        J'espère te croiser bientôt [lors d'un direct](https://youtube.com/@jiki-coding) !
+
+        Merci de m'avoir lu !
+        Jeremy
+    premium:
+      subject: "Profite encore plus de Jiki (et aide-nous)"
+      preview: "On a rendu Jiki gratuit parce qu'on veut qu'il soit accessible à tout le monde, quelle"
+      greeting: "Salut,"
+      body_markdown: |
+        On a rendu Jiki gratuit parce qu'on veut qu'il soit **accessible à tout le monde**, quelle que soit la situation financière de chacun. Tout le monde a accès à des centaines d'heures d'exercices et de vidéos, sans rien devoir en retour.
+
+        Mais **Jiki coûte de l'argent à faire tourner**, et on doit pouvoir payer nos loyers, notre nourriture (🍜) et notre caféine (☕), alors on a ajouté une formule Premium qui apporte quelques avantages supplémentaires qui, je pense, vont vraiment t'aider :
+        - **Demande à Jiki** : notre chat IA pour t'aider à te débloquer rapidement ou à explorer tes questions.
+        - **Projets Premium** : des exercices plus difficiles, où tu peux combiner les compétences que tu apprends.
+        - **Apprendre à créer** : beaucoup plus de contenu, où tu peux apprendre à mes côtés.
+        - **Badges** : montre ton soutien sur le site et dans les espaces communautaires avec les badges Premium.
+
+        On a rendu tout ça super abordable grâce à la **parité de pouvoir d'achat**. Ça veut dire que Premium coûte à peu près le prix de deux boissons à emporter dans ton pays, donc le tarif devrait te sembler raisonnable où que tu sois dans le monde.
+
+        Si Jiki te plaît, que tu veux **accélérer ton apprentissage** et soutenir l'équipe Jiki et moi-même, alors [passe à Premium](https://jiki.io/premium).
+
+        Merci,
+        Jeremy
+    community:
+      subject: "Ne galère pas tout seul, rejoins la communauté Jiki"
+      preview: "Tu as beaucoup plus de chances de réussir à apprendre si tu fais partie d'un groupe."
+      greeting: "Salut,"
+      body_markdown: |
+        Tu as beaucoup plus de chances de réussir à apprendre quoi que ce soit si **tu fais partie d'un groupe**. La programmation ne fait pas exception.
+
+        Si tu veux de l'aide, discuter de ton parcours en programmation ou simplement passer du temps avec d'autres, voici quelques endroits où le faire :
+        - [Notre forum](https://jiki.io/r/forum) : l'endroit idéal pour des conversations plus posées et plus longues. C'est ici qu'on **va plus loin**.
+        - [Le Discord d'Exercism](https://jiki.io/r/discord) : l'endroit idéal pour **discuter en temps réel** avec les autres personnes connectées. Cherche les salons #jiki-chat et #jiki-get-help.
+        - [YouTube](https://jiki.io/r/youtube) : participe à nos AMA (des sessions où tu peux tout me demander) et à nos autres **directs** pour me poser tes questions !
+
+        N'oublie pas qu'il y a des personnes de cultures très différentes dans ces espaces, alors **sois respectueux** envers tout le monde quand tu discutes.
+
+        À bientôt !
+        Jeremy

--- a/config/locales/mailers/premium_mailer.fr.yml
+++ b/config/locales/mailers/premium_mailer.fr.yml
@@ -1,0 +1,26 @@
+fr:
+  premium_mailer:
+    welcome_to_premium:
+      subject: "Bienvenue sur Jiki Premium !"
+      greeting: "Salut,"
+      body_markdown: |
+        Merci de ton abonnement à Jiki Premium !
+
+        Tu peux voir toutes les fonctionnalités auxquelles tu as accès sur la [page Premium](https://jiki.io/premium). On espère que tu vas bien t'amuser avec Jiki et qu'on te retrouvera bientôt lors d'un live !
+
+        Si tu as des questions, réponds simplement à cet e-mail.
+
+        À bientôt,  
+        Jeremy et l'équipe
+    subscription_ended:
+      subject: "Ton abonnement Jiki a pris fin"
+      greeting: "Salut,"
+      body_markdown: |
+        Ton abonnement Jiki Premium a pris fin et tu es désormais sur notre formule gratuite.
+
+        Tu gardes un accès complet à toute la section « Apprendre à coder ». Si tu veux te réabonner, tu peux le faire à tout moment depuis ta [page de paramètres](https://jiki.io/settings).
+
+        Merci d'avoir essayé Jiki Premium.
+
+        À bientôt,  
+        Jeremy et l'équipe

--- a/db/seeds/level_translations/fr.json
+++ b/db/seeds/level_translations/fr.json
@@ -1,0 +1,97 @@
+[
+  {
+    "level_uuid": "7963a7e0-0386-46fa-bf47-c19eaa1eb555",
+    "milestone_email_subject": "Bravo, première étape franchie !",
+    "milestone_email_content_markdown": "Beau travail, tu viens de terminer le premier niveau du cours Fondamentaux de la programmation de Jiki.\n\nTu as peut-être l'impression de ne pas encore faire de « vrai » code, mais tu viens d'acquérir l'une des compétences les plus importantes de la programmation. À partir de maintenant, tu vas utiliser des fonctions des centaines de fois par jour, donc c'est vraiment la base de tout le reste.\n\nEnsuite, on va voir comment utiliser les couleurs pour dessiner, puis on commencera à mêler un peu de logique à tout ça. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "de4de3c1-d2ee-4af5-9df6-857a9f1df478",
+    "milestone_email_subject": "Tu as aimé dessiner ?",
+    "milestone_email_content_markdown": "Beau travail sur ce niveau, et sur ton premier vrai dessin.\n\nTu as maintenant ajouté les strings et les couleurs à ta boîte à outils, ce qui veut dire que tes programmes peuvent commencer à manipuler du texte et à produire des choses qui rendent vraiment bien à l'écran.\n\nAu fil des prochaines leçons, on va introduire un peu de logique, pour que tu puisses dépasser les instructions linéaires et apporter de la variété et de l'intelligence à tes programmes. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "8eafc890-d96f-4143-9556-fafd58f90735",
+    "milestone_email_subject": "Ça boucle dans ta tête ?",
+    "milestone_email_content_markdown": "Beau travail sur ce niveau. Les boucles sont l'une des briques fondamentales de la programmation, et on espère qu'elles commencent à te paraître assez naturelles.\n\nIl existe d'autres types de boucles, que l'on verra plus tard dans le cours, mais la boucle repeat va rester ta compagne pendant les prochaines leçons.\n\nEnsuite, place aux variables, c'est-à-dire l'idée de stocker et de récupérer des valeurs pendant que ton programme s'exécute. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "a47b33c1-fecd-4f15-a025-f95b878e31b7",
+    "milestone_email_subject": "Les variables, c'est dans la poche",
+    "milestone_email_content_markdown": "Beau travail, tu as maintenant les variables bien en main.\n\nLes variables font partie de ces idées plutôt simples en apparence, mais elles vont sous-tendre presque tout ce que tu écriras à partir de maintenant. Pouvoir stocker une valeur, lui donner un nom et la réutiliser plus tard, c'est ce qui transforme une liste d'instructions figée en quelque chose de vraiment souple.\n\nEnsuite, on va voir comment les variables évoluent au fil du temps, ce que les programmeurs appellent « l'état ». Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "f74c506c-144e-4287-83eb-356568ffc234",
+    "milestone_email_subject": "L'état des lieux",
+    "milestone_email_content_markdown": "Beau travail sur celui-ci. Tu sais maintenant suivre des valeurs qui changent pendant que ton programme s'exécute, ce qui est un vrai pas en avant par rapport à il y a deux niveaux.\n\nCette idée d'état va revenir tout au long du cours, et elle devient plus intéressante à chaque fois qu'on la combine avec quelque chose de nouveau.\n\nEnsuite, place à un gros niveau. On va voir les fonctions qui renvoient des valeurs, puis on explorera les couleurs, le hasard, l'animation, la portée et les boucles imbriquées en chemin. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "e3933253-d25e-4b35-a442-4cd96ead2188",
+    "milestone_email_subject": "Un sacré butin",
+    "milestone_email_content_markdown": "Excellent travail sur un niveau bien chargé. Les fonctions qui renvoient des valeurs, les couleurs HSL et RGB, l'animation, les nombres aléatoires, la portée, les scénarios et les boucles dans les boucles. Ça fait beaucoup de nouvelles idées à ajouter d'un coup à ta boîte à outils.\n\nPas de panique si certaines restent encore un peu floues. Elles reviendront toutes dans d'autres contextes plus tard dans le cours, et elles te seront un peu plus familières à chaque fois.\n\nEnsuite, on va commencer à prendre des décisions dans le code avec les instructions if. C'est là que tes programmes commencent vraiment à paraître intelligents. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "2977da36-d6e7-4e94-b654-f029f8fd55dd",
+    "milestone_email_subject": "Si… alors quoi ?",
+    "milestone_email_content_markdown": "Bien joué sur le niveau des conditions. On espère que if et else commencent à te paraître assez naturels.\n\nLes conditions sont l'une des idées les plus importantes de la programmation. Presque tous les programmes intéressants ont besoin de prendre des décisions en fonction de ce qui est vrai à un instant donné, et tu as maintenant les outils de base pour le faire.\n\nEnsuite, on va voir des façons plus puissantes d'écrire des conditions, en les combinant avec and/or, ainsi que quelques idées voisines comme le modulo. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "fcd15968-fc9e-49e7-b6dc-d29da3ecf711",
+    "milestone_email_subject": "La suite logique",
+    "milestone_email_content_markdown": "Beau travail sur un niveau pas évident. Tu as maintenant and/or, le modulo et les boucles sans compteur bien en main.\n\nCe sont le genre d'outils qui te permettent d'écrire des conditions qui collent vraiment à la logique du monde réel, plutôt que de devoir tout découper en petites vérifications séparées.\n\nEnsuite, on va combiner les conditions et l'état, ce qui est le moment où tes programmes commencent à pouvoir réagir à ce qui se passe pendant leur exécution. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "f8e8a86f-8802-4cdb-863c-6f8187785cfd",
+    "milestone_email_subject": "Des programmes qui réagissent",
+    "milestone_email_content_markdown": "Beau travail. Combiner les conditions et l'état, c'est le moment où tes programmes commencent vraiment à paraître vivants : ils réagissent à ce qui se passe au lieu de suivre un scénario figé.\n\nC'est à peu près le niveau de complexité auquel tu vas écrire pendant tout le reste du cours, donc tout ce que tu as pratiqué ici va continuer à revenir.\n\nEnsuite, place à un gros morceau : écrire tes propres fonctions. Jusqu'ici, tu utilisais des fonctions écrites par quelqu'un d'autre. À partir de maintenant, tu vas écrire les tiennes. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "d45d91fe-f790-4f47-b072-9e7d8c453aa4",
+    "milestone_email_subject": "C'est toi qui commandes",
+    "milestone_email_content_markdown": "Excellent travail. Écrire tes propres fonctions, c'est un vrai changement. Tu ne te contentes plus d'utiliser les outils posés sur l'étagère, tu en fabriques de nouveaux.\n\nC'est l'une des compétences les plus importantes de toute la programmation. Un bon code, c'est avant tout des problèmes découpés en petites fonctions bien nommées, et tu as maintenant tout ce qu'il faut pour commencer à faire ça.\n\nEnsuite, on revient aux strings, pour voir comment les coller ensemble et y glisser des valeurs. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "0dcf7cf5-1b75-450d-aaeb-5246c28c3750",
+    "milestone_email_subject": "Tout se tient",
+    "milestone_email_content_markdown": "Bien joué sur celui-ci. La concaténation et les templates sont des idées plutôt simples, mais elles reviennent en permanence, surtout dès que tu produis du texte destiné à être lu par une personne.\n\nTu vas utiliser ces techniques dans à peu près tous les programmes que tu écriras à partir de maintenant.\n\nEnsuite, on va voir comment fouiller dans une string caractère par caractère, et comment parcourir son contenu. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "a6244fe4-bc09-4c54-b244-0599bd419fdf",
+    "milestone_email_subject": "Lettre par lettre",
+    "milestone_email_content_markdown": "Beau travail. On espère que l'accès par indice et le parcours des strings commencent à te paraître clairs.\n\nPouvoir regarder les caractères un par un et parcourir un texte de façon méthodique t'ouvre un immense éventail de problèmes que tu sais désormais résoudre. Une bonne partie de la programmation du monde réel consiste exactement en ce genre de travail.\n\nEnsuite, on va voir comment combiner plusieurs fonctions pour s'attaquer à des tâches plus complexes. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "f2d5a243-732a-433d-9e9b-51548c41828c",
+    "milestone_email_subject": "Mieux ensemble",
+    "milestone_email_content_markdown": "Beau travail sur ce niveau. Combiner des fonctions pour résoudre de plus gros problèmes, c'est exactement à quoi ressemble la programmation professionnelle au quotidien. Tu découpes un problème en morceaux, tu écris une petite fonction pour chaque morceau, puis tu les assembles.\n\nTu fais maintenant ça pour de vrai.\n\nEnsuite, on va voir les méthodes et les propriétés, une façon un peu différente de travailler avec les valeurs. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "37f0b015-986c-4b6a-8d3f-704a0056f994",
+    "milestone_email_subject": "Il y a bien une méthode",
+    "milestone_email_content_markdown": "Bien joué. Les méthodes et les propriétés ont un style un peu différent de ce que tu as vu jusqu'ici. Au lieu de passer une valeur à une fonction, tu appelles une fonction sur la valeur elle-même. L'idée demande un petit temps d'adaptation, mais elle est utilisée partout, donc elle va vite te paraître naturelle.\n\nEnsuite, on va voir des types de boucles plus puissants : les boucles for, les boucles while, break et continue. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "86e3939f-3141-4b0e-aedb-249a1da33530",
+    "milestone_email_subject": "Il n'y a pas que repeat",
+    "milestone_email_content_markdown": "Beau travail. Tu as maintenant les boucles for, les boucles while, break et continue bien en main. Ce sont les boucles que tu utiliseras le plus souvent en dehors de ce cours, donc le temps que tu y as consacré en valait vraiment la peine.\n\nChacune a un rôle un peu différent, et savoir laquelle choisir viendra avec la pratique.\n\nEnsuite, on va voir les tableaux, c'est-à-dire la façon dont les programmes stockent des collections d'éléments et travaillent avec. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "ecea29c5-9e4a-4d1a-a215-c3ea2d13a06d",
+    "milestone_email_subject": "Une belle collection",
+    "milestone_email_content_markdown": "Excellent travail. Les tableaux (ou « listes », comme les appellent certains) sont l'un des outils les plus utiles de n'importe quel langage. Dès que tu manipules plus d'un élément à la fois, tu vas te tourner vers un tableau.\n\nTu as maintenant une bonne maîtrise de la façon de les lire et de parcourir leur contenu.\n\nEnsuite, on va voir comment construire des tableaux à partir de rien, morceau par morceau. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "d65e091d-ea5d-4f7b-b588-d06fa712d91e",
+    "milestone_email_subject": "On assemble les morceaux",
+    "milestone_email_content_markdown": "Bien joué ! Lire dans un tableau, c'est pratique, mais c'est en pouvant les construire morceau par morceau qu'ils prennent toute leur valeur. Parcourir quelque chose, rassembler les éléments qui t'intéressent dans un nouveau tableau et le renvoyer : voilà un schéma que tu réutiliseras encore et encore.\n\nEnsuite, place aux dictionnaires. Ils te permettent de stocker des valeurs sous des clés nommées, plutôt que par simple position. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "4647e76e-e600-43dc-8354-bf30e2dc2537",
+    "milestone_email_subject": "Tout est dans le nom",
+    "milestone_email_content_markdown": "Beau travail. Les dictionnaires te permettent de stocker des valeurs sous des clés nommées plutôt que par simple position, ce qui rend la recherche d'une information rapide et lisible.\n\nEnsuite, et pour finir, on va voir comment modifier un dictionnaire : ajouter, mettre à jour et supprimer des entrées au fil de l'eau. Amuse-toi bien !"
+  },
+  {
+    "level_uuid": "42cbc5e7-c2eb-4abb-b3e2-724d240f6f9c",
+    "milestone_email_subject": "C'est dans la boîte",
+    "milestone_email_content_markdown": "Et voilà le dernier niveau des Fondamentaux de la programmation. On espère que les dictionnaires te paraissent maintenant un outil utile à ajouter à la panoplie, aux côtés des tableaux.\n\nC'est une vraie réussite. Tu as maintenant couvert toutes les briques de base de la programmation : les fonctions, les variables, l'état, les conditions, les boucles, les strings, les tableaux et les dictionnaires. Tout le reste ne sera que combinaisons et raffinements de ce que tu connais déjà.\n\nOn est vraiment fiers du chemin que tu as parcouru. Amuse-toi bien !"
+  }
+]


### PR DESCRIPTION
Promotes `fr` to a production locale and carries the French email copy it needs to be complete.

## What's here

- **The locale enablement.** `fr` was in `ALL_LOCALES` but not `PRODUCTION_LOCALES`, so the api could not serve it. This is the same one-line edit to `config/initializers/i18n.rb` that promoted `el` (#631) and `it`/`uk` (#627).
- **The three mailers French was missing** (`account_mailer`, `onboarding_mailer`, `premium_mailer`). French already had `devise_mailer`, `notifications_mailer`, `progression_mailer` and `shared`, so this takes it to 7/7.
- **The first `fr` level milestone seed file** (`db/seeds/level_translations/fr.json`), covering all 19 levels.

## Why now

French content is at 99%+ across the curriculum and the app string catalog, so the front end is ready; the api was the remaining blocker.

## Checks

Promotion arms the hard-fail guards for `fr`: the locale-parity test, `lib/locale_completeness_check.rb`, and the level translations completeness test. All pass on this branch, along with the full suite (2154 runs, 0 failures).

## Deploy note

The seed data is loaded by `bin/rails db:seed`, which is a deploy step, so the French milestone emails only become live once that has run.

## Known inconsistency to follow up (not from this work)

`config/locales/mailers/devise_mailer.fr.yml` is pre-existing and uses **vous**, while every other French mailer (including the three added here) uses **tu**. French emails therefore currently switch register between the devise emails and the rest. Worth settling on one, but it's a separate change: fixing it here would mean rewriting copy this PR doesn't otherwise touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WngKL7a7srwBLcLeLA1dLu
