### PR TITLE
fr: fix missing 'ce' in better-together milestone email

### DIFF
--- a/db/seeds/level_translations/fr.json
+++ b/db/seeds/level_translations/fr.json
@@ -62,7 +62,7 @@
   {
     "level_uuid": "f2d5a243-732a-433d-9e9b-51548c41828c",
     "milestone_email_subject": "Mieux ensemble",
-    "milestone_email_content_markdown": "Beau travail sur ce niveau. Combiner des fonctions pour résoudre de plus gros problèmes, c'est exactement à quoi ressemble la programmation professionnelle au quotidien. Tu découpes un problème en morceaux, tu écris une petite fonction pour chaque morceau, puis tu les assembles.\n\nTu fais maintenant ça pour de vrai.\n\nEnsuite, on va voir les méthodes et les propriétés, une façon un peu différente de travailler avec les valeurs. Amuse-toi bien !"
+    "milestone_email_content_markdown": "Beau travail sur ce niveau. Combiner des fonctions pour résoudre de plus gros problèmes, c'est exactement ce à quoi ressemble la programmation professionnelle au quotidien. Tu découpes un problème en morceaux, tu écris une petite fonction pour chaque morceau, puis tu les assembles.\n\nTu fais maintenant ça pour de vrai.\n\nEnsuite, on va voir les méthodes et les propriétés, une façon un peu différente de travailler avec les valeurs. Amuse-toi bien !"
   },
   {
     "level_uuid": "37f0b015-986c-4b6a-8d3f-704a0056f994",


### PR DESCRIPTION
Applies resu-xunil's t/1530 grammar fix that was previously reported as applied but never actually landed in the seed file.