### PR TITLE
it: reword make-your-own-functions milestone email per reviewer feedback

### DIFF
--- a/db/seeds/level_translations/it.json
+++ b/db/seeds/level_translations/it.json
@@ -47,7 +47,7 @@
   {
     "level_uuid": "d45d91fe-f790-4f47-b072-9e7d8c453aa4",
     "milestone_email_subject": "Ora sei tu al comando!",
-    "milestone_email_content_markdown": "Ottimo lavoro. Scrivere le tue funzioni è un vero cambiamento. Non stai più solo usando gli strumenti sullo scaffale, ne stai costruendo di nuovi.\n\nQuesta è una delle competenze più importanti in tutta la programmazione. Un buon codice consiste principalmente nel suddividere i problemi in piccole funzioni ben nominate, e ora hai tutto il necessario per iniziare a farlo.\n\nNel prossimo livello torneremo alle stringhe e vedremo come incollarle insieme e inserirvi valori. Divertiti!"
+    "milestone_email_content_markdown": "Ottimo lavoro. Scrivere le tue funzioni segna un vero salto di qualità: non stai più solo usando gli strumenti sullo scaffale, ma inizi a crearne di nuovi.\n\nQuesta è una delle competenze più importanti in tutta la programmazione. Un codice ben strutturato nasce soprattutto dalla capacità di dividere un problema in parti più piccole e risolverlo per mezzo di funzioni chiare e mirate, e ora hai tutto ciò che ti serve per iniziare a farlo.\n\nNel prossimo livello torneremo alle stringhe e vedremo come unirle e inserirvi dei valori. Divertiti!"
   },
   {
     "level_uuid": "0dcf7cf5-1b75-450d-aaeb-5246c28c3750",


### PR DESCRIPTION
The Italian reviewer [@kernelaklees](https://forum.jiki.io/t/1654) reviewed the "Now you're in charge" level milestone email (`make-your-own-functions`) and asked for two things.

**"buon codice"** — she changed her mind about it after first approving the post: it reads as too literal a rendering of "good code". She asked us to pick between `strutturato`, `solido`, `efficace` and `pulito`, noting she liked `pulito` but thought it slightly too informal, and leaned toward `strutturato` or `efficace` as more neutral for a learning context. This uses **"Un codice ben strutturato"**, which also reads naturally into the rest of the sentence (structure follows from breaking a problem into parts).

**"funzioni ben nominate"** → **"funzioni chiare e mirate"** — her rewording of "well-named functions", which she'd already given in her first post and we'd approved on the thread but never actually applied to the seed file. Her reworded opening and closing sentences from that same post are applied here too.

One thing deliberately not taken from her draft: she wrote "Nel prossimo passaggio", but "Nel prossimo livello" is the phrasing used across the other 18 emails in the series, so it is kept for consistency.

Only `db/seeds/level_translations/it.json` changes, and only the one level's two-paragraph body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)