### PR TITLE
it: onboarding_mailer.coding wording fix

### DIFF
--- a/config/locales/mailers/onboarding_mailer.it.yml
+++ b/config/locales/mailers/onboarding_mailer.it.yml
@@ -25,10 +25,10 @@ it:
         Jeremy
     coding:
       subject: "Costruisci basi di programmazione solide"
-      preview: "Imparare a programmare ha la fama di essere tecnico e difficile."
+      preview: "Imparare a programmare ha fama di essere tecnico e difficile."
       greeting: "Ciao di nuovo,"
       body_markdown: |
-        Imparare a programmare ha la fama di essere tecnico e difficile. Quando ho iniziato a imparare a programmare, ero un bambino di 8 anni che non sapeva nulla di programmazione, se non che **all'improvviso potevo creare cose fantastiche**. Non sapevo che dovesse essere difficile. Sapevo solo che all'improvviso avevo un nuovo sfogo per la mia creatività.
+        Imparare a programmare ha fama di essere tecnico e difficile. Quando ho iniziato avevo solo 8 anni e non ne sapevo assolutamente nulla, se non **che all'improvviso avrei potuto creare cose fantastiche**. Non sapevo che potesse essere difficile. Sapevo solo che tutto ad un tratto avevo un nuovo modo per esprimere la mia creatività.
 
         Mentre impari a programmare, **non voglio che tu la veda come una disciplina tecnica da padroneggiare**. Voglio che tu la veda come un luogo in cui liberare la **tua** creatività, dove puoi **divertirti a creare cose** e risolvere puzzle. Perché è questo che è davvero la programmazione: risolvere problemi.
 


### PR DESCRIPTION
Forum-reviewed fix from kernelaklees (t/1586): rewords the opening paragraph of the coding-onboarding email for a more natural, less literal-translation-sounding phrasing.