### PR TITLE
it: warmer greeting in progression_mailer.level_completed

### DIFF
--- a/config/locales/mailers/progression_mailer.it.yml
+++ b/config/locales/mailers/progression_mailer.it.yml
@@ -1,6 +1,6 @@
 it:
   progression_mailer:
     level_completed:
-      greeting: "Ciao,"
+      greeting: "Eccoci qui,"
       signoff: "A presto,"
       team: "Jeremy e il team"


### PR DESCRIPTION
Applies kernelaklees's t/1632 suggestion: 'Ciao,' → 'Eccoci qui,'.