### PR TITLE
pt-BR: capitalize Equipe in level_completed team signoff

### DIFF
--- a/config/locales/mailers/progression_mailer.pt-BR.yml
+++ b/config/locales/mailers/progression_mailer.pt-BR.yml
@@ -3,4 +3,4 @@
     level_completed:
       greeting: "Olá,"
       signoff: "Abraços,"
-      team: "Jeremy e equipe"
+      team: "Jeremy e Equipe"


### PR DESCRIPTION
## Summary
- Capitalizes "Equipe" in the pt-BR `level_completed` mailer team signoff, so it matches the capitalization of "Jeremy" (was "Jeremy e equipe", now "Jeremy e Equipe").

## Source
Native-speaker forum feedback: forum topic 1615, post 4977 (reviewer fagnerpereira).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>