### PR TITLE
it: onboarding_mailer.coding wording fixes, round 2

### DIFF
--- a/config/locales/mailers/onboarding_mailer.it.yml
+++ b/config/locales/mailers/onboarding_mailer.it.yml
@@ -30,13 +30,13 @@ it:
       body_markdown: |
         Imparare a programmare ha la fama di essere tecnico e difficile. Quando ho iniziato a imparare a programmare, ero un bambino di 8 anni che non sapeva nulla di programmazione, se non che **all'improvviso potevo creare cose fantastiche**. Non sapevo che dovesse essere difficile. Sapevo solo che all'improvviso avevo un nuovo sfogo per la mia creatività.
 
-        Mentre impari a programmare, **non voglio che tu la veda come una disciplina tecnica da padroneggiare**. Voglio che tu la veda come un luogo in cui liberare la **tua** creatività, dove puoi **divertirti a creare cose** e risolvere puzzle. Perché è questo che è davvero la programmazione: risolvere problemi.
+        Mentre impari a programmare, **non voglio che tu la consideri una disciplina tecnica da padroneggiare.** Voglio che tu la veda come uno spazio in cui liberare la **tua** creatività, dove puoi **divertirti a creare** e a risolvere puzzle. Perché, in fondo, la programmazione è proprio questo: risolvere problemi.
 
-        Non importa [quale linguaggio di programmazione impari](https://jiki.io/blog/just-learn-to-code), ciò che conta è che tu costruisca una comprensione davvero solida di **come funziona la programmazione**.
+        Non importa [quale linguaggio impari](https://jiki.io/blog/just-learn-to-code): ciò che conta è costruire una comprensione davvero solida di **come funziona la programmazione**.
 
-        Man mano che progredisci, ci saranno momenti in cui la programmazione ti sembrerà difficile e frustrante. Ma questo non accade perché la _programmazione_ sia difficile: accade perché **imparare è difficile**. Se vuoi diventare bravo in qualsiasi cosa, devi passare attraverso fasi in cui la sfida sembra troppo grande, ma devi perseverare.
+        Andando avanti, ci saranno momenti in cui ti sembrerà tutto difficile e frustrante. Questo non accade perché programmare sia difficile: accade perché imparare lo è. Se vuoi diventare bravo in qualcosa, devi attraversare fasi in cui la sfida sembra troppo grande, e proprio lì dovrai perseverare.
 
-        Se non sei sicuro che la parte di programmazione valga lo sforzo, leggi [questo post del blog](https://jiki.io/blog/should-i-still-learn-to-code-in-2026) che spiega perché dovresti ancora imparare a programmare nel 2026.
+        Se non sei sicuro che valga la pena imparare a programmare, leggi [questo post del blog](https://jiki.io/blog/should-i-still-learn-to-code-in-2026) che spiega perché dovresti farlo anche nel 2026.
 
         Grazie per aver letto!
         Jeremy


### PR DESCRIPTION
Forum-reviewed follow-up fixes from kernelaklees (t/1586): paragraphs 2-5 of the coding-onboarding email. Two of her suggestions dropped the paragraph's markdown hyperlink; kept her wording but restored the links, since links must never be removed regardless of reviewer wording.