### PR TITLE
it: welcome/reset-password email wording fixes

### DIFF
--- a/config/locales/mailers/account_mailer.it.yml
+++ b/config/locales/mailers/account_mailer.it.yml
@@ -6,11 +6,11 @@ it:
       body_markdown: |
         Benvenuto su [Jiki](https://jiki.io)! Siamo davvero felici di averti qui.
 
-        Jiki è stato progettato per portarti da principiante assoluto a programmatore sicuro di te. Lavorerai su progetti divertenti e risolverai problemi interessanti, facendo progressi un piccolo passo alla volta e imparando tantissimo lungo il percorso.
+        Jiki è stato progettato per accompagnarti da principiante assoluto a programmatore sicuro di sé. Lavorerai su progetti divertenti e affronterai problemi interessanti, facendo progressi un piccolo passo alla volta e imparando tantissimo lungo il percorso.
 
-        Se ti blocchi o hai domande, non esitare a contattarci. Imparare a programmare all'inizio può sembrare opprimente, ma ce la farai!
+        Se ti blocchi o hai domande, puoi sempre chiedere. All'inizio programmare può sembrare un po' ostico, ma ce la farai!
 
-        Divertiti e goditi il viaggio!
+        Divertiti e goditi l'avventura!
 
         Ciao,  
         Jeremy e il team

--- a/config/locales/mailers/devise_mailer.it.yml
+++ b/config/locales/mailers/devise_mailer.it.yml
@@ -5,14 +5,14 @@ it:
     mailer:
       confirmation_instructions:
         subject: Istruzioni per la conferma
-        preview: 'Puoi confermare il tuo account cliccando sul link qui sotto:'
+        preview: 'Conferma il tuo account cliccando sul link qui sotto:'
         greeting: Ti diamo il benvenuto!
-        body_markdown: 'Puoi confermare il tuo account cliccando sul link qui sotto:'
+        body_markdown: 'Conferma il tuo account cliccando sul link qui sotto:'
         cta: Conferma il mio account
       reset_password_instructions:
-        subject: Istruzioni per reimpostare la password
-        preview: Qualcuno ha richiesto di resettare la tua password, se lo vuoi davvero puoi farlo cliccando sul link qui sotto.
+        subject: Come reimpostare la password
+        preview: 'Qualcuno ha richiesto di reimpostare la password del tuo account. Se sei stato tu, puoi procedere cliccando sul link qui sotto. Se non hai effettuato tu la richiesta, puoi ignorare questa email: il tuo account non subirà modifiche.'
         greeting: Ciao,
-        body_markdown: Qualcuno ha richiesto di resettare la tua password, se lo vuoi davvero puoi farlo cliccando sul link qui sotto.
-        cta: Cambia la mia password
-        footer: Se non sei stato tu ad effettuare questa richiesta puoi ignorare questa mail. La tua password non cambierà finché non accederai al link sopra.
+        body_markdown: 'Qualcuno ha richiesto di reimpostare la password del tuo account. Se sei stato tu, puoi procedere cliccando sul link qui sotto. Se non hai effettuato tu la richiesta, puoi ignorare questa email: il tuo account non subirà modifiche.'
+        cta: Reimposta la mia password
+        footer: 'Se non hai effettuato tu la richiesta, puoi ignorare questa email: il tuo account non subirà modifiche. La tua password non verrà modificata finché non cliccherai sul link qui sopra.'


### PR DESCRIPTION
## Summary
- Applies forum-reviewed Italian wording fixes from native speaker kernelaklees.
- `account_mailer.it.yml` welcome email: rephrase body_markdown for more natural/idiomatic Italian (t/1579).
- `devise_mailer.it.yml` confirmation_instructions: swap "Puoi confermare..." → "Conferma..." in preview/body_markdown only, subject left untouched pending separate follow-up (partial t/1580).
- `devise_mailer.it.yml` reset_password_instructions: full set of wording fixes to subject, preview, body_markdown, cta, footer (t/1581).

## Test plan
- [x] `bundle exec ruby -ryaml` load check on both edited YAML files (passed)
- [x] Full test suite run via pre-commit hook (2154 runs, 0 failures, 0 errors)
- [x] Brakeman scan via pre-commit hook (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)