### PR TITLE
it: naturalize onboarding_mailer premium email

### DIFF
--- a/config/locales/mailers/onboarding_mailer.it.yml
+++ b/config/locales/mailers/onboarding_mailer.it.yml
@@ -64,17 +64,17 @@ it:
       preview: "Abbiamo reso Jiki gratuito perché vogliamo che sia accessibile a tutti, a prescindere"
       greeting: "Ciao,"
       body_markdown: |
-        Abbiamo reso Jiki gratuito perché vogliamo che sia **accessibile a tutti**, a prescindere dalla situazione economica di ciascuno. Tutti ricevono centinaia di ore di esercizi e video, tutti disponibili senza chiedere nulla in cambio.
+        Abbiamo reso Jiki gratuito perché vogliamo che sia **accessibile a tutti**, a prescindere dalla situazione economica di ciascuno. Tutti ricevono centinaia di ore di esercizi e video, tutti disponibili senza alcun costo aggiuntivo.
 
-        Ma **Jiki costa denaro per funzionare**, e dobbiamo poter pagare gli affitti e permetterci cibo (🍜) e caffeina (☕), quindi abbiamo aggiunto un piano Premium che offre alcuni vantaggi extra che penso ti aiuteranno davvero:
+        Ma **Jiki ha dei costi di manutenzione**: dobbiamo pagare l'affitto e permetterci cibo (🍜) e caffè (☕), quindi abbiamo aggiunto un piano Premium che offre alcuni vantaggi extra che penso ti aiuteranno davvero:
         - **Chiedi a Jiki**: la nostra chat IA per aiutarti a sbloccarti rapidamente o esplorare le tue domande.
         - **Progetti Premium**: esercizi più difficili, in cui puoi combinare le competenze che stai imparando.
         - **Impara a costruire**: molto più contenuto con cui puoi imparare insieme a me.
         - **Badge**: mostra il tuo supporto sul sito e negli spazi della community con i badge Premium.
 
-        L'abbiamo reso super conveniente usando la **parità di potere d'acquisto**. Questo significa che Premium costa più o meno come due bevande da asporto nel tuo paese, quindi dovrebbe sembrarti un prezzo ragionevole ovunque ti trovi nel mondo.
+        L'abbiamo reso super conveniente usando la **parità di potere d'acquisto**. Questo significa che Premium costa più o meno come due consumazioni nel tuo paese, quindi dovrebbe sembrarti un prezzo ragionevole ovunque ti trovi nel mondo.
 
-        Se ti piace Jiki, vuoi **accelerare il tuo apprendimento** e vuoi supportare me e il team di Jiki, allora per favore [passa a Premium](https://jiki.io/premium).
+        Se ti piace Jiki, vuoi **accelerare il tuo apprendimento** e vuoi supportare me e il team di Jiki, allora [passa a Premium](https://jiki.io/premium).
 
         Grazie,
         Jeremy


### PR DESCRIPTION
Applies kernelaklees's t/1626 feedback: reworded intro, tightened running-costs paragraph, changed 'due caffè' to 'due consumazioni' to avoid a price-mismatch, and dropped 'per favore' from the CTA.