### PR TITLE
pt-BR: naturalize footer wording (e-mail→email, cancelar inscrição)

### DIFF
--- a/config/locales/mailers/shared.pt-BR.yml
+++ b/config/locales/mailers/shared.pt-BR.yml
@@ -2,8 +2,8 @@
   mailers:
     shared:
       footer:
-        account_notice_html: "Você está recebendo este e-mail porque tem uma conta no %{jiki_link}."
-        manage_preferences_only_html: "Quer mudar como você recebe estes e-mails? Você pode %{preferences_link}"
-        manage_with_unsubscribe_html: "Quer mudar como você recebe estes e-mails? Você pode %{preferences_link} ou %{unsubscribe_link} desta lista."
+        account_notice_html: "Você está recebendo este email porque tem uma conta no %{jiki_link}."
+        manage_preferences_only_html: "Quer mudar como você recebe estes emails? Você pode %{preferences_link}"
+        manage_with_unsubscribe_html: "Quer mudar como você recebe estes emails? Você pode %{preferences_link} ou %{unsubscribe_link} desta lista."
         update_preferences: "atualizar suas preferências"
-        unsubscribe: "cancelar a inscrição"
+        unsubscribe: "cancelar inscrição"


### PR DESCRIPTION
## Summary

Applies native-speaker forum feedback on the pt-BR mailer footer strings (forum topic 1613, post 4965, reviewer fagnerpereira):

- Replace hyphenated "e-mail"/"e-mails" with "email"/"emails" throughout `config/locales/mailers/shared.pt-BR.yml`. Reviewer's note: the hyphenated form reads as overly formal/official; the unhyphenated form is more natural, casual, and app-appropriate for Brazilian Portuguese, and more compact for UI. (Personal recommendation, not a hard rule; reviewer cited a recent bank email using the same unhyphenated spelling.)
- Change `unsubscribe` from "cancelar a inscrição" to "cancelar inscrição" (drop the article) — reads more naturally and is more concise for UI.

Only prose wording changed; all placeholders (`%{jiki_link}`, `%{preferences_link}`, `%{unsubscribe_link}`), HTML entity structure, key names, and indentation are unchanged.

## Test plan

- [x] Pre-commit hook (full test suite + Brakeman) passed clean
- [x] Diff reviewed to confirm only the four described wording changes are present