### PR TITLE
Promote es-419 to a production locale

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -22,7 +22,7 @@ module I18n
 
   # The live set: locales that ship to production. The locale-parity guard test
   # hard-fails on any of these that drifts from en.
-  PRODUCTION_LOCALES = %w[el en fr hu it uk].freeze
+  PRODUCTION_LOCALES = %w[el en es-419 fr hu it uk].freeze
 
   # The draft set: everything not yet live. Translation generation targets every
   # locale (so content can be pre-generated before a locale is promoted), but


### PR DESCRIPTION
## What

Adds `es-419` to `I18n::PRODUCTION_LOCALES` in `config/initializers/i18n.rb`. That is the whole change:

```diff
-  PRODUCTION_LOCALES = %w[el en fr hu it uk].freeze
+  PRODUCTION_LOCALES = %w[el en es-419 fr hu it uk].freeze
```

`es-419` was already in `ALL_LOCALES`, already has its `LANGUAGE_VARIANTS` collapse rule (`es` bare and every non-`ES` region resolve to `es-419`), and `WIP_LOCALES` / `SUPPORTED_LOCALES` are derived, so no second edit is needed anywhere. The initializer's own comment says promotion is a one-line edit to this list, and it is.

## What es-419 is

Neutral Latin American Spanish (UN M.49 area 419), as distinct from `es-ES` (Peninsular). Per `User::NormalizeLocaleTags::LANGUAGE_VARIANTS`, it is the default target for a region-less `es` and for every Spanish region other than `ES`, so it covers by far the larger share of Spanish-speaking users.

## Why now

es-419 is translation-complete for everything this repo owns, per the i18n coverage report:

- **56/56 mailer catalog keys**, across all 7 catalogs (`account_mailer`, `devise_mailer`, `notifications_mailer`, `onboarding_mailer`, `premium_mailer`, `progression_mailer`, `shared`)
- **19/19 level milestone emails** in `db/seeds/level_translations/es-419.json`

## What this arms

Promotion flips es-419 from "warn" to "hard fail" in three places, all of which read `PRODUCTION_LOCALES` directly, so no registration step is required:

| Guard | Effect |
| --- | --- |
| `lib/locale_completeness_check.rb` (CI: Locale completeness workflow) | every en key must be present and non-empty in es-419 |
| `test/i18n_parity_test.rb` | key-tree + `%{interpolation}` parity against en, and no missing catalog file |
| `test/db/seeds/level_translations_completeness_test.rb` | every level needs a non-blank es-419 milestone subject and body |

## Test results

`lib/locale_completeness_check.rb` is the CI hard gate and is plain Ruby with no Rails dependency, so it runs cleanly:

```
$ ruby lib/locale_completeness_check.rb
✓ All 392 keys present and non-empty across 7 production locale(s): el, en, es-419, fr, hu, it, uk
```

(Before the change it read `✓ All 336 keys ... across 6 production locale(s)`. 392 − 336 = 56, the es-419 catalog keys now being enforced.)

**The Rails-booting test suite could not be run locally.** `bin/rails` segfaults during boot on this machine, inside `strscan`/`erb` — the same pre-existing failure noted in 72ed964's commit message, entirely unrelated to this change (it reproduces on a bare `bundle exec ruby -e 'require "erb"; ERB.new("x<%= 1 %>").result'` with no application code loaded). So `I18nParityTest` and `LevelTranslationsCompletenessTest` were verified by running their exact algorithms as a standalone Ruby script against this tree:

```
== catalog parity (7 en catalogs, 56 keys) ==
PASS: no parity problems for es-419

== level_translations completeness (19 levels, 19 es-419 entries) ==
PASS: every level has a complete es-419 entry
```

No missing keys, no extra keys, no interpolation mismatches, no missing catalog files, no blank milestone fields. **CI running the real test files is the authoritative check — please read the CI result on this PR rather than taking the local standalone run as final.**

## Investigation notes

- Grepped every consumer of `PRODUCTION_LOCALES` / `SUPPORTED_LOCALES` / `ALL_LOCALES`. Nothing else hardcodes the production list: `test/test_helper.rb#with_locales` deliberately uses synthetic locales (`xx`, `yy`) precisely so promotions don't change test meaning, and the mailer tests, factories and serializers derive from the constants.
- `config/locales/activerecord.hu.yml` has no `en` reference catalog, so it is not parity-checked and es-419 needs no equivalent.
- Not part of this PR, but worth flagging: `es-ES` remains WIP, so in production an `Accept-Language: es-ES` browser collapses to `es-ES` (unsupported) and falls through to `en` rather than to `es-419`. If Peninsular users should see Latin American Spanish rather than English in the interim, that's a `LANGUAGE_VARIANTS` change, not a locale promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mjK5uu6Fw5mJgAXyT93c6