### PR TITLE
it: drop redundant "Jiki" from account_deletion_confirmation body

### DIFF
--- a/config/locales/mailers/account_mailer.it.yml
+++ b/config/locales/mailers/account_mailer.it.yml
@@ -19,7 +19,7 @@ it:
       preview: "Conferma di voler eliminare definitivamente il tuo account Jiki"
       greeting: "Ciao,"
       body_markdown: |
-        Abbiamo ricevuto una richiesta di eliminare il tuo account Jiki.
+        Abbiamo ricevuto una richiesta di eliminare il tuo account.
 
         Se sei stato tu a inviare questa richiesta, fai clic sul pulsante qui sotto per confermare. Questa azione è permanente e non può essere annullata. Tutti i tuoi progressi e i tuoi dati verranno eliminati.
 


### PR DESCRIPTION
Forum-reviewed wording fix from kernelaklees (t/1577): the deletion-confirmation email body said "il tuo account Jiki", which reads oddly since it's the only account option when a user has no linked accounts. Drops "Jiki" to match her suggestion.

🤖 Generated with Claude Code